### PR TITLE
[zh-cn] Remove duplicate description key in kubectl create page

### DIFF
--- a/content/zh-cn/docs/reference/kubectl/generated/kubectl_create/_index.md
+++ b/content/zh-cn/docs/reference/kubectl/generated/kubectl_create/_index.md
@@ -5,8 +5,6 @@ weight: 30
 description: >-
   基于文件或标准输入创建一个资源
 no_list: true
-description: >-
-  基于文件或标准输入创建一个资源
 ---
 <!--
 title: kubectl create


### PR DESCRIPTION
The file content/zh-cn/docs/reference/kubectl/generated/kubectl_create/_index.md had the description key duplicated in its frontmatter. Hugo errors on duplicate frontmatter keys in newer versions, blocking the Hugo upgrade effort.

Removed the second description block (the two lines after no_list: true), keeping only the first occurrence.

Closes #55991

```release-note
NONE
```