### PR TITLE
Updated busybox image url from gcr.io container registry to registry.k8s.io

### DIFF
--- a/content/en/docs/tasks/debug/debug-application/debug-service.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-service.md
@@ -22,7 +22,7 @@ For many steps here you will want to see what a Pod running in the cluster
 sees.  The simplest way to do this is to run an interactive busybox Pod:
 
 ```none
-kubectl run -it --rm --restart=Never busybox --image=gcr.io/google-containers/busybox sh
+kubectl run -it --rm --restart=Never busybox --image=registry.k8s.io/busybox:1.27.2 sh
 ```
 
 {{< note >}}


### PR DESCRIPTION
### Description

Fixes https://github.com/kubernetes/website/issues/49523

Updated `busybox` image url from `gcr.io` container registry to `registry.k8s.io` 

Updated website artices under tasks/debugging This replaces an old unmaintained, unpatched image to reference one without CVEs

Here are the references: https://cs.k8s.io/?q=gcr.io%2Fgoogle-containers&i=nope&literal=nope&files=&excludeFiles=blog%2F*&repos=kubernetes/website

Notes:

1. Blog posts not updated as per the original issue
2. Only English version was updated, I can push the rest of the languages (KO, PT) if accepted in separate PRs


### Issue

Closes: #49523