### PR TITLE
docs: clarify kubernetes.default.svc behavior on dual stack clusters

### DIFF
--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -108,7 +108,7 @@ The kube-controller-manager flags `--node-cidr-mask-size-ipv4|--node-cidr-mask-s
 are set with default values. See [configure IPv4/IPv6 dual stack](/docs/concepts/services-networking/dual-stack#configure-ipv4-ipv6-dual-stack).
 
 {{< note >}}
-The `--apiserver-advertise-address` flag does not support dual-stack. Because Kubernetes does not implement cross-IP-family traffic, your API server advertise address must belong to the same IP family as your primary service subnet (the first IP range specified in the `networking.serviceSubnet` list in your kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)). This is required for the `kubernetes.default.svc` service to work correctly.
+The `--apiserver-advertise-address` flag does not support dual-stack. The API server advertise address must use the same IP family as the primary service subnet, which is the first IP range in the `networking.serviceSubnet` list in your kubeadm configuration file. Kubernetes clusters do not support routing service traffic across IP families, so the `kubernetes.default.svc` service only works correctly when the advertise address and the primary service subnet use the same IP family.
 {{< /note >}}
 
 ### Join a node to dual-stack cluster

--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -108,7 +108,7 @@ The kube-controller-manager flags `--node-cidr-mask-size-ipv4|--node-cidr-mask-s
 are set with default values. See [configure IPv4/IPv6 dual stack](/docs/concepts/services-networking/dual-stack#configure-ipv4-ipv6-dual-stack).
 
 {{< note >}}
-The `--apiserver-advertise-address` flag does not support dual-stack.
+The `--apiserver-advertise-address` flag does not support dual-stack, hence you should configure your primary service subnet (e.g. the one specified first in the `networking.serviceSubnet` list in your kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)) with the same IP family in order for `kubernetes.default.svc.` service to work.
 {{< /note >}}
 
 ### Join a node to dual-stack cluster

--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -108,7 +108,7 @@ The kube-controller-manager flags `--node-cidr-mask-size-ipv4|--node-cidr-mask-s
 are set with default values. See [configure IPv4/IPv6 dual stack](/docs/concepts/services-networking/dual-stack#configure-ipv4-ipv6-dual-stack).
 
 {{< note >}}
-The `--apiserver-advertise-address` flag does not support dual-stack, hence you should configure your primary service subnet (for example, the one specified first in the `networking.serviceSubnet` list in your kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)) with the same IP family in order for `kubernetes.default.svc.` service to work.
+The `--apiserver-advertise-address` flag does not support dual-stack. Because Kubernetes does not implement cross-IP-family traffic, your API server advertise address must belong to the same IP family as your primary service subnet (the first IP range specified in the `networking.serviceSubnet` list in your kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)). This is required for the `kubernetes.default.svc` service to work correctly.
 {{< /note >}}
 
 ### Join a node to dual-stack cluster

--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -108,7 +108,7 @@ The kube-controller-manager flags `--node-cidr-mask-size-ipv4|--node-cidr-mask-s
 are set with default values. See [configure IPv4/IPv6 dual stack](/docs/concepts/services-networking/dual-stack#configure-ipv4-ipv6-dual-stack).
 
 {{< note >}}
-The `--apiserver-advertise-address` flag does not support dual-stack, hence you should configure your primary service subnet (e.g. the one specified first in the `networking.serviceSubnet` list in your kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)) with the same IP family in order for `kubernetes.default.svc.` service to work.
+The `--apiserver-advertise-address` flag does not support dual-stack, hence you should configure your primary service subnet (for example, the one specified first in the `networking.serviceSubnet` list in your kubeadm [configuration file](/docs/reference/config-api/kubeadm-config.v1beta4/)) with the same IP family in order for `kubernetes.default.svc.` service to work.
 {{< /note >}}
 
 ### Join a node to dual-stack cluster


### PR DESCRIPTION
### Issue

- When creating dual stack clusters, a common pitfall is to use a primary service subnet that differs from `kube-apiserver` advertised address family, making the (crucial) `kubernetes.default.svc.` service unable to route requests to `kube-apiserver`.

### This PR

- Clarifies documentation for this specific case.

### Notes

- I'm not quite satisfied with the clarification, we might want to rephrase of move it. However, I do think the underlying pitfall is real and worth flagging for administrators. 

### Related

- [kubernetes #111671](https://github.com/kubernetes/kubernetes/issues/111671)