### PR TITLE
defer cgroup driver fallback removal to 1.38

### DIFF
--- a/content/en/docs/setup/production-environment/container-runtimes.md
+++ b/content/en/docs/setup/production-environment/container-runtimes.md
@@ -158,7 +158,7 @@ containerd 1.y and below) do not support the `RuntimeConfig` CRI RPC, and
 may not respond correctly to this query, and thus the Kubelet falls back to using the
 value in its own `--cgroup-driver` flag.
 
-In Kubernetes 1.37, this fallback behavior will be dropped, and older versions
+In Kubernetes 1.38, this fallback behavior will be dropped, and older versions
 of containerd will fail with newer kubelets.
 
 {{< caution >}}


### PR DESCRIPTION
Retargets the one-line documentation update from kubernetes/website#55809 to main.

The original PR was merged into dev-1.37 and is being reverted separately in kubernetes/website#55953.