### PR TITLE
Docsy dark mode switcher

### DIFF
--- a/assets/js/legacy-script.js
+++ b/assets/js/legacy-script.js
@@ -387,6 +387,13 @@ var pushmenu = (function(){
                         aTag.href = '';
                         aTag.innerHTML = clone.innerHTML;
                         aTag.onclick = clone.onclick;
+                        // Preserve data-* attributes (e.g. data-bs-theme-value) so cloned controls can be identified.
+                        for (var i = 0; i < clone.attributes.length; i++) {
+                            var attr = clone.attributes[i];
+                            if (attr.name.indexOf('data-') === 0) {
+                                aTag.setAttribute(attr.name, attr.value);
+                            }
+                        }
                         clone = aTag;
                     }
                     var li = newDOMElement('li');
@@ -402,6 +409,24 @@ var pushmenu = (function(){
         $(".pi-pushmenu").each(function(){
             allPushMenus[this.id] = PushMenu(this);
         });
+
+        // Cloned theme buttons lose Docsy's addEventListener bindings; forward clicks to the original.
+        // Capture-phase listener runs before sled.onclick's stopPropagation kills the bubble.
+        document.addEventListener('click', function (e) {
+            var target = e.target.closest('.pi-pushmenu [data-bs-theme-value]');
+            if (!target) return;
+            e.preventDefault();
+            var theme = target.getAttribute('data-bs-theme-value');
+            var original = document.querySelector('#bd-theme ~ ul [data-bs-theme-value="' + theme + '"]');
+            if (original) {
+                original.click();
+            }
+            var pushmenuEl = target.closest('.pi-pushmenu');
+            if (pushmenuEl) {
+                pushmenuEl.classList.remove('on');
+                setTimeout(function () { pushmenuEl.style.display = 'none'; }, 300);
+            }
+        }, true);
     });
 
     function show(objId) {

--- a/assets/js/theme-image-swap.js
+++ b/assets/js/theme-image-swap.js
@@ -1,0 +1,25 @@
+// Swap img src on Docsy theme toggle.
+// <picture media="prefers-color-scheme: dark"> only reads the OS-level signal; it cannot read the
+// data-bs-theme DOM attribute that Docsy's toggle writes, so we mirror that attribute into img.src here.
+(() => {
+  'use strict';
+
+  const apply = () => {
+    const dark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
+    document.querySelectorAll('img[data-theme-src-dark]').forEach(img => {
+      const next = dark
+        ? img.getAttribute('data-theme-src-dark')
+        : img.getAttribute('data-theme-src-light');
+      if (next && img.getAttribute('src') !== next) {
+        img.setAttribute('src', next);
+      }
+    });
+  };
+
+  apply();
+
+  new MutationObserver(apply).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-bs-theme'],
+  });
+})();

--- a/assets/js/theme-lock.js
+++ b/assets/js/theme-lock.js
@@ -1,0 +1,15 @@
+// theme_lock front-matter: pin a page to "light" or "dark" regardless of user preference.
+// Reads window.themeLock set by the inline init in head-end.html, then forces data-bs-theme
+// and reverts any later writes (Docsy's dark-mode.js, cross-tab updates, etc.).
+(() => {
+  const lock = window.themeLock;
+  if (lock !== 'light' && lock !== 'dark') return;
+  const root = document.documentElement;
+  root.setAttribute('data-bs-theme', lock);
+  root.classList.add('theme-locked');
+  new MutationObserver(() => {
+    if (root.getAttribute('data-bs-theme') !== lock) {
+      root.setAttribute('data-bs-theme', lock);
+    }
+  }).observe(root, { attributes: true, attributeFilter: ['data-bs-theme'] });
+})();

--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -19,7 +19,7 @@ $vendor-strip-font-size: 16px;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 body {
-  background-color: white;
+  background-color: var(--bs-body-bg);
 
   a {
     color: $primary;
@@ -28,7 +28,7 @@ body {
 
 section {
   position: relative;
-  background-color: white;
+  background-color: var(--bs-body-bg);
 }
 
 section,

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -151,12 +151,10 @@ body.td-404 main .error-details {
     text-decoration: underline; // exception from usual convention
   }
 
-  picture {
+  > img.cncf-img {
     display: block;
-    > * {
-      min-height: 4em;
-      width: calc(clamp(20em,18em + 20mm,100vw));
-    }
+    min-height: 4em;
+    width: calc(clamp(20em,18em + 20mm,100vw));
   }
 }
 
@@ -315,7 +313,7 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
 }
 
 // Home page dark-mode
-@media (prefers-color-scheme: dark) {
+[data-bs-theme="dark"] {
   body.cid-home {
     main {
       background-color: $dark-bg-color-2;
@@ -397,17 +395,6 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
         background-color: #a9a9a9 !important;
       }
     }
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .td-main .td-search__input.form-control.dark-theme-focus {
-    &, &::placeholder {
-      background-color: #d3d3d3;
-    }
-  }
-  .td-search__input.form-control.dark-theme-focus:focus {
-    color: #222;
   }
 }
 
@@ -504,10 +491,9 @@ body.cid-community {
     visibility: hidden;
   }
 
-  section.linkbox {
-    max-width: calc(clamp(50%, calc(100em + 2vw), 100vw));
-    margin-left: auto;
-    margin-right: auto;
+  [data-bs-theme="dark"] & section.linkbox {
+    background: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
   }
 
   #banner {
@@ -826,8 +812,8 @@ body.cid-community #navigation-items {
 
   gap: 1.25em;
 
-  border-bottom: 1px solid #aaaaaa;
-  border-top: 1px solid #aaaaaa;
+  border-bottom: 1px solid var(--bs-border-color);
+  border-top: 1px solid var(--bs-border-color);
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -844,8 +830,8 @@ body.cid-community #navigation-items .community-nav-item {
   text-decoration: none;
   text-transform: uppercase;
   font-weight: 400;
-  color: #303030;
-  background: #ffffff;
+  color: var(--bs-body-color);
+  background: var(--bs-secondary-bg);
   font-size: 1.1em;
   padding: 0.2em;
   margin: 0;
@@ -995,7 +981,7 @@ body.cid-community .fullbutton {
  ------------------------------------- */
 body.cid-community #videos {
   width: 100%;
-  background-color: #eeeeee;
+  background-color: var(--bs-tertiary-bg);
 }
 
 body.cid-community #videos .container {
@@ -1086,7 +1072,7 @@ body.cid-community .community-section.community-frame .twittercol1 {
 }
 
 body.cid-community details > summary {
-  color: #303030;
+  color: var(--bs-body-color);
 }
 
 body.cid-community #cncf-code-of-conduct-intro,
@@ -1247,17 +1233,17 @@ body.cid-partners {
     /*  GRID OF THREE  */
     .span_3_of_3 {
         width: 35%;
-        background-color: $light-grey;
+        background-color: var(--bs-tertiary-bg);
         padding: 20px;
     }
     .span_2_of_3 {
         width: 35%;
-        background-color: $light-grey;
+        background-color: var(--bs-tertiary-bg);
         padding: 20px;
     }
     .span_1_of_3 {
         width: 35%;
-        background-color: $light-grey;
+        background-color: var(--bs-tertiary-bg);
         padding: 20px;
     }
 
@@ -1270,9 +1256,9 @@ body.cid-partners {
     .col-nav {
         display: table-cell; /* Make elements inside the container behave like table cells */
             width: 18%;
-            background-color: $light-grey;
+            background-color: var(--bs-secondary-bg);
             padding: 20px;
-            border: 5px solid white;
+            border: 5px solid var(--bs-body-bg);
     }
 
     /*  GO FULL WIDTH AT LESS THAN 480 PIXELS */
@@ -1311,7 +1297,7 @@ body.cid-partners {
 
     #usersGrid a {
         display: inline-block;
-        background-color: $light-grey;
+        background-color: var(--bs-tertiary-bg);
     }
 
     #ktpContainer, #distContainer, #kcspContainer, #isvContainer, #servContainer {
@@ -1352,7 +1338,7 @@ body.cid-partners {
     }
 
     .partner-box img {
-        background-color: $light-grey;
+        background-color: var(--bs-tertiary-bg);
     }
 
     .partner-box > div {
@@ -1360,7 +1346,7 @@ body.cid-partners {
     }
 
     .partner-box a {
-        color: #3576E3;
+        color: var(--bs-link-color);
     }
 
     @media screen and (max-width: 1024px) {
@@ -1526,8 +1512,8 @@ body.td-documentation {
 /* glossary tooltip */
 .glossary-tooltip {
   display: inline-block;
-  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
-  color: black;
+  border-bottom: 1px dotted var(--bs-body-color); /* If you want dots under the hoverable text */
+  color: var(--bs-body-color);
   text-decoration: none !important;
 }
 
@@ -1817,7 +1803,7 @@ div.alert > em.javascript-required {
 .search-bar .td-search {
   display: flex;
   align-items: center;
-  background-color: #fff;
+  background-color: var(--bs-body-bg);
   outline: 1px solid $secondary;
   border: none;
   border-radius: 20px;
@@ -1854,8 +1840,8 @@ div.alert > em.javascript-required {
 // PageFind Styles
 
 #search .pagefind-ui form input  {
-  background-color: #fff;
-  border: 1px solid #4c4c4c;
+  background-color: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
   border-radius: 20px;
   overflow-x: hidden;
   width: auto;
@@ -1993,7 +1979,7 @@ body.td-home section#upcoming-events > .col > .row {
 
   flex-direction: row;
   row-gap: 0.25rem;
-  column-gap: calc(clamp(1rem, 5vw, 6rem);
+  column-gap: calc(clamp(1rem, 5vw, 6rem));
   justify-content: center;
   flex-wrap: wrap;
 
@@ -2059,9 +2045,11 @@ body.td-home section.case-studies {
       justify-content: space-between;
       text-align: center;
       width: clamp(6rem, 20%, 50vw);
-      picture, picture img {
+      > img {
         height: 4.8rem;
-        text-align: center;
+        width: auto;
+        object-fit: contain;
+        align-self: center;
       }
       > a {
         display: block;

--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -107,8 +107,8 @@ div.feature-state-notice {
 
 .glossary-tooltip {
   display: inline-block;
-  border-bottom: 1px dotted black;
-  color: $black;
+  border-bottom: 1px dotted var(--bs-body-color);
+  color: var(--bs-body-color);
   background: transparent;
   text-decoration: none !important;
 }
@@ -471,12 +471,12 @@ body.docs-portal {
     }
 
     .launch-card:has(button) {
-      background: rgba(210, 210, 210, 0.2);
-      color: $black;
+      background: var(--bs-secondary-bg);
+      color: var(--bs-body-color);
     }
 
     .launch-card:hover {
-      background: rgba(210, 210, 210, 0.4);
+      background: var(--bs-tertiary-bg);
     }
 
     .launch-card:has(button:hover) {
@@ -523,7 +523,7 @@ main {
 
   // Look & Feel , Aesthetics
   div.metric:nth-of-type(odd) {
-    background-color: $light-grey;
+    background-color: var(--bs-tertiary-bg);
   }
 
   div.metrics {
@@ -560,11 +560,11 @@ main {
         li.metric_labels_varying{
           span{
                 display: inline-block;
-                background-color: $metric-labels-varying;
+                background-color: var(--bs-secondary-bg);
                 padding: 0 0.5em;
                 margin-right: .35em;
                 font-family: monospace;
-                border: 1px solid $metric-labels-varying-border;
+                border: 1px solid var(--bs-border-color);
                 border-radius: 5%;
                 margin-bottom: .35em;
           }

--- a/assets/scss/_k8s_gcs-search-dark.scss
+++ b/assets/scss/_k8s_gcs-search-dark.scss
@@ -1,0 +1,282 @@
+// Google Programmable Search Engine dark-mode styling.
+// Forward-port of Docsy v0.15's assets/scss/td/_gcs-search-dark.scss
+// (we're on Docsy 0.10 which doesn't ship this file yet).
+// Delete this file when k/website upgrades to Docsy 0.15+.
+//
+// Source: https://github.com/google/docsy/blob/v0.15.0/assets/scss/td/_gcs-search-dark.scss
+//
+// !important is required because Google's stylesheet uses high-specificity
+// + inline styles; the cleaner long-term fix is to configure colors on the
+// CSE admin panel for engine ID 011737558837375720776:fsdu1nryfng.
+//
+// cSpell:ignore gcsc tabh refinementhActive subelements
+
+:root {
+  --td-gcs-primary: var(--bs-link-color, var(--bs-primary));
+  --td-gcs-secondary: var(--bs-secondary-color);
+  --td-gcs-bg: var(--bs-body-bg);
+  --td-gcs-text: var(--bs-body-color);
+  --td-gcs-border: var(--bs-border-color);
+  --td-gcs-success: var(--bs-success);
+  --td-gcs-radius: var(--bs-border-radius);
+  --td-gcs-overlay-alpha: 0.72;
+}
+
+.gs-web-image-box {
+  margin-right: 0.5rem !important;
+}
+
+.gsc-control-cse {
+  font-family: var(--bs-body-font-family, system-ui, sans-serif) !important;
+  font-size: var(--bs-body-font-size, 1rem) !important;
+  line-height: var(--bs-body-line-height, 1.5) !important;
+  color: var(--bs-body-color, #212529) !important;
+}
+
+.gsc-tabHeader,
+.gsc-orderby,
+.gsc-result-info,
+.gs-snippet,
+.gsc-refinementHeader,
+.gsc-result {
+  font-size: var(--bs-body-font-size, 1rem) !important;
+  line-height: var(--bs-body-line-height, 1.5) !important;
+}
+
+.gsc-orderby,
+.gsc-orderby-label,
+.gsc-selected-option-container,
+.gsc-selected-option,
+.gsc-option-menu-item {
+  font-size: var(--bs-body-font-size, 1rem) !important;
+  line-height: var(--bs-body-line-height, 1.5) !important;
+}
+
+.gs-title {
+  font-size: calc(var(--bs-body-font-size, 1rem) * 1.1) !important;
+  line-height: 1.4 !important;
+}
+
+[data-bs-theme='dark'] {
+  .gsc-control-cse,
+  .gsc-control-cse .gsc-control-wrapper-cse {
+    background-color: var(--td-gcs-bg) !important;
+    color: var(--td-gcs-text) !important;
+    border: 0 !important;
+  }
+
+  .gsc-above-wrapper-area,
+  .gsc-tabsArea,
+  .gsc-refinementsArea {
+    border-bottom: 1px solid var(--td-gcs-border) !important;
+  }
+
+  .gsc-search-box {
+    background: transparent !important;
+  }
+
+  .gsc-input-box,
+  td.gsc-input {
+    background-color: var(--td-gcs-bg) !important;
+    border: 1px solid var(--td-gcs-border) !important;
+  }
+
+  input.gsc-input,
+  input.gsc-input:focus {
+    background-color: transparent !important;
+    color: var(--td-gcs-text) !important;
+    box-shadow: none !important;
+  }
+
+  input.gsc-search-button,
+  input.gsc-search-button-v2 {
+    background-color: var(--td-gcs-primary) !important;
+    border-color: var(--td-gcs-primary) !important;
+    color: #fff !important;
+    border-radius: var(--td-gcs-radius);
+  }
+
+  .gsc-modal-background-image,
+  .gsc-modal-background-image.gsc-modal-background-image-visible {
+    background-color: rgba(var(--td-gcs-bg), var(--td-gcs-overlay-alpha)) !important;
+    background-image: none !important;
+  }
+
+  .gsc-results-wrapper-overlay {
+    background-color: rgba(var(--td-gcs-bg), var(--td-gcs-overlay-alpha)) !important;
+  }
+
+  .gsc-results-wrapper-overlay.gsc-results-wrapper-visible {
+    background-color: rgba(var(--bs-secondary-bg-rgb), var(--td-gcs-overlay-alpha)) !important;
+  }
+
+  .gsc-tabHeader {
+    background: transparent !important;
+  }
+
+  .gsc-tabHeader.gsc-tabhInactive {
+    color: var(--td-gcs-secondary) !important;
+    border-bottom: 2px solid transparent !important;
+    cursor: pointer;
+  }
+
+  .gsc-tabHeader.gsc-tabhActive,
+  .gsc-refinementHeader.gsc-refinementhActive {
+    border-bottom: 2px solid var(--td-gcs-primary) !important;
+    color: var(--td-gcs-primary) !important;
+    background: transparent !important;
+  }
+
+  .gsc-refinementHeader {
+    color: var(--td-gcs-secondary) !important;
+  }
+
+  .gsc-results,
+  .gsc-results .gsc-result,
+  .gsc-webResult.gsc-result,
+  .gsc-imageResult-classic {
+    background-color: var(--td-gcs-bg) !important;
+    color: var(--td-gcs-text) !important;
+  }
+
+  .gsc-results .gsc-webResult.gsc-result,
+  .gsc-webResult.gsc-result {
+    border: 1px solid transparent !important;
+    background-color: var(--td-gcs-bg) !important;
+  }
+
+  .gsc-webResult.gsc-result.gsc-promotion {
+    background-color: var(--td-gcs-bg) !important;
+    border-color: transparent !important;
+  }
+
+  .gs-title,
+  .gs-title * {
+    color: var(--td-gcs-primary) !important;
+  }
+
+  .gs-snippet {
+    color: var(--td-gcs-secondary) !important;
+  }
+
+  .gs-no-results-result .gs-snippet,
+  .gs-error-result .gs-snippet {
+    background-color: var(--bs-warning-bg-subtle) !important;
+    border: 1px solid var(--bs-warning-border-subtle) !important;
+  }
+
+  .gs-visibleUrl,
+  .gs-visibleUrl-short {
+    color: var(--td-gcs-success) !important;
+  }
+
+  .gsc-result-info {
+    color: var(--td-gcs-secondary) !important;
+  }
+
+  .gsc-orderby {
+    background: transparent !important;
+  }
+
+  .gsc-orderby-label {
+    color: var(--td-gcs-secondary) !important;
+  }
+
+  .gsc-selected-option-container {
+    background-color: var(--td-gcs-bg) !important;
+    border: 1px solid var(--td-gcs-border) !important;
+    border-radius: var(--td-gcs-radius);
+    color: var(--td-gcs-text) !important;
+    position: relative;
+    padding-right: 1.7rem;
+  }
+
+  .gsc-selected-option {
+    color: inherit !important;
+  }
+
+  .gsc-control-cse .gsc-option-selector {
+    background: none !important;
+    width: 0 !important;
+    height: 0 !important;
+    padding: 0 !important;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid var(--td-gcs-secondary);
+    position: absolute !important;
+    top: 50% !important;
+    right: 0.55rem !important;
+    transform: translateY(-50%);
+  }
+
+  .gsc-control-cse .gsc-option-menu {
+    background: var(--td-gcs-bg) !important;
+    border: 1px solid var(--td-gcs-border) !important;
+    color: var(--td-gcs-text) !important;
+  }
+
+  .gsc-option-menu-item {
+    color: var(--td-gcs-text) !important;
+    background: transparent !important;
+  }
+
+  .gsc-option-menu-item-highlighted {
+    background: rgba(255, 255, 255, 0.08) !important;
+    color: var(--td-gcs-text) !important;
+  }
+
+  .gsc-results .gsc-cursor-box {
+    margin: 10px 0;
+  }
+
+  .gsc-results .gsc-cursor-box .gsc-cursor-page {
+    text-decoration: none;
+    color: var(--td-gcs-text) !important;
+    background: transparent;
+  }
+
+  .gsc-results .gsc-cursor-box .gsc-cursor-current-page {
+    border: var(--td-gcs-primary) solid 1px !important;
+    color: var(--bs-body-color) !important;
+    border-radius: 999px;
+    padding: 0.25rem 0.6rem;
+  }
+
+  .gsc-completion-container {
+    background: var(--td-gcs-bg) !important;
+    border: 1px solid var(--td-gcs-border) !important;
+    color: var(--td-gcs-text) !important;
+  }
+
+  .gsc-completion-selected {
+    background: rgba(255, 255, 255, 0.08) !important;
+  }
+
+  .gs-spelling a {
+    color: var(--td-gcs-primary) !important;
+  }
+
+  .gsc-table-result,
+  .gsc-table-cell-snippet-close {
+    border: 0 !important;
+  }
+
+  .gcsc-find-more-on-google {
+    color: var(--td-gcs-secondary) !important;
+  }
+
+  .gcsc-find-more-on-google a,
+  .gcsc-find-more-on-google-text,
+  .gcsc-find-more-on-google-query {
+    color: var(--td-gcs-primary) !important;
+    text-decoration: none !important;
+  }
+
+  .gcsc-find-more-on-google-magnifier path {
+    fill: var(--td-gcs-primary) !important;
+  }
+
+  .gcsc-find-more-on-google:hover .gcsc-find-more-on-google-magnifier path {
+    fill: var(--td-gcs-link-hover, var(--td-gcs-primary)) !important;
+  }
+}

--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -1,4 +1,10 @@
 .td-navbar {
+  --bs-navbar-color: #{$navbar-dark-color};
+  --bs-navbar-hover-color: #{$navbar-dark-hover-color};
+  --bs-navbar-active-color: #{$navbar-dark-active-color};
+  --bs-navbar-brand-color: #{$navbar-dark-color};
+  --bs-navbar-brand-hover-color: #{$navbar-dark-hover-color};
+
   background: transparent !important;
   position: fixed !important;
   transition: 0.3s;
@@ -74,14 +80,14 @@
 }
 
 .navbar-bg-onscroll {
-  background: white !important;
-  box-shadow: 0 1px 2px $medium-grey;
+  background: var(--bs-body-bg) !important;
+  box-shadow: 0 1px 2px var(--bs-border-color);
 
   .navbar-nav .nav-link, #hamburger {
-    color: $dark-grey;
+    color: var(--bs-body-color);
 
-    &:hover:focus {
-      color: $medium-grey;
+    &:hover, &:focus {
+      color: $primary;
     }
   }
 
@@ -89,19 +95,64 @@
     // Based on from Bootstrap's _navbar.scss
     .show > .nav-link,
     .nav-link.show {
-      color: $medium-light-grey;
+      color: $primary;
     }
 
     .active > .nav-link,
     .nav-link.active {
-      color: $dark-grey;
-      box-shadow: 0 2px $dark-grey;
+      color: $primary;
+      box-shadow: 0 2px $primary;
     }
   }
 
   .navbar-brand__logo.navbar-logo svg #its-pronounced path {
     fill: $primary;
   }
+}
+
+/* theme_lock front-matter: render a static placeholder where the theme toggle would be. */
+.td-locked-theme {
+  color: var(--bs-secondary-color);
+  cursor: not-allowed;
+  opacity: 0.75;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    color: var(--bs-secondary-color);
+  }
+
+  .bi {
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+.td-light-dark-menu .td-locked-theme {
+  position: relative;
+}
+
+.td-light-dark-menu .td-locked-theme__label {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.td-light-dark-menu .td-locked-theme:hover .td-locked-theme__label,
+.td-light-dark-menu .td-locked-theme:focus-visible .td-locked-theme__label {
+  opacity: 1;
 }
 
 /* Small/Mobile viewport nav menu */
@@ -138,7 +189,7 @@
     top: 0;
     width: 0;
     height: 100%;
-    background-color: white;
+    background-color: var(--bs-body-bg);
     overflow: auto;
     transition: 0.3s;
 
@@ -152,7 +203,7 @@
         width: 100%;
         min-height: 2.75rem;
         padding: 0 60px 0 20px;
-        border-bottom: 1px solid #cccccc;
+        border-bottom: 1px solid var(--bs-border-color);
 
         // Hides the logo that will be in the list
         &:first-child {
@@ -184,6 +235,19 @@
       &:active {
         box-shadow: none !important;
       }
+    }
+
+    // Theme-switcher icons lose Docsy's .td-light-dark-menu wrapper during auto-burger cloning.
+    .bi {
+      width: 1em;
+      height: 1em;
+      vertical-align: -.125em;
+      fill: currentcolor;
+    }
+
+    // Hide the cloned dropdown toggle itself; Light/Dark/Auto rows below already cover the choice.
+    .content ul li:has(> a > svg.theme-icon-active) {
+      display: none;
     }
   }
 }

--- a/assets/scss/_k8s_search.scss
+++ b/assets/scss/_k8s_search.scss
@@ -1,16 +1,13 @@
-.td-navbar, .td-search {
-  .td-search__input, .td-search__input::placeholder {
-    background: white;
-    color: black;
-  }
-
-  .td-search__icon {
-    color: black;
-  }
-}
-
 .td-search {
   width: unset;
+}
+
+.td-search .td-search__input {
+  border: 1px solid var(--bs-border-color);
+}
+
+.td-navbar .td-search .td-search__input {
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 // PageFind Styles
@@ -24,3 +21,4 @@
     margin-left: 1rem;
   }
 }
+

--- a/assets/scss/_k8s_training.scss
+++ b/assets/scss/_k8s_training.scss
@@ -90,9 +90,9 @@ body.training .col-nav {
   display: flex;
   flex-grow: 1;
   width: 18%;
-  background-color: $light-grey;
+  background-color: var(--bs-secondary-bg);
   padding: 20px;
-  border: 5px solid $white;
+  border: 5px solid var(--bs-body-bg);
 }
 
 body.training #get-certified .col-nav {
@@ -277,7 +277,7 @@ body.training .blue-bg {
 }
 
 body.training .lighter-gray-bg {
-  background-color: darken($light-grey, 2%);
+  background-color: var(--bs-tertiary-bg);
 }
 
 body.training .two-thirds-centered {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -10,11 +10,16 @@ Add styles or import other files. */
 @import "k8s_community";
 @import "k8s_nav";
 @import "k8s_search";
+@import "k8s_gcs-search-dark";
 @import "k8s_sidebar-tree";
 @import "k8s_training";
 
 //Media queries
 @import "base";
+
+// Docsy 0.10's chroma helper: imports light + dark syntax-highlight CSS
+// gated on data-bs-theme. Requires hugo.toml [markup.highlight] noClasses = false.
+@import "td/code-dark";
 
 // This is based on Bootstrap's grid system with classes like d-lg-block and d-xl-block
 // Bootstrap 5 included in Docsy 0.7 has a breakpoint at 1400px and it can be used once 0.7 upgrade is done

--- a/hugo.toml
+++ b/hugo.toml
@@ -61,7 +61,7 @@ enableGitInfo = true
     lineNoStart = 1
     lineNos = false
     lineNumbersInTable = true
-    noClasses = true
+    noClasses = false
     style = "emacs"
     tabWidth = 4
   [markup.tableOfContents]
@@ -228,6 +228,8 @@ sidebar_search_disable = false
 navbar_logo = true
 # Set to true to disable the About link in the site footer
 footer_about_enable = true
+# Light/dark mode switcher (Docsy 0.10+ feature).
+showLightDarkModeMenu = true
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -737,6 +737,9 @@ other = "Synopsis"
 [tab_default]
 other = "Tab {{ . }}"
 
+[theme_locked_notice]
+other = "Theme fixed for this page"
+
 [thirdparty_message]
 other = """This section links to third party projects that provide functionality required by Kubernetes. The Kubernetes project authors aren't responsible for these projects, which are listed alphabetically. To add a project to this list, read the <a href="/docs/contribute/style/content-guide/#third-party-content">content guide</a> before submitting a change. <a href="#third-party-content-disclaimer">More information.</a>"""
 

--- a/layouts/partials/cncf.html
+++ b/layouts/partials/cncf.html
@@ -1,9 +1,10 @@
 <div class="main-section">
   <div class="cncf-logo-details">
       <p>{{ T "main_cncf_project" | safeHTML }}</p>
-      <picture>
-          <source srcset="/images/cncf-logo-dark.svg" media="(prefers-color-scheme: dark)">
-          <img src="/images/cncf-logo-white.svg" class="cncf-img" alt="Cloud Native Computing Foundation logo">
-      </picture>
+      <img src="/images/cncf-logo-white.svg"
+           data-theme-src-light="/images/cncf-logo-white.svg"
+           data-theme-src-dark="/images/cncf-logo-dark.svg"
+           class="cncf-img"
+           alt="Cloud Native Computing Foundation logo">
   </div>
 </div>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -109,3 +109,14 @@
 
 {{- $legacyScriptJs := resources.Get "js/legacy-script.js" -}}
 <script src="{{ $legacyScriptJs.RelPermalink }}"></script>
+
+{{/* theme_lock front-matter: pin a page to "light" or "dark" regardless of user preference.
+     Useful for pages whose diagrams/figures only read correctly in one mode. */}}
+{{- with .Params.theme_lock -}}
+{{- $lock := . | lower -}}
+{{- if or (eq $lock "light") (eq $lock "dark") -}}
+<script>window.themeLock={{ $lock | jsonify | safeJS }};</script>
+{{- $themeLockJs := resources.Get "js/theme-lock.js" -}}
+<script src="{{ $themeLockJs.RelPermalink }}"></script>
+{{- end -}}
+{{- end -}}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -3,8 +3,8 @@
     (not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
 
-<nav class="js-navbar-scroll navbar navbar-expand navbar-dark
-            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-auto-burger="primary">
+<nav class="js-navbar-scroll navbar navbar-expand
+            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-bs-theme="dark" data-auto-burger="primary">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
@@ -46,6 +46,28 @@
       <li class="nav-item dropdown me-xl-4 d-none d-lg-block">
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
+      {{ end -}}
+      {{ if .Site.Params.ui.showLightDarkModeMenu -}}
+        {{ with .Params.theme_lock -}}
+        <li class="td-light-dark-menu nav-item">
+          <a href="#" class="td-locked-theme nav-link d-flex align-items-center" role="button" aria-disabled="true" title="{{ T "theme_locked_notice" }}" onclick="return false;">
+            {{ if eq (lower .) "dark" -}}
+            <svg class="bi" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor">
+              <path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/>
+            </svg>
+            {{- else -}}
+            <svg class="bi" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor">
+              <path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/>
+            </svg>
+            {{- end }}
+            <span class="td-locked-theme__label ms-2">{{ T "theme_locked_notice" }}</span>
+          </a>
+        </li>
+        {{- else -}}
+        <li class="td-light-dark-menu nav-item dropdown">
+          {{ partial "theme-toggler" . }}
+        </li>
+        {{- end }}
       {{ end -}}
     </ul>
   </div>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -33,7 +33,11 @@
 {{ else if .Site.Params.customSearch }}
 {{ $jsSearch = resources.Get "js/custom-search.js" }}
 {{ end }}
-{{ $js := (slice $jsBs $jsBase $jsNav $jsSearch) | resources.Concat "js/main.js" -}}
+{{ $jsArray := slice $jsBs $jsBase $jsNav $jsSearch -}}
+{{ if .Site.Params.ui.showLightDarkModeMenu -}}
+  {{ $jsArray = $jsArray | append (resources.Get "js/dark-mode.js") -}}
+{{ end -}}
+{{ $js := $jsArray | resources.Concat "js/main.js" -}}
 {{ if hugo.IsProduction -}}
   {{ $js := $js | minify | fingerprint -}}
   <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
@@ -54,5 +58,15 @@
 {{ end -}}
 
 <script src='{{ "js/tabpane-persist.js" | relURL }}'></script>
+
+{{ if .Site.Params.ui.showLightDarkModeMenu -}}
+  {{ $themeSwap := resources.Get "js/theme-image-swap.js" -}}
+  {{ if hugo.IsProduction -}}
+    {{ $themeSwap = $themeSwap | minify | fingerprint -}}
+    <script src="{{ $themeSwap.RelPermalink }}" integrity="{{ $themeSwap.Data.Integrity }}" crossorigin="anonymous"></script>
+  {{ else -}}
+    <script src="{{ $themeSwap.RelPermalink }}"></script>
+  {{ end -}}
+{{ end -}}
 
 {{ partial "hooks/body-end.html" . }}

--- a/layouts/shortcodes/blocks/case-studies.html
+++ b/layouts/shortcodes/blocks/case-studies.html
@@ -17,10 +17,10 @@
 				{{ $dark = $logo }}
 			{{- end -}}
 	  <div class="case-study-item">
-        <picture>
-	  	  <source srcset="{{$dark.RelPermalink}}" media="(prefers-color-scheme: dark)">
-	  	    <img src="{{ $logo.RelPermalink }}" alt="{{ .Title }}">
-		</picture>
+        <img src="{{ $logo.RelPermalink }}"
+             data-theme-src-light="{{ $logo.RelPermalink }}"
+             data-theme-src-dark="{{ $dark.RelPermalink }}"
+             alt="{{ .Title }}">
         <p>"{{ .Params.quote | truncate 100 }}"</p>
         <a href="{{ .RelPermalink }}">{{ T "main_read_more" }}</a>
       </div>


### PR DESCRIPTION
Adds a light/dark mode switcher to the navbar using Docsy 0.10's `theme-toggler` partial and Bootstrap 5.3 color modes. 

Includes a forward-port of Docsy v0.15's `_gcs-search-dark.scss` for Google CSE dark-mode styling, delete when k/website upgrades to Docsy 0.15+.

**Depends on #55856 (Docsy 0.7.2 → 0.10 upgrade) — cannot merge until that lands.**

Added frontmatter to overide theme

## some pages to test 

- [home](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/) — Home page
- [/community/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/community/) — Community page
- [/blog/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/blog/) — blog page
- [/docs/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/docs/) — documentation page
- [/docs/concepts/overview/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/docs/concepts/overview) — docs concept page (theme_lock frontmatter override)
-  [/docs/concepts/overview/components/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/docs/concepts/overview/components/)  - (theme_lock frontmatter override)
- [/docs/tutorials/hello-minikube/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/docs/tutorials/hello-minikube/) — code blocks flip with chroma `td/_code-dark.scss`
- [/docs/tasks/tools/install-kubectl-macos/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/docs/tasks/tools/install-kubectl-macos/) — tab shortcodes + code blocks
- [/docs/reference/glossary/?fundamental=true](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/docs/reference/glossary/?fundamental=true) — glossary terms
- [/docs/reference/instrumentation/metrics/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/docs/reference/instrumentation/metrics/) — auto-generated reference content
- [/docs/reference/kubernetes-api/cluster-resources/namespace-v1/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/docs/reference/kubernetes-api/cluster-resources/namespace-v1/) — auto-generated API ref
- [/zh-cn/docs/concepts/overview/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/zh-cn/docs/concepts/overview/) — multi-language page in dark mode
- [/training/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/training/) — training page
- [/search/?q=kubernetes](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/search/?q=kubernetes) — Google CSE results theme via forward-ported `_gcs-search-dark.scss`
- [/releases/download/](https://deploy-preview-55918--kubernetes-io-main-staging.netlify.app/releases/download/) — releases page surface


### Issue

Closes: #25061