### PR TITLE
Fix CRD versioning metadata examples

### DIFF
--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning.md
@@ -284,6 +284,7 @@ and should indicate what API group, version, and kind should be used instead, if
 ```yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
+metadata:
   name: crontabs.example.com
 spec:
   group: example.com
@@ -361,6 +362,7 @@ An older API version cannot be dropped from a CustomResourceDefinition manifest 
 ```yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
+metadata:
   name: crontabs.example.com
 spec:
   group: example.com


### PR DESCRIPTION
This fixes two CustomResourceDefinition examples in the CRD versioning documentation.

Both examples had metadata.name indented directly under kind, without a metadata field. This made the YAML invalid.

The examples now include metadata before name.