### PR TITLE
Update HTTP/2 RFC reference from 7540 to 9113

### DIFF
--- a/content/en/docs/concepts/services-networking/service.md
+++ b/content/en/docs/concepts/services-networking/service.md
@@ -363,7 +363,7 @@ This field follows standard Kubernetes label syntax. Valid values are one of:
 
 | Protocol | Description |
 |----------|-------------|
-| `kubernetes.io/h2c` | HTTP/2 over cleartext as described in [RFC 7540](https://www.rfc-editor.org/rfc/rfc7540) |
+| `kubernetes.io/h2c` | HTTP/2 over cleartext as described in [RFC 9113](https://www.rfc-editor.org/rfc/rfc9113) |
 | `kubernetes.io/ws`  | WebSocket over cleartext as described in [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455) |
 | `kubernetes.io/wss` | WebSocket over TLS as described in [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455) |
 


### PR DESCRIPTION
Hi,

I noticed that the HTTP2 cleartext section in the Service docs was referencing an obsoleted RFC. RFC 9113 was published in June 2022 and obsoleted. RFC 7540.

Direct link to the relevant preview page: https://deploy-preview-55996--kubernetes-io-main-staging.netlify.app/docs/concepts/services-networking/service/#application-protocol

### Description

RFC 7540 was obsoleted by RFC 9113, this PR just updates the reference.
