### PR TITLE
Fix kubectl scale and patch examples

### DIFF
--- a/content/en/docs/concepts/workloads/management.md
+++ b/content/en/docs/concepts/workloads/management.md
@@ -224,7 +224,7 @@ deployment.apps/my-nginx created
 Ensure that there is 1 replica:
 
 ```shell
-kubectl scale --replicas 1 deployments/my-nginx --subresource='scale' --type='merge' -p '{"spec":{"replicas": 1}}'
+kubectl scale deployment/my-nginx --replicas=1
 ```
 
 ```none
@@ -235,7 +235,7 @@ and allow Kubernetes to add more temporary replicas during a rollout, by setting
 100%:
 
 ```shell
-kubectl patch --type='merge' -p '{"spec":{"strategy":{"rollingUpdate":{"maxSurge": "100%" }}}}'
+kubectl patch deployment/my-nginx --type='merge' -p '{"spec":{"strategy":{"rollingUpdate":{"maxSurge":"100%"}}}}'
 ```
 
 ```none


### PR DESCRIPTION
This PR fixes two kubectl examples in the Managing Workloads page.

The scale example used patch-only flags with kubectl scale. The updated
command uses the supported kubectl scale syntax.

The patch example was missing the target Deployment. The updated command
patches deployment/my-nginx.

Tested with kubectl and minikube: the old commands fail, and the updated
commands complete successfully.