### PR TITLE
Remove deprecated lang front matter from pod-lifecycle.md

### DIFF
--- a/content/de/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/de/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -3,7 +3,6 @@ title: Pod-Lebenszyklus
 content_type: concept
 weight: 30
 math: true
-lang: de
 ---
 
 <!-- overview -->


### PR DESCRIPTION
## Changes

Removes the deprecated `lang: de` front matter from `content/de/docs/concepts/workloads/pods/pod-lifecycle.md`.

Hugo v0.144.0 deprecated the `lang` field in front matter — the language is now inferred from the `content/de/` directory path.

### Verification

After this change, `make serve` should no longer warn:
```
WARN  deprecated: lang in front matter was deprecated in Hugo v0.144.0
```

Checked all other markdown files in `content/` — this is the only file with the deprecated `lang` front matter.

Fixes #55976