### PR TITLE
fix(kubectl-docs): removed a duplicate description line in the zh-cn kubectl create reference page

### DIFF
--- a/content/zh-cn/docs/reference/kubectl/generated/kubectl_create/_index.md
+++ b/content/zh-cn/docs/reference/kubectl/generated/kubectl_create/_index.md
@@ -2,8 +2,6 @@
 title: kubectl create
 content_type: tool-reference
 weight: 30
-description: >-
-  基于文件或标准输入创建一个资源
 no_list: true
 description: >-
   基于文件或标准输入创建一个资源


### PR DESCRIPTION
### Description

Removed a duplicate description line in the zh-cn kubectl create reference page

### Issue
[content/zh-cn/docs/reference/kubectl/generated/kubectl_create/_index.md](https://github.com/Caesarsage/website/blob/main/content/zh-cn/docs/reference/kubectl/generated/kubectl_create/_index.md?plain=1) has the description: key twice in its front matte

Newer Hugo errors on duplicate front-matter keys, so this blocks the build for hugo upgrade effort https://github.com/kubernetes/website/pull/55972

Delete the second description: block (the two lines after no_list: true).

Closes: #55991