### PR TITLE
improve minikube cluster onboarding flow

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
@@ -29,61 +29,6 @@ or [Git Bash](https://gitforwindows.org/) to run the commands as written.
 Commands that use `export`, `$()`, and similar constructs are **not** compatible
 with PowerShell or the Windows Command Prompt.
 
-## Create a minikube cluster
-
-```shell
-minikube start
-```
-
-## Check the status of minikube cluster
-
-Verify the status of minikube cluster to ensure all the components are in a running state.
-
-```shell
-minikube status
-```
-
-The output from above command should show all components Running or Configured, as shown in the example output below:
-
-```shell
-minikube
-type: Control Plane
-host: Running
-kubelet: Running
-apiserver: Running
-kubeconfig: Configured
-```
-
-## Open the Dashboard
-
-Open the Kubernetes dashboard. You can do this two different ways:
-
-{{< tabs name="dashboard" >}}
-{{% tab name="Launch a browser" %}}
-Open a new terminal, and run:
-
-```shell
-minikube dashboard
-```
-
-Now, switch back to terminal where you ran `minikube start`.
-{{% /tab %}}
-{{% tab name="URL copy and paste" %}}
-
-If you don't want minikube to open a web browser for you, run the `dashboard` subcommand with the `--url` flag. `minikube` output URL that you can open in the browser you prefer.
-
-Open a **new** terminal, and run:
-
-```shell
-# start a new terminal, and leave this running
-minikube dashboard --url
-```
-
-Now, you can use this URL and switch back to terminal where you ran `minikube start`.
-
-{{% /tab %}}
-{{< /tabs >}}
-
 ## Kubernetes Clusters
 
 {{% alert %}}
@@ -143,6 +88,22 @@ Kubernetes implementation that creates a VM on your local machine and deploys a
 simple cluster containing only one node. Minikube is available for Linux, macOS,
 and Windows systems. The Minikube CLI provides basic bootstrapping operations for
 working with your cluster, including start, stop, status, and delete.
+
+## Create a minikube cluster
+
+To start a minikube cluster:
+
+```shell
+minikube start
+```
+
+To verify the cluster status:
+
+```shell
+minikube status
+```
+
+For a complete walkthrough including deploying your first app and exploring the Kubernetes dashboard, see the [Hello Minikube](/docs/tutorials/hello-minikube/) tutorial.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
@@ -1,5 +1,6 @@
 ---
 title: Using Minikube to Create a Cluster
+content_type: tutorial
 weight: 10
 ---
 
@@ -11,6 +12,15 @@ weight: 10
 
 ## {{% heading "prerequisites" %}}
 
+This tutorial assumes that you have already installed `minikube`.
+See [minikube start](https://minikube.sigs.k8s.io/docs/start/) for installation instructions.
+{{< note >}}
+Only execute instructions in **step 1: Installation**. The rest is covered in this tutorial.
+{{< /note >}}
+
+You also need to install `kubectl`.
+See [Install tools](/docs/tasks/tools/#kubectl) for installation instructions.
+
 The shell commands in this tutorial use POSIX shell syntax, which is supported by
 the default shells on most Linux and macOS systems (for example, bash, zsh, or sh).
 Windows users must use a POSIX-compatible shell such as
@@ -19,6 +29,60 @@ or [Git Bash](https://gitforwindows.org/) to run the commands as written.
 Commands that use `export`, `$()`, and similar constructs are **not** compatible
 with PowerShell or the Windows Command Prompt.
 
+## Create a minikube cluster
+
+```shell
+minikube start
+```
+
+## Check the status of minikube cluster
+
+Verify the status of minikube cluster to ensure all the components are in a running state.
+
+```shell
+minikube status
+```
+
+The output from above command should show all components Running or Configured, as shown in the example output below:
+
+```shell
+minikube
+type: Control Plane
+host: Running
+kubelet: Running
+apiserver: Running
+kubeconfig: Configured
+```
+
+## Open the Dashboard
+
+Open the Kubernetes dashboard. You can do this two different ways:
+
+{{< tabs name="dashboard" >}}
+{{% tab name="Launch a browser" %}}
+Open a new terminal, and run:
+
+```shell
+minikube dashboard
+```
+
+Now, switch back to terminal where you ran `minikube start`.
+{{% /tab %}}
+{{% tab name="URL copy and paste" %}}
+
+If you don't want minikube to open a web browser for you, run the `dashboard` subcommand with the `--url` flag. `minikube` output URL that you can open in the browser you prefer.
+
+Open a **new** terminal, and run:
+
+```shell
+# start a new terminal, and leave this running
+minikube dashboard --url
+```
+
+Now, you can use this URL and switch back to terminal where you ran `minikube start`.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Kubernetes Clusters
 
@@ -82,5 +146,5 @@ working with your cluster, including start, stop, status, and delete.
 
 ## {{% heading "whatsnext" %}}
 
-* Tutorial [Hello Minikube](/docs/tutorials/hello-minikube/).
+* Tutorial [Deploy an App](/docs/tutorials/kubernetes-basics/deploy-app/deploy-intro/).
 * Learn more about [Cluster Architecture](/docs/concepts/architecture/).


### PR DESCRIPTION
### Description

This PR improves the onboarding flow for the "Using Minikube to Create a Cluster" tutorial.

Previously, the tutorial introduced Kubernetes cluster concepts but did not include the actual steps required to create and verify a Minikube cluster. New users were expected to navigate to the separate "Hello Minikube" tutorial before continuing to the next module, which could make the learning flow confusing for beginners.

This update adds:

- Minikube and kubectl prerequisite guidance
- Commands to start a Minikube cluster
- Steps to verify cluster status
- Instructions for opening the Kubernetes dashboard
- A clearer tutorial progression from cluster creation to application deployment

The "What's next" section now points directly to the "Deploy an App" tutorial to provide a more linear beginner experience.

### Issue

Closes: #55942