### PR TITLE
Remove deprecated lang front matter

### DIFF
--- a/content/de/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/de/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -3,7 +3,6 @@ title: Pod-Lebenszyklus
 content_type: concept
 weight: 30
 math: true
-lang: de
 ---
 
 <!-- overview -->


### PR DESCRIPTION
Hugo v0.144+ infers language from content/<lang>/ directories. The `lang:` key in YAML front matter is deprecated.

This PR removes the deprecated `lang: de` from:
- `content/de/docs/concepts/workloads/pods/pod-lifecycle.md`

Fixes #55976