### PR TITLE
Add accessible label to mobile navigation button

### DIFF
--- a/assets/js/legacy-script.js
+++ b/assets/js/legacy-script.js
@@ -56,6 +56,27 @@ function px(n){
     return n + 'px';
 }
 
+function mobileNavElement() {
+    return document.querySelector('[data-auto-burger="primary"]');
+}
+
+function mobileNavLabel(attributeName) {
+    var mobileNav = mobileNavElement();
+
+    if (mobileNav) {
+        return mobileNav.getAttribute(attributeName);
+    }
+}
+
+function setHamburgerNavLabel(attributeName) {
+    var hamburger = document.getElementById('hamburger');
+    var label = mobileNavLabel(attributeName);
+
+    if (hamburger && label) {
+        hamburger.setAttribute('aria-label', label);
+    }
+}
+
 var kub = (function () {
     var HEADER_HEIGHT;
     var html, header, mainNav, quickstartButton, hero, encyclopedia, footer, headlineWrapper;
@@ -71,6 +92,7 @@ var kub = (function () {
         footer = $('footer');
         headlineWrapper = $('#headlineWrapper');
         HEADER_HEIGHT = header.outerHeight();
+        setHamburgerNavLabel('data-auto-burger-open-label');
 
         resetTheView();
 
@@ -376,6 +398,16 @@ var pushmenu = (function(){
 
             var autoBurger = document.getElementById(id) || newDOMElement('div', 'pi-pushmenu', id);
             var ul = autoBurger.querySelector('ul') || newDOMElement('ul');
+            var labelAttrs = ['data-auto-burger-open-label', 'data-auto-burger-close-label'];
+
+            for (var i = 0; i < labelAttrs.length; i++) {
+                var labelAttr = labelAttrs[i];
+                var labelValue = container.getAttribute(labelAttr);
+
+                if (labelValue) {
+                    autoBurger.setAttribute(labelAttr, labelValue);
+                }
+            }
 
             $(container).find('a[href], button').each(function () {
                 if (!booleanAttributeValue(this, 'data-auto-burger-exclude', false)) {
@@ -423,6 +455,7 @@ var pushmenu = (function(){
             }
             var pushmenuEl = target.closest('.pi-pushmenu');
             if (pushmenuEl) {
+                setHamburgerNavLabel('data-auto-burger-open-label');
                 pushmenuEl.classList.remove('on');
                 setTimeout(function () { pushmenuEl.style.display = 'none'; }, 300);
             }
@@ -471,6 +504,7 @@ var pushmenu = (function(){
         function closeMe(e) {
             if (e.target == sled) return;
 
+            setHamburgerNavLabel('data-auto-burger-open-label');
             $(el).removeClass('on');
             setTimeout(function(){
                 $(el).css({display: 'none'});
@@ -478,6 +512,7 @@ var pushmenu = (function(){
         }
 
         function exposeMe(){
+            setHamburgerNavLabel('data-auto-burger-close-label');
             $(el).css({
                 display: 'block',
                 zIndex: highestZ()

--- a/assets/js/legacy-script.js
+++ b/assets/js/legacy-script.js
@@ -448,6 +448,10 @@ var pushmenu = (function(){
         sled.appendChild(content);
 
         var closeButton = newDOMElement('button', 'btn fa fa-times');
+        var closeButtonLabel = el.getAttribute('data-auto-burger-close-label');
+        if (closeButtonLabel) {
+            closeButton.setAttribute('aria-label', closeButtonLabel);
+        }
         closeButton.onclick = closeMe;
 
         sled.appendChild(closeButton);

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -767,6 +767,12 @@ other = "Translated By"
 [ui_search]
 other = "Search this site"
 
+[ui_nav_close_menu]
+other = "Close navigation menu"
+
+[ui_nav_open_menu]
+other = "Open navigation menu"
+
 [version_check_mustbe]
 other = "Your Kubernetes server must be version "
 

--- a/i18n/fa/fa.toml
+++ b/i18n/fa/fa.toml
@@ -673,6 +673,12 @@ other = "در کلیپ‌بورد کپی شد: "
 [translated_by]
 other = "ترجمه توسط"
 
+[ui_nav_close_menu]
+other = "بستن منوی ناوبری"
+
+[ui_nav_open_menu]
+other = "باز کردن منوی ناوبری"
+
 [ui_search]
 other = "جستجو در این سایت"
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -4,7 +4,7 @@
 -}}
 
 <nav class="js-navbar-scroll navbar navbar-expand
-            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-bs-theme="dark" data-auto-burger="primary" data-auto-burger-close-label="{{ T "ui_nav_close_menu" }}">
+            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-bs-theme="dark" data-auto-burger="primary" data-auto-burger-open-label="{{ T "ui_nav_open_menu" }}" data-auto-burger-close-label="{{ T "ui_nav_close_menu" }}">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -4,7 +4,7 @@
 -}}
 
 <nav class="js-navbar-scroll navbar navbar-expand
-            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-bs-theme="dark" data-auto-burger="primary">
+            {{- if $cover }} td-navbar-cover {{- end }} flex-md-column flex-xl-row td-navbar" data-bs-theme="dark" data-auto-burger="primary" data-auto-burger-close-label="{{ T "ui_nav_close_menu" }}">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
@@ -82,5 +82,5 @@
     The menu overlay is added to the DOM and shown/hidden all by JS.
     We should explore a Hugo way of doing this.
   */ -}}
-  <button id="hamburger" class="btn fas fa-bars" onclick="kub.toggleMenu()" aria-label="Open navigation menu" data-auto-burger-exclude></button>
+  <button id="hamburger" class="btn fas fa-bars" onclick="kub.toggleMenu()" aria-label="{{ T "ui_nav_open_menu" }}" data-auto-burger-exclude></button>
 </nav>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -82,5 +82,5 @@
     The menu overlay is added to the DOM and shown/hidden all by JS.
     We should explore a Hugo way of doing this.
   */ -}}
-  <button id="hamburger" class="btn fas fa-bars" onclick="kub.toggleMenu()" data-auto-burger-exclude></button>
+  <button id="hamburger" class="btn fas fa-bars" onclick="kub.toggleMenu()" aria-label="Open navigation menu" data-auto-burger-exclude></button>
 </nav>


### PR DESCRIPTION
### Description

This PR adds accessible labels to the mobile navigation controls using localizable strings.

The mobile hamburger button is icon-only, so it now uses a localized label for:

`Open navigation menu`

The mobile pushmenu close button is also icon-only and generated from `legacy-script.js`, so it now uses a localized label for:

`Close navigation menu`

This helps screen reader users understand what each mobile navigation control does, while keeping the text translatable for localized versions of the website.

### Changes

- Added `ui_nav_open_menu` and `ui_nav_close_menu` to `i18n/en/en.toml`
- Updated `navbar.html` to use the localized open-menu label
- Passed the localized close-menu label through a data attribute
- Updated `legacy-script.js` to apply the localized close-menu label to the generated close button

### Testing

I checked that the mobile navigation controls now have accessible labels:

- `#hamburger` uses the localized open menu label
- `.btn.fa.fa-times` close button uses the localized close menu label

I also rebased the branch on the latest upstream `main` and resolved the merge conflict.

### Related issue

Fixes #56014