### PR TITLE
Update OWNER_ALIASES for v1.37 release

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -60,6 +60,7 @@ aliases:
     - dipesh-rawat
     - divya-mohan0209
     - katcosgrove
+    - kernel-kun # RT 1.37 Docs Lead
     - lmktfy
     - natalisucks
     - nate-double-u


### PR DESCRIPTION
### Description

As v1.37 Docs Lead, add @kernel-kun (myself) into the `sig-docs-en-owners` group for release tasks.

### Issue

Closes: #