### PR TITLE
[zh-cn] Improve translation of "Automated rollouts and rollbacks

### DIFF
--- a/content/zh-cn/docs/concepts/overview/_index.md
+++ b/content/zh-cn/docs/concepts/overview/_index.md
@@ -110,7 +110,7 @@ Kubernetes 为你提供：
   For example, you can automate Kubernetes to create new containers for your
   deployment, remove existing containers and adopt all their resources to the new container.
 -->
-* **自动部署和回滚**
+* **自动发布和回滚**
 
   你可以使用 Kubernetes 描述已部署容器的所需状态，
   它可以以受控的速率将实际状态更改为期望状态。


### PR DESCRIPTION
Location

Page:
https://kubernetes.io/zh-cn/docs/concepts/overview/

Section:
Why you need Kubernetes and what it can do

Sentence:
"Automated rollouts and rollbacks"

Current Chinese Translation
“自动部署和回滚”

Suggested Translation
“自动发布与回滚”

Reason
In Kubernetes terminology, “rollout” usually refers to the release/update rollout process rather than the initial deployment itself.

Using “发布” may better reflect the original meaning and align better with Kubernetes commands such as: kubectl rollout status kubectl rollout undo

The current translation “部署” is understandable, but it may not fully convey the semantics of progressive rollout and version update management in Kubernetes.
