### PR TITLE
Document multiple inter-pod affinity terms

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -287,6 +287,36 @@ To use inter-pod affinity, use the `affinity.podAffinity` field in the Pod spec.
 For inter-pod anti-affinity, use the `affinity.podAntiAffinity` field in the Pod
 spec.
 
+##### Multiple affinity terms
+
+When multiple terms are specified under `requiredDuringSchedulingIgnoredDuringExecution`, all terms must be satisfied for a node to be considered a valid match. The scheduler evaluates each affinity term independently and intersects the resulting sets of eligible nodes.
+
+For example, the following Pod can only be scheduled onto a node if that node already runs at least one Pod with the label `app=frontend` and at least one Pod with the label `environment=production`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: complex-affinity-pod
+spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: frontend
+        topologyKey: topology.kubernetes.io/zone
+      - labelSelector:
+          matchLabels:
+            environment: production
+        topologyKey: topology.kubernetes.io/zone
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.8
+```
+
+The scheduler evaluates both affinity terms and only considers nodes that satisfy all specified terms.
+
 #### Scheduling Behavior
 
 When scheduling a new Pod, the Kubernetes scheduler evaluates the Pod's affinity/anti-affinity rules in the context of the current cluster state:

--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -289,34 +289,53 @@ spec.
 
 ##### Multiple affinity terms
 
-When multiple terms are specified under `requiredDuringSchedulingIgnoredDuringExecution`, all terms must be satisfied for a node to be considered a valid match. The scheduler evaluates each affinity term independently and intersects the resulting sets of eligible nodes.
+When multiple terms are specified under `requiredDuringSchedulingIgnoredDuringExecution`, the nodes that satisfy each term are identified separately. The resulting sets of nodes are then intersected, so a node must satisfy all terms.
 
-For example, the following Pod can only be scheduled onto a node if that node already runs at least one Pod with the label `app=frontend` and at least one Pod with the label `environment=production`:
+For example, the following Pod can be scheduled onto a node if that node already runs a Pod with the label `app=frontend` and another Pod with the label `environment=production`. Both Pods must be on the same node for that node to satisfy both affinity terms.
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: complex-affinity-pod
+  name: pod-a
+  labels:
+    app: frontend
+spec:
+  containers:
+    - name: c1
+      image: registry.k8s.io/pause:3.8
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-b
+  labels:
+    environment: production
+spec:
+  containers:
+    - name: c1
+      image: registry.k8s.io/pause:3.8
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-x
 spec:
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchLabels:
-            app: frontend
-        topologyKey: topology.kubernetes.io/zone
-      - labelSelector:
-          matchLabels:
-            environment: production
-        topologyKey: topology.kubernetes.io/zone
+        - labelSelector:
+            matchLabels:
+              app: frontend
+          topologyKey: kubernetes.io/hostname
+        - labelSelector:
+            matchLabels:
+              environment: production
+          topologyKey: kubernetes.io/hostname
   containers:
-  - name: main
-    image: registry.k8s.io/pause:3.8
+    - name: c1
+      image: registry.k8s.io/pause:3.8
 ```
-
-The scheduler evaluates both affinity terms and only considers nodes that satisfy all specified terms.
-
 #### Scheduling Behavior
 
 When scheduling a new Pod, the Kubernetes scheduler evaluates the Pod's affinity/anti-affinity rules in the context of the current cluster state:


### PR DESCRIPTION
### Description:

Document the behavior of multiple terms in inter-pod affinity and add an example showing how multiple requiredDuringSchedulingIgnoredDuringExecution terms are evaluated.

Closes: #55875 