### PR TITLE
Fix stale source links in Indonesian docs

### DIFF
--- a/content/id/docs/concepts/configuration/manage-compute-resources-container.md
+++ b/content/id/docs/concepts/configuration/manage-compute-resources-container.md
@@ -192,7 +192,7 @@ karena limit sumber dayanya, lihat bagian [Penyelesaian Masalah](#penyelesaian-m
 
 Penggunaan sumber daya dari sebuah Pod dilaporkan sebagai bagian dari kondisi Pod.
 
-Jika [_monitoring_ opsional](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/cluster-monitoring/README.md) diaktifkan pada klaster kamu, maka penggunaan sumber daya Pod dapat diambil
+Jika [_monitoring_ opsional](/id/docs/tasks/debug-application-cluster/resource-usage-monitoring/) diaktifkan pada klaster kamu, maka penggunaan sumber daya Pod dapat diambil
 dari sistem _monitoring_ kamu.
 
 ## Penyelesaian Masalah

--- a/content/id/docs/concepts/containers/container-environment.md
+++ b/content/id/docs/concepts/containers/container-environment.md
@@ -46,7 +46,7 @@ FOO_SERVICE_PORT=<port dimana service dijalankan>
 ```
 
 Semua *Service* memiliki alamat-alamat IP yang bisa didapatkan di dalam Kontainer melalui DNS,
-jika [*addon* DNS](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/) diaktifkan. 
+jika [*addon* DNS](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/) diaktifkan. 
 
 
 

--- a/content/id/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/id/docs/concepts/services-networking/connect-applications-service.md
@@ -116,7 +116,7 @@ Kamu sekarang dapat melakukan *curl* ke dalam *nginx Service* di `<CLUSTER-IP>:<
 ## Mengakses Service
 
 Kubernetes mendukung 2 mode utama untuk menemukan sebuah *Service* - variabel *environment* dan *DNS*.
-*DNS* membutuhkan [tambahan CoreDNS di dalam klaster](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/coredns).
+*DNS* membutuhkan [tambahan CoreDNS di dalam klaster](https://releases.k8s.io/v{{< skew currentPatchVersion >}}/cluster/addons/dns/coredns).
 
 ### Variabel Environment
 
@@ -169,7 +169,7 @@ NAME       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)         AGE
 kube-dns   ClusterIP   10.0.0.10    <none>        53/UDP,53/TCP   8m
 ```
 
-Jika *DNS* belum berjalan, kamu dapat [mengaktifkannya](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/dns/kube-dns/README.md#how-do-i-configure-it).
+Jika *DNS* belum berjalan, kamu dapat [mengaktifkannya](/docs/tasks/administer-cluster/coredns/#installing-coredns).
 
 Sisa panduan ini mengasumsikan kamu mempunyai *Service* dengan IP (my-nginx), dan sebuah server *DNS*  yang memberikan nama ke dalam IP tersebut (CoreDNS klaster), jadi kamu dapat berkomunikasi dengan *Service* dari *Pod* lain di dalam klaster menggunakan metode standar (contohnya *gethostbyname*). Jalankan aplikasi *curl* lain untuk melakukan pengujian ini:
 

--- a/content/id/docs/concepts/services-networking/service.md
+++ b/content/id/docs/concepts/services-networking/service.md
@@ -295,7 +295,7 @@ Kubernetes mendukung 2 buah mode primer untuk melakukan `Service` - variabel _en
 
 Ketika sebuah `Pod` dijalankan pada *node*, _kubelet_ menambahkan seperangkat variabel _environment_
 untuk setiap `Service` yang aktif. _Environment_ yang didukung adalah [Docker links compatible](https://docs.docker.com/userguide/dockerlinks/) variabel (perhatikan
-[makeLinkVariables](http://releases.k8s.io/{{< param "githubbranch" >}}/pkg/kubelet/envvars/envvars.go#L49))
+[makeLinkVariables](https://github.com/kubernetes/kubernetes/blob/dd2d12f6dc0e654c15d5db57a5f9f6ba61192726/pkg/kubelet/envvars/envvars.go#L72))
 dan variabel `{SVCNAME}_SERVICE_HOST` dan `{SVCNAME}_SERVICE_PORT`, dinama nama `Service` akan diubah
 menjadi huruf kapital dan tanda _minus_  akan diubah menjadi _underscore_.
 

--- a/content/id/docs/tasks/administer-cluster/dns-custom-nameservers.md
+++ b/content/id/docs/tasks/administer-cluster/dns-custom-nameservers.md
@@ -25,7 +25,7 @@ menjelaskan tentang bagaimana menggunakan `kubeadm` untuk melakukan migrasi dari
 
 DNS adalah Service bawaan dalam Kubernetes yang diluncurkan secara otomatis
 melalui _addon manager_
-[add-on klaster](http://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons/README.md).
+[add-on klaster](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/addon-manager/README.md).
 
 Sejak Kubernetes v1.12, CoreDNS adalah server DNS yang direkomendasikan untuk menggantikan kube-dns. Jika klaster kamu
 sebelumnya menggunakan kube-dns, maka kamu mungkin masih menggunakan `kube-dns` daripada CoreDNS.


### PR DESCRIPTION
### Summary
- Replace Indonesian docs links that expanded to stale `releases.k8s.io/main` targets.
- Use the current stable docs/source targets already used by the English docs where applicable.
- Keep the patch limited to the six broken links in the affected Indonesian pages.

### Rationale
The affected links used `{{< param "githubbranch" >}}`, which resolves to `main` for the website build. The reported `releases.k8s.io/main/...` URLs currently return 404, while the replacement targets resolve successfully.

### Tests
- `git diff --check`
- `rg -n -F 'releases.k8s.io/{{< param "githubbranch" >}}' <touched files>`
- `Invoke-WebRequest -Method Head` for each replacement URL

Not run: local Hugo build (`hugo` is not installed in this environment).

Part of #55886.
