### PR TITLE
feat: add visible sort indicators to sortable table headers

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -2130,3 +2130,31 @@ section.k8s-birthday-override:has(div.k8s-birthday-override.revert-to-previous i
     visibility: hidden;
   }
 }
+
+
+/* Sortable table: visible sort indicators */
+.sortable-table thead th {
+  position: relative;
+  padding-right: 1.5em;
+  user-select: none;
+
+  &::after {
+    content: "↕";
+    position: absolute;
+    right: 0.4em;
+    top: 50%;
+    transform: translateY(-50%);
+    opacity: 0.4;
+    font-size: 0.85em;
+  }
+
+  &[data-sort-dir="asc"]::after {
+    content: "↑";
+    opacity: 1;
+  }
+
+  &[data-sort-dir="desc"]::after {
+    content: "↓";
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Description

Adds visible sort indicators (↕, ↑, ↓) to `.sortable-table` headers using CSS `::after` pseudo-elements.

## Changes

Added SCSS rules to `assets/scss/_custom.scss` that use the `data-sort-dir` attribute (already set by `sortable-table.js`) to display directional arrows:

- **Unsorted columns:** dimmed ↕ (bidirectional arrow, opacity 0.4)
- **Ascending sort:** ↑ (full opacity)
- **Descending sort:** ↓ (full opacity)

## Why

Sortable columns currently support keyboard interaction and `aria-sort`, but there is no visible indication that a column is sortable or which direction is currently active. This improves discoverability for all users.

## Implementation

Pure CSS approach using `::after` pseudo-elements synchronized with the existing `data-sort-dir` attribute — no JavaScript changes needed.

```scss
.sortable-table thead th {
  &::after { content: "↕"; opacity: 0.4; }
  &[data-sort-dir="asc"]::after { content: "↑"; opacity: 1; }
  &[data-sort-dir="desc"]::after { content: "↓"; opacity: 1; }
}
```

Fixes #55766