### PR TITLE
Convert keys to base64 encoding

### DIFF
--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -355,8 +355,8 @@ Following are the manual steps to follow in case you run into problems running m
 # Create a public private key pair
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /d/tmp/nginx.key -out /d/tmp/nginx.crt -subj "/CN=my-nginx/O=my-nginx"
 # Convert the keys to base64 encoding
-cat /d/tmp/nginx.crt | base64
-cat /d/tmp/nginx.key | base64
+cat /d/tmp/nginx.crt | base64 | tr -d '\n'
+cat /d/tmp/nginx.key | base64 | tr -d '\n'
 ```
  
 Use the output from the previous commands to create a yaml file as follows.


### PR DESCRIPTION
The manual Base64 encoding approach `cat /d/tmp/nginx.crt | base64 | tr -d '\n'` `cat /d/tmp/nginx.key | base64 | tr -d '\n'`  is typically needed if writing a YAML file.

Closes: #55939