### PR TITLE
Fix Indonesian kubectl tool links

### DIFF
--- a/content/id/docs/tasks/tools/_index.md
+++ b/content/id/docs/tasks/tools/_index.md
@@ -18,9 +18,9 @@ dan melihat *log* (catatan). Untuk informasi lebih lanjut termasuk daftar lengka
 kubectl dapat diinstal pada berbagai platform Linux, macOS dan Windows.
 Pilihlah sistem operasi pilihan kamu di bawah ini.
 
-- [Instalasi kubectl pada Linux](/en/docs/tasks/tools/install-kubectl-linux)
-- [Instalasi kubectl pada macOS](/en/docs/tasks/tools/install-kubectl-macos)
-- [Instalasi kubectl pada Windows](/en/docs/tasks/tools/install-kubectl-windows)
+- [Instalasi kubectl pada Linux](/docs/tasks/tools/install-kubectl-linux/)
+- [Instalasi kubectl pada macOS](/docs/tasks/tools/install-kubectl-macos/)
+- [Instalasi kubectl pada Windows](/docs/tasks/tools/install-kubectl-windows/)
 
 ## kind
 


### PR DESCRIPTION
### Summary
- fix three Indonesian kubectl tool links that pointed at `/en/docs/...`
- use the canonical English `/docs/.../` paths while the Indonesian translations are unavailable

### Rationale
The docs-wide broken-link report includes the Linux kubectl link as a representative 404. The same tools index also linked macOS and Windows through the same `/en/docs/...` pattern, so this fixes the small related set together.

### Tests
- `git diff --check`
- verified the three target source files exist under `content/en/docs/tasks/tools/`
- `Invoke-WebRequest -Method Head` returned 200 for:
  - `https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/`
  - `https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/`
  - `https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/`

Part of #55886