### PR TITLE
KEP-961: update maxUnavailable docs to reflect the FG being off by default

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -361,7 +361,7 @@ unavailable Pod in the range `0` to `replicas - 1`, it will be counted towards
 `maxUnavailable`.
 
 {{< note >}}
-The `maxUnavailable` field is in Beta stage and it is enabled by default.
+The `maxUnavailable` field is in Beta stage and it is disabled by default.
 {{< /note >}}
 
 ### Forced rollback

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MaxUnavailableStatefulSet.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MaxUnavailableStatefulSet.md
@@ -12,7 +12,11 @@ stages:
     toVersion: "1.34"
   - stage: beta
     defaultValue: true
-    fromVersion: "1.35"
+    fromVersion: "1.35.0"
+    toVersion: "1.35.3"
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.35.4"
 ---
 Enables setting the `maxUnavailable` field for the
 [rolling update strategy](/docs/concepts/workloads/controllers/statefulset/#rolling-updates)


### PR DESCRIPTION
### Description
Update docs for maxUnavailable StatefulSet, after the feature gate was disabled by default in https://github.com/kubernetes/kubernetes/pull/137904 due to https://github.com/kubernetes/kubernetes/pull/137409 bug. 

### Issue
KEP: https://github.com/kubernetes/enhancements/issues/961

/sig apps
/assign @helayoty 