### PR TITLE
Improve dark mode readability for Kubernetes Basics diagrams

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_01_cluster.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_01_cluster.svg
@@ -8,6 +8,7 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    width="476.1"
    height="385.3"
+   viewBox="0 0 476.1 385.3"
    version="1.1"
    id="svg161">
   <metadata
@@ -90,6 +91,7 @@
 	.st61{fill:#011F38;stroke:#414042;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}</style>
+  <rect x="0" y="0" width="476.1" height="385.3" fill="#FFFFFF"/>
   <symbol
      viewBox="-68.6 -66.9 137.2 133.9"
      id="master_x5F_level1_1_">

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_02_first_app.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_02_first_app.svg
@@ -8,6 +8,7 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    width="476.1"
    height="385.3"
+   viewBox="0 0 476.1 385.3"
    version="1.1"
    id="svg1987">
   <metadata
@@ -181,6 +182,13 @@
   </symbol>
   <g
      id="g1985">
+    <rect
+       x="0"
+       y="0"
+       width="476.1"
+       height="385.3"
+       fill="#FFFFFF"
+       id="background_rect" />
     <title
        id="title1814">Layer 1</title>
     <g

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_03_nodes.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_03_nodes.svg
@@ -68,6 +68,7 @@
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
+<rect x="0" y="0" width="504" height="432" fill="#FFFFFF"/>
 <symbol  id="node_high_level" viewBox="-81 -93 162 186.1">
 	<polygon class="st0" points="-80,-46 -80,46 0,92 80,46 80,-46 0,-92 	"/>
 	<g id="Isolation_Mode_3_">

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_03_pods.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_03_pods.svg
@@ -68,6 +68,7 @@
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
+<rect x="0" y="0" width="668" height="277" fill="#FFFFFF"/>
 <symbol  id="node_high_level" viewBox="-81 -93 162 186.1">
 	<polygon class="st0" points="-80,-46 -80,46 0,92 80,46 80,-46 0,-92 	"/>
 	<g id="Isolation_Mode_3_">

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_05_scaling1.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_05_scaling1.svg
@@ -68,6 +68,7 @@
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
+<rect x="0" y="0" width="484" height="440.4" fill="#FFFFFF"/>
 <symbol  id="node_high_level" viewBox="-81 -93 162 186.1">
 	<polygon class="st0" points="-80,-46 -80,46 0,92 80,46 80,-46 0,-92 	"/>
 	<g id="Isolation_Mode_3_">

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_05_scaling2.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_05_scaling2.svg
@@ -68,6 +68,7 @@
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
+<rect x="0" y="0" width="484" height="440.4" fill="#FFFFFF"/>
 <symbol  id="node_high_level" viewBox="-81 -93 162 186.1">
 	<polygon class="st0" points="-80,-46 -80,46 0,92 80,46 80,-46 0,-92 	"/>
 	<g id="Isolation_Mode_3_">

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates1.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates1.svg
@@ -68,6 +68,7 @@
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
+<rect x="0" y="0" width="484" height="440.4" fill="#FFFFFF"/>
 <symbol  id="node_high_level" viewBox="-81 -93 162 186.1">
 	<polygon class="st0" points="-80,-46 -80,46 0,92 80,46 80,-46 0,-92 	"/>
 	<g id="Isolation_Mode_3_">

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates2.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates2.svg
@@ -68,6 +68,7 @@
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
+<rect x="0" y="0" width="484" height="440.4" fill="#FFFFFF"/>
 <symbol  id="node_high_level" viewBox="-81 -93 162 186.1">
 	<polygon class="st0" points="-80,-46 -80,46 0,92 80,46 80,-46 0,-92 	"/>
 	<g id="Isolation_Mode_3_">

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates3.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates3.svg
@@ -68,6 +68,7 @@
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
+<rect x="0" y="0" width="484" height="440.4" fill="#FFFFFF"/>
 <symbol  id="node_high_level" viewBox="-81 -93 162 186.1">
 	<polygon class="st0" points="-80,-46 -80,46 0,92 80,46 80,-46 0,-92 	"/>
 	<g id="Isolation_Mode_3_">

--- a/content/en/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates4.svg
+++ b/content/en/docs/tutorials/kubernetes-basics/public/images/module_06_rollingupdates4.svg
@@ -68,6 +68,7 @@
 	.st62{fill:none;stroke:#011F38;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st63{fill:none;stroke:#011F38;stroke-width:0.2813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
+<rect x="0" y="0" width="484" height="440.4" fill="#FFFFFF"/>
 <symbol  id="node_high_level" viewBox="-81 -93 162 186.1">
 	<polygon class="st0" points="-80,-46 -80,46 0,92 80,46 80,-46 0,-92 	"/>
 	<g id="Isolation_Mode_3_">


### PR DESCRIPTION
### Description

This PR fixes the dark mode readability issue in the “Learn Kubernetes Basics” tutorial.

Some SVG diagrams used dark text on a transparent background. In dark mode, the page background becomes dark, so the diagram text becomes difficult to read.

This PR updates the affected SVG diagrams directly by adding a stable white background inside the SVGs. This keeps the diagram text readable in both light mode and dark mode without changing the site-wide dark mode CSS.

### Pages checked

I verified the affected tutorial pages locally in dark mode:

- `create-cluster`
- `deploy-app`
- `explore`
- `scale`
- `update`

### Testing

Tested locally with the Kubernetes website preview in dark mode.

### Related issue

Fixes #56026