### PR TITLE
docs: add InPlace VPA update mode documentation

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
@@ -110,7 +110,7 @@ spec:
     kind: Deployment
     name: my-app
   updatePolicy:
-    updateMode: "Recreate"  # Off, Initial, Recreate, InPlaceOrRecreate
+    updateMode: "Recreate"  # Off, Initial, Recreate, InPlaceOrRecreate, InPlace
 ```
 
 ### Off {#updateMode-Off}
@@ -138,6 +138,49 @@ In `InPlaceOrRecreate` mode, VPA attempts to update Pod resource requests and li
 (similar to `Recreate` mode) and allowing the workload controller to create a replacement Pod with updated resources.
 
 In this mode, the updater applies recommendations in-place using the [Resize Container Resources In-Place](/docs/tasks/configure-pod-container/resize-container-resources/) feature.
+
+
+### InPlace {#updateMode-InPlace}
+
+This mode is available as an alpha feature in VPA 1.7.0 and requires
+Kubernetes 1.33 or later with the `InPlacePodVerticalScaling` cluster feature
+gate enabled, and the `InPlace` feature gate enabled on the VPA updater and
+admission controller. It uses the
+[in-place Pod resize](/docs/concepts/workloads/pods/pod-lifecycle/#pod-resize)
+feature to apply updates without disrupting the Pod.
+
+In `InPlace` mode, VPA attempts to update Pod resource requests and limits without
+restarting or evicting the Pod. Unlike `InPlaceOrRecreate`, this mode **never falls
+back to eviction**. If an in-place update cannot be applied (for example, because the
+node does not have enough capacity), VPA defers the update and retries it in a
+subsequent reconciliation loop.
+
+To use `InPlace` mode, enable the `InPlace` feature gate on both the VPA updater
+and admission controller:
+
+```shell
+--feature-gates=InPlace=true
+```
+
+Then set `updateMode` to `"InPlace"` in your VPA spec:
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: my-app-vpa
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: my-app
+  updatePolicy:
+    updateMode: "InPlace"
+```
+
+**Key difference from `InPlaceOrRecreate`:** When a resize is deferred, in progress,
+or infeasible, `InPlace` mode always waits and retries — it never evicts the Pod,
+regardless of how long the update is pending.
 
 ### Auto (deprecated) {#updateMode-Auto}
 


### PR DESCRIPTION
### Description :
Add documentation for the new **InPlace** VPA update mode introduced
in VPA v1.7.0 (alpha) and merged in kubernetes/autoscaler#8888

The **InPlace** mode allows VPA to resize pods in-place without falling
back to eviction. If an update cannot be applied , VPA defers and retries
in the next reconciliation loop. 
The pod is never evicted.

This mode requires :
- Kubernetes 1.33+ with **InPlacePodVerticalScaling** feature gate enabled
- VPA feature gate **InPlace=true** enabled on updater and admission controller

Closes: kubernetes/autoscaler#9654