### PR TITLE
Fix RTL mobile navbar hamburger position

### DIFF
--- a/assets/scss/_k8s_nav.scss
+++ b/assets/scss/_k8s_nav.scss
@@ -44,6 +44,11 @@
     right: 0.75rem;
     font-size: xx-large;
 
+    :dir(rtl) & {
+      right: auto;
+      left: 0.75rem;
+    }
+
     // Bootstrap buttons have a noticeable depression effect when clicked which is not desirable for the hamburger button
     &:focus,
     &:active {


### PR DESCRIPTION
## Description

Fixes #55924.

This keeps the mobile navbar hamburger on the left side for RTL layouts so it does not overlap the centered Kubernetes logo.

The change is scoped to the existing `#hamburger` positioning rule and mirrors the issue's suggested `:dir(rtl)` approach.

Note: #55851 also changes the mobile navigation implementation. This PR only addresses the current RTL regression in the existing navbar CSS.

## Validation

- `git diff --check`
- Compiled a focused Sass selector snippet to confirm `:dir(rtl) &` emits the intended selector:
  `:dir(rtl) .td-navbar #hamburger { ... }`

I could not run a full Hugo site build in this local environment because `hugo` is not installed.
