### PR TITLE
Add theme_lock front matter to concepts overview pages

### DIFF
--- a/content/en/docs/concepts/architecture/cloud-controller.md
+++ b/content/en/docs/concepts/architecture/cloud-controller.md
@@ -2,6 +2,7 @@
 title: Cloud Controller Manager
 content_type: concept
 weight: 40
+theme_lock: light
 ---
 
 <!-- overview -->

--- a/content/en/docs/concepts/overview/_index.md
+++ b/content/en/docs/concepts/overview/_index.md
@@ -7,6 +7,7 @@ description: >
   Kubernetes is a portable, extensible, open source platform for managing containerized workloads and services that facilitate both declarative configuration and automation. It has a large, rapidly growing ecosystem. Kubernetes services, support, and tools are widely available.
 content_type: concept
 weight: 20
+theme_lock: light
 card:
   name: concepts
   weight: 10

--- a/content/en/docs/concepts/overview/components.md
+++ b/content/en/docs/concepts/overview/components.md
@@ -6,6 +6,7 @@ content_type: concept
 description: >
   An overview of the key components that make up a Kubernetes cluster.
 weight: 10
+theme_lock: light
 card:
   title: Components of a cluster
   name: concepts


### PR DESCRIPTION
Adds theme_lock: light to three pages whose diagrams only read correctly in light mode:

docs/concepts/architecture/cloud-controller.md
docs/concepts/overview/_index.md
docs/concepts/overview/components.md

This is front matter only — the key is inert until the dark/light mode switcher lands. #55918  

Merging it now lets localizations copy the field ahead of that. 
From suggestion on slack
https://kubernetes.slack.com/archives/C1J0BPD2M/p1780055232733509?thread_ts=1780035450.570789&cid=C1J0BPD2M