### PR TITLE
Fix pod name in init container env example

### DIFF
--- a/content/en/docs/tasks/inject-data-application/define-environment-variable-via-file.md
+++ b/content/en/docs/tasks/inject-data-application/define-environment-variable-via-file.md
@@ -66,7 +66,7 @@ kubectl get pods
 Check container logs for environment variables:
 
 ```shell
-kubectl logs dapi-test-pod -c use-envfile | grep DB_ADDRESS
+kubectl logs envfile-test-pod -c use-envfile | grep DB_ADDRESS
 ```
 
 The output shows the values of selected environment variables:


### PR DESCRIPTION
### Description

This PR fixes the Pod name used in the `kubectl logs` command for the init container environment variable example.

The example creates a Pod named `envfile-test-pod`, but the log command used `dapi-test-pod`.

### Related issue

Fixes #56008