### PR TITLE
Fix SupplementalGroupsPolicy feature gate link

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/SupplementalGroupsPolicy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/SupplementalGroupsPolicy.md
@@ -15,4 +15,4 @@ stages:
     fromVersion: "1.33"
 ---
 Enables support for fine-grained SupplementalGroups control.
-For more details, see [Configure fine-grained SupplementalGroups control for a Pod](/content/en/docs/tasks/configure-pod-container/security-context/#supplementalgroupspolicy).
+For more details, see [Configure fine-grained SupplementalGroups control for a Pod](/docs/tasks/configure-pod-container/security-context/#supplementalgroupspolicy).


### PR DESCRIPTION
### Summary
- fix a broken `/content/en/docs/...` link in the SupplementalGroupsPolicy feature-gate description
- update the matching source comment in the zh-cn page so the stale link is not copied forward

### Rationale
The docs-wide broken-link report includes `/content/en/docs/tasks/configure-pod-container/security-context/` as a published 404. The canonical English docs URL is `/docs/tasks/configure-pod-container/security-context/`.

### Tests
- `git diff --check`
- verified `content/en/docs/tasks/configure-pod-container/security-context.md` exists
- `rg -n "/content/en/docs/tasks/configure-pod-container/security-context" content/en/docs/reference/command-line-tools-reference/feature-gates content/zh-cn/docs/reference/command-line-tools-reference/feature-gates` returns no matches
- `Invoke-WebRequest -Method Head https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#supplementalgroupspolicy` returned 200

Part of #55886