### PR TITLE
Add release binaries and source archives link

### DIFF
--- a/content/en/releases/download.md
+++ b/content/en/releases/download.md
@@ -79,4 +79,10 @@ is signed in the same way as for the multi-architecture manifest lists.
 
 ## Binaries
 
+The table below lists the individual component binaries. For release archives
+(the `kubernetes.tar.gz` source archive and the client, server, and node
+tarballs) along with their checksums, see the release archives linked under
+[Related Links](/releases/{{< skew currentVersion >}}/#related-links) on the
+current release page.
+
 {{< release-binaries >}}

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -531,6 +531,9 @@ other = "Actively Supported"
 [release_announcement_blog]
 other = "Release Announcement Blog"
 
+[release_archives]
+other = "Release binaries and source archives"
+
 # The following text is displayed when JavaScript isn't available.
 [release_binary_alternate_links]
 other  = """You can find links to download Kubernetes components (and their checksums) in the [CHANGELOG](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) files.

--- a/layouts/docs/release-series.html
+++ b/layouts/docs/release-series.html
@@ -123,7 +123,7 @@
   </table>
   {{ end }}
 
-  <h2>{{ T "release_links" }}</h2>
+  <h2 id="related-links">{{ T "release_links" }}</h2>
   <ul>
     {{ if .Params.status | in (slice "supported" "maintenance") }}
     <li>
@@ -141,6 +141,11 @@
         }}
       </a>
       {{ end }}
+    </li>
+    <li>
+      <a href="https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-{{ .Params.minorVersion }}.md#downloads-for-v{{ replace .Params.latestPatchVersion "." "" }}">
+        {{ T "release_archives" }} ({{ .Params.latestPatchVersion }})
+      </a>
     </li>
     {{ end }}
     <li>


### PR DESCRIPTION
### Description

Add a "Release binaries and source archives" link to the `Related Links` section of each release series page (/releases/1.36/). It points to the `Downloads for v<latest patch> section` of that minor's CHANGELOG, which lists the source archive and the client/server/node tarballs with their checksums.

Also added link from the download page to that section on the current release page.

### Issue

Closes: #55767

Previews:
https://deploy-preview-56009--kubernetes-io-main-staging.netlify.app/releases/1.36/
https://deploy-preview-56009--kubernetes-io-main-staging.netlify.app/releases/download/#binaries