### PR TITLE
Official 1.37 Release Docs

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -158,7 +158,7 @@ containerd 1.y and below) do not support the `RuntimeConfig` CRI RPC, and
 may not respond correctly to this query, and thus the Kubelet falls back to using the
 value in its own `--cgroup-driver` flag.
 
-In Kubernetes 1.37, this fallback behavior will be dropped, and older versions
+In Kubernetes 1.38, this fallback behavior will be dropped, and older versions
 of containerd will fail with newer kubelets.
 
 {{< caution >}}


### PR DESCRIPTION
🛑 DO NOT MERGE 🛑 UNTIL KUBERNETES 1.37 IS RELEASED

Target Date: 2026-26-08

Release deadlines: [sig-release timeline](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.37#timeline)

/hold