### PR TITLE
[de] Remove deprecated lang front matter from pod-lifecycle page

### DIFF
--- a/content/de/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/de/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -3,7 +3,6 @@ title: Pod-Lebenszyklus
 content_type: concept
 weight: 30
 math: true
-lang: de
 ---
 
 <!-- overview -->


### PR DESCRIPTION
Removed deprecated lang: de field from content/de/docs/concepts/workloads/pods/pod-lifecycle.md. Hugo deprecated this field in v0.144.0 -- the language is inferred from the content/de/ path. Searched all content/de/ files; this was the only file affected.

Closes #55976

```release-note
NONE
```