### PR TITLE
docs: clarify kubelet seccomp-default flag

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/kubelet.md
+++ b/content/en/docs/reference/command-line-tools-reference/kubelet.md
@@ -820,10 +820,10 @@ kubelet [flags]
 </tr>
 
 <tr>
-<td colspan="2">--seccomp-default RuntimeDefault</td>
+<td colspan="2">--seccomp-default&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: false</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Enable the use of RuntimeDefault as the default seccomp profile for all workloads.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>If true, enable the use of RuntimeDefault as the default seccomp profile for all workloads.</p></td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Problem
- The kubelet reference page lists `--seccomp-default RuntimeDefault`, which makes the flag look like it accepts `RuntimeDefault` as an argument.
- The issue asks for the boolean/default behavior to be reflected in the generated reference entry.

Root cause
- The manual kubelet reference entry did not match the upstream kubelet `BoolVar` definition for `seccomp-default`.

Solution
- Update the flag row to show `Default: false`.
- Reword the description to say `If true`, matching the boolean nature of the flag.

Tests run
- `git diff --check`
- Verified the updated `--seccomp-default` entry in `content/en/docs/reference/command-line-tools-reference/kubelet.md`

Fixes #55288