### PR TITLE
Simplify Pod Lifecycle page and add dedicated Pod termination page

### DIFF
--- a/content/en/blog/_posts/2024/pod-failure-policy-for-jobs-goes-ga.md
+++ b/content/en/blog/_posts/2024/pod-failure-policy-for-jobs-goes-ga.md
@@ -86,7 +86,7 @@ corresponds to these disruption scenarios:
 - `EvictionByEvictionAPI` - the Pod is due to be deleted by an
    [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/).
 - `DeletionByPodGC` - the Pod is bound to a node that no longer exists, and is due to
-   be deleted by [Pod garbage collection](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection).
+   be deleted by [Pod garbage collection](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection).
 - `TerminationByKubelet` - the Pod was terminated by
   [graceful node shutdown](/docs/concepts/cluster-administration/node-shutdown/#graceful-node-shutdown),
   [node pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/)

--- a/content/en/docs/concepts/architecture/garbage-collection.md
+++ b/content/en/docs/concepts/architecture/garbage-collection.md
@@ -8,7 +8,7 @@ weight: 70
 {{<glossary_definition term_id="garbage-collection" length="short">}} This
 allows the clean up of resources like the following:
 
-* [Terminated pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
+* [Terminated pods](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection)
 * [Completed Jobs](/docs/concepts/workloads/controllers/ttlafterfinished/)
 * [Objects without owner references](#owners-dependents)
 * [Unused containers and container images](#containers-images)

--- a/content/en/docs/concepts/cluster-administration/node-shutdown.md
+++ b/content/en/docs/concepts/cluster-administration/node-shutdown.md
@@ -34,7 +34,7 @@ For more details, refer to the
 The kubelet attempts to detect node system shutdown and terminates pods running on the node.
 
 Kubelet ensures that pods follow the normal
-[pod termination process](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+[pod termination process](/docs/concepts/workloads/pods/pod-termination/)
 during the node shutdown. During node shutdown, the kubelet does not accept new
 Pods (even if those Pods are already bound to the node).
 

--- a/content/en/docs/concepts/containers/container-lifecycle-hooks.md
+++ b/content/en/docs/concepts/containers/container-lifecycle-hooks.md
@@ -50,7 +50,7 @@ the handler, the container will eventually terminate within the Pod's terminatio
 parameters are passed to the handler.
 
 A more detailed description of the termination behavior can be found in
-[Termination of Pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).
+[Termination of Pods](/docs/concepts/workloads/pods/pod-termination/).
 
 `StopSignal`
 
@@ -58,7 +58,7 @@ The StopSignal lifecycle can be used to define a stop signal which would be sent
 stopped. If you set this, it overrides any `STOPSIGNAL` instruction defined within the container image.
 
 A more detailed description of termination behaviour with custom stop signals can be found in
-[Stop Signals](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-stop-signals).
+[Stop Signals](/docs/concepts/workloads/pods/pod-termination/#pod-termination-stop-signals).
 
 ### Hook handler implementations
 

--- a/content/en/docs/concepts/scheduling-eviction/api-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/api-eviction.md
@@ -11,7 +11,7 @@ using a client of the {{<glossary_tooltip term_id="kube-apiserver" text="API ser
 creates an `Eviction` object, which causes the API server to terminate the Pod.
 
 API-initiated evictions respect your configured [`PodDisruptionBudgets`](/docs/tasks/run-application/configure-pdb/)
-and [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-lifecycle#pod-termination).
+and [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-termination/).
 
 Using the API to create an Eviction object for a Pod is like performing a
 policy-controlled [`DELETE` operation](/docs/reference/kubernetes-api/workload-resources/pod-v1/#delete-delete-a-pod)

--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -216,7 +216,7 @@ makes Pod P eligible to preempt Pods on another Node.
 #### Graceful termination of preemption victims
 
 When Pods are preempted, the victims get their
-[graceful termination period](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).
+[graceful termination period](/docs/concepts/workloads/pods/pod-termination/).
 They have that much time to finish their work and exit. If they don't, they are
 killed. This graceful termination period creates a time gap between the point
 that the scheduler preempts Pods and the time when the pending Pod (P) can be

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -866,7 +866,7 @@ such as CronJob) have a default deletion
 policy of `orphanDependents` causing Pods created by an unmanaged Job to be left around
 after that Job is fully deleted.
 Even though the {{< glossary_tooltip text="control plane" term_id="control-plane" >}} eventually
-[garbage collects](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)
+[garbage collects](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection)
 the Pods from a deleted Job after they either fail or complete, sometimes those
 lingering pods may cause cluster performance degradation or in worst case cause the
 cluster to go offline due to this degradation.
@@ -961,7 +961,7 @@ reset to the current time. This means that the `.spec.activeDeadlineSeconds`
 timer will be stopped and reset when a Job is suspended and resumed.
 
 When you suspend a Job, any running Pods that don't have a status of `Completed`
-will be [terminated](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+will be [terminated](/docs/concepts/workloads/pods/pod-termination/)
 with a SIGTERM signal. The Pod's graceful termination period will be honored and
 your Pod must handle this signal in this period. This may involve saving
 progress for later or undoing changes. Pods terminated this way will not count

--- a/content/en/docs/concepts/workloads/pods/disruptions.md
+++ b/content/en/docs/concepts/workloads/pods/disruptions.md
@@ -141,7 +141,7 @@ The default behavior is to wait for the application pods to become [healthy](/do
 before the drain can proceed.
 
 When a pod is evicted using the eviction API, it is gracefully
-[terminated](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination), honoring the
+[terminated](/docs/concepts/workloads/pods/pod-termination/), honoring the
 `terminationGracePeriodSeconds` setting in its [PodSpec](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#podspec-v1-core).
 
 ## PodDisruptionBudget example {#pdb-example}
@@ -251,7 +251,7 @@ indicates one of the following reasons for the Pod termination:
 : Pod has been marked for {{<glossary_tooltip term_id="api-eviction" text="eviction using the Kubernetes API">}} .
 
 `DeletionByPodGC`
-: Pod, that is bound to a no longer existing Node, is due to be deleted by [Pod garbage collection](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection).
+: Pod, that is bound to a no longer existing Node, is due to be deleted by [Pod garbage collection](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection).
 
 `TerminationByKubelet`
 : Pod has been terminated by the kubelet, because of either {{<glossary_tooltip term_id="node-pressure-eviction" text="node pressure eviction">}},
@@ -272,7 +272,7 @@ Pod disruption condition will be cleared.
 {{< /note >}}
 
 Along with cleaning up the pods, the Pod garbage collector (PodGC) will also mark them as failed if they are in a non-terminal
-phase (see also [Pod garbage collection](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)).
+phase (see also [Pod garbage collection](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection)).
 
 When using a Job (or CronJob), you may want to use these Pod disruption conditions as part of your Job's
 [Pod failure policy](/docs/concepts/workloads/controllers/job#pod-failure-policy).

--- a/content/en/docs/concepts/workloads/pods/pod-condition.md
+++ b/content/en/docs/concepts/workloads/pods/pod-condition.md
@@ -153,7 +153,7 @@ indicates one of the following reasons for the Pod termination:
 : Pod has been marked for {{<glossary_tooltip term_id="api-eviction" text="eviction using the Kubernetes API">}} .
 
 `DeletionByPodGC`
-: Pod, that is bound to a no longer existing Node, is due to be deleted by [Pod garbage collection](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection).
+: Pod, that is bound to a no longer existing Node, is due to be deleted by [Pod garbage collection](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection).
 
 `TerminationByKubelet`
 : Pod has been terminated by the kubelet, because of either {{<glossary_tooltip term_id="node-pressure-eviction" text="node pressure eviction">}},
@@ -174,7 +174,7 @@ Pod disruption condition will be cleared.
 {{< /note >}}
 
 Along with cleaning up the pods, the Pod garbage collector (PodGC) will also mark them as failed if they are in a non-terminal
-phase (see also [Pod garbage collection](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection)).
+phase (see also [Pod garbage collection](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection)).
 
 When using a Job (or CronJob), you may want to use these Pod disruption conditions as part of your Job's
 [Pod failure policy](/docs/concepts/workloads/controllers/job#pod-failure-policy).

--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -22,7 +22,7 @@ ID ([UID](/docs/concepts/overview/working-with-objects/names/#uids)), and schedu
 to run on nodes where they remain until termination (according to restart policy) or
 deletion.
 If a {{< glossary_tooltip term_id="node" >}} dies, the Pods running on (or scheduled
-to run on) that node are [marked for deletion](#pod-garbage-collection). The control
+to run on) that node are [marked for deletion](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection). The control
 plane marks the Pods for removal after a timeout period.
 
 <!-- body -->
@@ -132,7 +132,7 @@ Pod phase is an explicit part of the Kubernetes data model and of the
 ```
 
 A Pod is granted a term to terminate gracefully, which defaults to 30 seconds.
-You can use the flag `--force` to [terminate a Pod by force](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-forced).
+You can use the flag `--force` to [terminate a Pod by force](/docs/concepts/workloads/pods/pod-termination/#pod-termination-forced).
 {{< /note >}}
 
 Since Kubernetes 1.27, the kubelet transitions deleted Pods to a terminal phase
@@ -143,7 +143,7 @@ before their deletion from the API server, with two exceptions:
 managed directly by the kubelet and represented by {{< glossary_tooltip
 text="mirror Pods" term_id="mirror-pod" >}}) 
 *  [force-deleted
-Pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-forced)
+Pods](/docs/concepts/workloads/pods/pod-termination/#pod-termination-forced)
 without a finalizer
 
 If a node dies or is disconnected from the rest of the cluster, Kubernetes
@@ -858,192 +858,13 @@ shutdown.
 Typically, with this graceful termination of the pod, kubelet makes requests to the container runtime
 to attempt to stop the containers in the pod by first sending a TERM (aka. SIGTERM) signal,
 with a grace period timeout, to the main process in each container.
-The requests to stop the containers are processed by the container runtime asynchronously.
-There is no guarantee to the order of processing for these requests.
-Many container runtimes respect the `STOPSIGNAL` value defined in the container image and,
-if different, send the container image configured STOPSIGNAL instead of TERM.
 Once the grace period has expired, the KILL signal is sent to any remaining
 processes, and the Pod is then deleted from the
-{{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}. If the kubelet or the
-container runtime's management service is restarted while waiting for processes to terminate, the
-cluster retries from the start including the full original grace period.
+{{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}.
 
-### Stop Signals {#pod-termination-stop-signals}
-
-The stop signal used to kill the container can be defined in the container image with the `STOPSIGNAL` instruction.
-If no stop signal is defined in the image, the default signal of the container runtime
-(SIGTERM for both containerd and CRI-O) would be used to kill the container.
-
-### Defining custom stop signals
-
-{{< feature-state feature_gate_name="ContainerStopSignals" >}}
-
-If the `ContainerStopSignals` feature gate is enabled, you can configure a custom stop signal
-for your containers from the container Lifecycle. We require the Pod's `spec.os.name` field
-to be present as a requirement for defining stop signals in the container lifecycle.
-The list of signals that are valid depends on the OS the Pod is scheduled to.
-For Pods scheduled to Windows nodes, we only support SIGTERM and SIGKILL as valid signals.
-
-Here is an example Pod spec defining a custom stop signal:
-
-```yaml
-spec:
-  os:
-    name: linux
-  containers:
-    - name: my-container
-      image: container-image:latest
-      lifecycle:
-        stopSignal: SIGUSR1
-```
-
-If a stop signal is defined in the lifecycle, this will override the signal defined in the container image.
-If no stop signal is defined in the container spec, the container would fall back to the default behavior.
-
-### Pod Termination Flow {#pod-termination-flow}
-
-Pod termination flow, illustrated with an example:
-
-1. You use the `kubectl` tool to manually delete a specific Pod, with the default grace period
-   (30 seconds).
-
-1. The Pod in the API server is updated with the time beyond which the Pod is considered "dead"
-   along with the grace period.
-   If you use `kubectl describe` to check the Pod you're deleting, that Pod shows up as "Terminating".
-   On the node where the Pod is running: as soon as the kubelet sees that a Pod has been marked
-   as terminating (a graceful shutdown duration has been set), the kubelet begins the local Pod
-   shutdown process.
-
-   1. If one of the Pod's containers has defined a `preStop`
-      [hook](/docs/concepts/containers/container-lifecycle-hooks) and the `terminationGracePeriodSeconds`
-      in the Pod spec is not set to 0, the kubelet runs that hook inside of the container.
-      The default `terminationGracePeriodSeconds` setting is 30 seconds.
-
-      If the `preStop` hook is still running after the grace period expires, the kubelet requests
-      a small, one-off grace period extension of 2 seconds.
-
-   {{% note %}}
-   If the `preStop` hook needs longer to complete than the default grace period allows,
-   you must modify `terminationGracePeriodSeconds` to suit this.
-   {{% /note %}}
-
-   1. The kubelet triggers the container runtime to send a TERM signal to process 1 inside each
-      container.
-
-      There is [special ordering](#termination-with-sidecars) if the Pod has any
-      {{< glossary_tooltip text="sidecar containers" term_id="sidecar-container" >}} defined.
-      Otherwise, the containers in the Pod receive the TERM signal at different times and in
-      an arbitrary order. If the order of shutdowns matters, consider using a `preStop` hook
-      to synchronize (or switch to using sidecar containers).
-
-1. At the same time as the kubelet is starting graceful shutdown of the Pod, the control plane
-   evaluates whether to remove that shutting-down Pod from EndpointSlice objects,
-   where those objects represent a {{< glossary_tooltip term_id="service" text="Service" >}}
-   with a configured {{< glossary_tooltip text="selector" term_id="selector" >}}.
-   {{< glossary_tooltip text="ReplicaSets" term_id="replica-set" >}} and other workload resources
-   no longer treat the shutting-down Pod as a valid, in-service replica.
-
-   Pods that shut down slowly should not continue to serve regular traffic and should start
-   terminating and finish processing open connections.  Some applications need to go beyond
-   finishing open connections and need more graceful termination, for example, session draining
-   and completion.
-
-   Any endpoints that represent the terminating Pods are not immediately removed from
-   EndpointSlices, and a status indicating [terminating state](/docs/concepts/services-networking/endpoint-slices/#conditions)
-   is exposed from the EndpointSlice API.
-   Terminating endpoints always have their `ready` status as `false` (for backward compatibility
-   with versions before 1.26), so load balancers will not use it for regular traffic.
-
-   If traffic draining on terminating Pod is needed, the actual readiness can be checked as a
-   condition `serving`.  You can find more details on how to implement connections draining in the
-   tutorial [Pods And Endpoints Termination Flow](/docs/tutorials/services/pods-and-endpoint-termination-flow/)
-
-   <a id="pod-termination-beyond-grace-period" />
-
-1. The kubelet ensures the Pod is shut down and terminated
-
-   1. When the grace period expires, if there is still any container running in the Pod, the
-      kubelet triggers forcible shutdown.
-      The container runtime sends `SIGKILL` to any processes still running in any container in the Pod.
-      The kubelet also cleans up a hidden `pause` container if that container runtime uses one.
-   1. The kubelet transitions the Pod into a terminal phase (`Failed` or `Succeeded` depending on
-      the end state of its containers).
-   1. The kubelet triggers forcible removal of the Pod object from the API server, by setting grace period
-      to 0 (immediate deletion).
-   1. The API server deletes the Pod's API object, which is then no longer visible from any client.
-
-### Forced Pod termination {#pod-termination-forced}
-
-{{< caution >}}
-Forced deletions can be potentially disruptive for some workloads and their Pods.
-{{< /caution >}}
-
-By default, all deletes are graceful within 30 seconds. The `kubectl delete` command supports
-the `--grace-period=<seconds>` option which allows you to override the default and specify your
-own value.
-
-Setting the grace period to `0` forcibly and immediately deletes the Pod from the API
-server. If the Pod was still running on a node, that forcible deletion triggers the kubelet to
-begin immediate cleanup.
-
-Using kubectl, You must specify an additional flag `--force` along with `--grace-period=0`
-in order to perform force deletions.
-
-When a force deletion is performed, the API server does not wait for confirmation
-from the kubelet that the Pod has been terminated on the node it was running on. It
-removes the Pod in the API immediately so a new Pod can be created with the same
-name. On the node, Pods that are set to terminate immediately will still be given
-a small grace period before being force killed.
-
-{{< caution >}}
-Immediate deletion does not wait for confirmation that the running resource has been terminated.
-The resource may continue to run on the cluster indefinitely.
-{{< /caution >}}
-
-If you need to force-delete Pods that are part of a StatefulSet, refer to the task
-documentation for
-[deleting Pods from a StatefulSet](/docs/tasks/run-application/force-delete-stateful-set-pod/).
-
-### Pod shutdown and sidecar containers {#termination-with-sidecars}
-
-If your Pod includes one or more
-[sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/)
-(init containers with an `Always` restart policy), the kubelet will delay sending
-the TERM signal to these sidecar containers until the last main container has fully terminated.
-The sidecar containers will be terminated in the reverse order they are defined in the Pod spec.
-This ensures that sidecar containers continue serving the other containers in the Pod until they
-are no longer needed.
-
-This means that slow termination of a main container will also delay the termination of the sidecar containers.
-If the grace period expires before the termination process is complete, the Pod may enter [forced termination](#pod-termination-beyond-grace-period).
-In this case, all remaining containers in the Pod will be terminated simultaneously with a short grace period.
-
-Similarly, if the Pod has a `preStop` hook that exceeds the termination grace period, emergency termination may occur.
-In general, if you have used `preStop` hooks to control the termination order without sidecar containers, you can now
-remove them and allow the kubelet to manage sidecar termination automatically.
-
-### Garbage collection of Pods {#pod-garbage-collection}
-
-For failed Pods, the API objects remain in the cluster's API until a human or
-{{< glossary_tooltip term_id="controller" text="controller" >}} process
-explicitly removes them.
-
-The Pod garbage collector (PodGC), which is a controller in the control plane, cleans up
-terminated Pods (with a phase of `Succeeded` or `Failed`), when the number of Pods exceeds the
-configured threshold (determined by `terminated-pod-gc-threshold` in the kube-controller-manager).
-This avoids a resource leak as Pods are created and terminated over time.
-
-Additionally, PodGC cleans up any Pods which satisfy any of the following conditions:
-
-1. are orphan Pods - bound to a node which no longer exists,
-1. are unscheduled terminating Pods,
-1. are terminating Pods, bound to a non-ready node tainted with
-   [`node.kubernetes.io/out-of-service`](/docs/reference/labels-annotations-taints/#node-kubernetes-io-out-of-service).
-
-Along with cleaning up the Pods, PodGC will also mark them as failed if they are in a non-terminal
-phase. Also, PodGC adds a Pod disruption condition when cleaning up an orphan Pod.
-See [Pod disruption conditions](/docs/concepts/workloads/pods/disruptions#pod-disruption-conditions)
-for more details.
+For the full termination process — including custom stop signals, the step-by-step
+termination flow, forced deletion, how sidecar containers are shut down, and garbage
+collection of terminated Pods — see [Termination of Pods](/docs/concepts/workloads/pods/pod-termination/).
 
 ## Pod behavior during kubelet restarts {#kubelet-restarts}
 

--- a/content/en/docs/concepts/workloads/pods/pod-termination.md
+++ b/content/en/docs/concepts/workloads/pods/pod-termination.md
@@ -1,0 +1,221 @@
+---
+title: Termination of Pods
+content_type: concept
+weight: 45
+---
+
+<!-- overview -->
+
+Because Pods represent processes running on nodes in the cluster, it is important to
+allow those processes to gracefully terminate when they are no longer needed (rather
+than being abruptly stopped with a `KILL` signal and having no chance to clean up).
+
+The design aim is for you to be able to request deletion and know when processes
+terminate, but also be able to ensure that deletes eventually complete.
+When you request deletion of a Pod, the cluster records and tracks the intended grace period
+before the Pod is allowed to be forcefully killed. With that forceful shutdown tracking in
+place, the {{< glossary_tooltip text="kubelet" term_id="kubelet" >}} attempts graceful
+shutdown.
+
+<!-- body -->
+
+Typically, with this graceful termination of the pod, kubelet makes requests to the container runtime
+to attempt to stop the containers in the pod by first sending a TERM (aka. SIGTERM) signal,
+with a grace period timeout, to the main process in each container.
+The requests to stop the containers are processed by the container runtime asynchronously.
+There is no guarantee to the order of processing for these requests.
+Many container runtimes respect the `STOPSIGNAL` value defined in the container image and,
+if different, send the container image configured STOPSIGNAL instead of TERM.
+Once the grace period has expired, the KILL signal is sent to any remaining
+processes, and the Pod is then deleted from the
+{{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}. If the kubelet or the
+container runtime's management service is restarted while waiting for processes to terminate, the
+cluster retries from the start including the full original grace period.
+
+## Stop Signals {#pod-termination-stop-signals}
+
+The stop signal used to kill the container can be defined in the container image with the `STOPSIGNAL` instruction.
+If no stop signal is defined in the image, the default signal of the container runtime
+(SIGTERM for both containerd and CRI-O) would be used to kill the container.
+
+### Defining custom stop signals
+
+{{< feature-state feature_gate_name="ContainerStopSignals" >}}
+
+If the `ContainerStopSignals` feature gate is enabled, you can configure a custom stop signal
+for your containers from the container Lifecycle. We require the Pod's `spec.os.name` field
+to be present as a requirement for defining stop signals in the container lifecycle.
+The list of signals that are valid depends on the OS the Pod is scheduled to.
+For Pods scheduled to Windows nodes, we only support SIGTERM and SIGKILL as valid signals.
+
+Here is an example Pod spec defining a custom stop signal:
+
+```yaml
+spec:
+  os:
+    name: linux
+  containers:
+    - name: my-container
+      image: container-image:latest
+      lifecycle:
+        stopSignal: SIGUSR1
+```
+
+If a stop signal is defined in the lifecycle, this will override the signal defined in the container image.
+If no stop signal is defined in the container spec, the container would fall back to the default behavior.
+
+## Pod Termination Flow {#pod-termination-flow}
+
+Pod termination flow, illustrated with an example:
+
+1. You use the `kubectl` tool to manually delete a specific Pod, with the default grace period
+   (30 seconds).
+
+1. The Pod in the API server is updated with the time beyond which the Pod is considered "dead"
+   along with the grace period.
+   If you use `kubectl describe` to check the Pod you're deleting, that Pod shows up as "Terminating".
+   On the node where the Pod is running: as soon as the kubelet sees that a Pod has been marked
+   as terminating (a graceful shutdown duration has been set), the kubelet begins the local Pod
+   shutdown process.
+
+   1. If one of the Pod's containers has defined a `preStop`
+      [hook](/docs/concepts/containers/container-lifecycle-hooks) and the `terminationGracePeriodSeconds`
+      in the Pod spec is not set to 0, the kubelet runs that hook inside of the container.
+      The default `terminationGracePeriodSeconds` setting is 30 seconds.
+
+      If the `preStop` hook is still running after the grace period expires, the kubelet requests
+      a small, one-off grace period extension of 2 seconds.
+
+   {{% note %}}
+   If the `preStop` hook needs longer to complete than the default grace period allows,
+   you must modify `terminationGracePeriodSeconds` to suit this.
+   {{% /note %}}
+
+   1. The kubelet triggers the container runtime to send a TERM signal to process 1 inside each
+      container.
+
+      There is [special ordering](#termination-with-sidecars) if the Pod has any
+      {{< glossary_tooltip text="sidecar containers" term_id="sidecar-container" >}} defined.
+      Otherwise, the containers in the Pod receive the TERM signal at different times and in
+      an arbitrary order. If the order of shutdowns matters, consider using a `preStop` hook
+      to synchronize (or switch to using sidecar containers).
+
+1. At the same time as the kubelet is starting graceful shutdown of the Pod, the control plane
+   evaluates whether to remove that shutting-down Pod from EndpointSlice objects,
+   where those objects represent a {{< glossary_tooltip term_id="service" text="Service" >}}
+   with a configured {{< glossary_tooltip text="selector" term_id="selector" >}}.
+   {{< glossary_tooltip text="ReplicaSets" term_id="replica-set" >}} and other workload resources
+   no longer treat the shutting-down Pod as a valid, in-service replica.
+
+   Pods that shut down slowly should not continue to serve regular traffic and should start
+   terminating and finish processing open connections.  Some applications need to go beyond
+   finishing open connections and need more graceful termination, for example, session draining
+   and completion.
+
+   Any endpoints that represent the terminating Pods are not immediately removed from
+   EndpointSlices, and a status indicating [terminating state](/docs/concepts/services-networking/endpoint-slices/#conditions)
+   is exposed from the EndpointSlice API.
+   Terminating endpoints always have their `ready` status as `false` (for backward compatibility
+   with versions before 1.26), so load balancers will not use it for regular traffic.
+
+   If traffic draining on terminating Pod is needed, the actual readiness can be checked as a
+   condition `serving`.  You can find more details on how to implement connections draining in the
+   tutorial [Pods And Endpoints Termination Flow](/docs/tutorials/services/pods-and-endpoint-termination-flow/)
+
+   <a id="pod-termination-beyond-grace-period" />
+
+1. The kubelet ensures the Pod is shut down and terminated
+
+   1. When the grace period expires, if there is still any container running in the Pod, the
+      kubelet triggers forcible shutdown.
+      The container runtime sends `SIGKILL` to any processes still running in any container in the Pod.
+      The kubelet also cleans up a hidden `pause` container if that container runtime uses one.
+   1. The kubelet transitions the Pod into a terminal phase (`Failed` or `Succeeded` depending on
+      the end state of its containers).
+   1. The kubelet triggers forcible removal of the Pod object from the API server, by setting grace period
+      to 0 (immediate deletion).
+   1. The API server deletes the Pod's API object, which is then no longer visible from any client.
+
+## Forced Pod termination {#pod-termination-forced}
+
+{{< caution >}}
+Forced deletions can be potentially disruptive for some workloads and their Pods.
+{{< /caution >}}
+
+By default, all deletes are graceful within 30 seconds. The `kubectl delete` command supports
+the `--grace-period=<seconds>` option which allows you to override the default and specify your
+own value.
+
+Setting the grace period to `0` forcibly and immediately deletes the Pod from the API
+server. If the Pod was still running on a node, that forcible deletion triggers the kubelet to
+begin immediate cleanup.
+
+Using kubectl, You must specify an additional flag `--force` along with `--grace-period=0`
+in order to perform force deletions.
+
+When a force deletion is performed, the API server does not wait for confirmation
+from the kubelet that the Pod has been terminated on the node it was running on. It
+removes the Pod in the API immediately so a new Pod can be created with the same
+name. On the node, Pods that are set to terminate immediately will still be given
+a small grace period before being force killed.
+
+{{< caution >}}
+Immediate deletion does not wait for confirmation that the running resource has been terminated.
+The resource may continue to run on the cluster indefinitely.
+{{< /caution >}}
+
+If you need to force-delete Pods that are part of a StatefulSet, refer to the task
+documentation for
+[deleting Pods from a StatefulSet](/docs/tasks/run-application/force-delete-stateful-set-pod/).
+
+## Pod shutdown and sidecar containers {#termination-with-sidecars}
+
+If your Pod includes one or more
+[sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/)
+(init containers with an `Always` restart policy), the kubelet will delay sending
+the TERM signal to these sidecar containers until the last main container has fully terminated.
+The sidecar containers will be terminated in the reverse order they are defined in the Pod spec.
+This ensures that sidecar containers continue serving the other containers in the Pod until they
+are no longer needed.
+
+This means that slow termination of a main container will also delay the termination of the sidecar containers.
+If the grace period expires before the termination process is complete, the Pod may enter [forced termination](#pod-termination-beyond-grace-period).
+In this case, all remaining containers in the Pod will be terminated simultaneously with a short grace period.
+
+Similarly, if the Pod has a `preStop` hook that exceeds the termination grace period, emergency termination may occur.
+In general, if you have used `preStop` hooks to control the termination order without sidecar containers, you can now
+remove them and allow the kubelet to manage sidecar termination automatically.
+
+## Garbage collection of Pods {#pod-garbage-collection}
+
+For failed Pods, the API objects remain in the cluster's API until a human or
+{{< glossary_tooltip term_id="controller" text="controller" >}} process
+explicitly removes them.
+
+The Pod garbage collector (PodGC), which is a controller in the control plane, cleans up
+terminated Pods (with a phase of `Succeeded` or `Failed`), when the number of Pods exceeds the
+configured threshold (determined by `terminated-pod-gc-threshold` in the kube-controller-manager).
+This avoids a resource leak as Pods are created and terminated over time.
+
+Additionally, PodGC cleans up any Pods which satisfy any of the following conditions:
+
+1. are orphan Pods - bound to a node which no longer exists,
+1. are unscheduled terminating Pods,
+1. are terminating Pods, bound to a non-ready node tainted with
+   [`node.kubernetes.io/out-of-service`](/docs/reference/labels-annotations-taints/#node-kubernetes-io-out-of-service).
+
+Along with cleaning up the Pods, PodGC will also mark them as failed if they are in a non-terminal
+phase. Also, PodGC adds a Pod disruption condition when cleaning up an orphan Pod.
+See [Pod disruption conditions](/docs/concepts/workloads/pods/disruptions#pod-disruption-conditions)
+for more details.
+
+## {{% heading "whatsnext" %}}
+
+* Learn more about the [Pod lifecycle](/docs/concepts/workloads/pods/pod-lifecycle/).
+* Learn more about [container lifecycle hooks](/docs/concepts/containers/container-lifecycle-hooks/),
+  including the `preStop` hook used during termination.
+* Learn more about [sidecar containers](/docs/concepts/workloads/pods/sidecar-containers/).
+* Follow the tutorial [Pods And Endpoints Termination Flow](/docs/tutorials/services/pods-and-endpoint-termination-flow/)
+  to learn how to drain connections during termination.
+* Learn how to [safely drain a node](/docs/tasks/administer-cluster/safely-drain-node/).
+* Learn how to [force delete Pods from a StatefulSet](/docs/tasks/run-application/force-delete-stateful-set-pod/).

--- a/content/en/docs/concepts/workloads/pods/probes.md
+++ b/content/en/docs/concepts/workloads/pods/probes.md
@@ -86,7 +86,7 @@ If you want to be able to drain requests when the Pod is deleted, you do not
 necessarily need a readiness probe; when the Pod is deleted, the corresponding
 endpoint in the EndpointSlice will update its [conditions](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/#conditions): the endpoint ready
 condition will be set to false, so load balancers will not use the Pod for
-regular traffic. See [Pod termination](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+regular traffic. See [Pod termination](/docs/concepts/workloads/pods/pod-termination/)
 for more information about how the kubelet handles Pod deletion.
 {{< /note >}}
 

--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -74,7 +74,7 @@ next init container from the ordered `.spec.initContainers` list.
 That status either becomes true because there is a process running in the
 container and no startup probe defined, or as a result of its `startupProbe` succeeding.
 
-Upon Pod [termination](/docs/concepts/workloads/pods/pod-lifecycle/#termination-with-sidecars),
+Upon Pod [termination](/docs/concepts/workloads/pods/pod-termination/#termination-with-sidecars),
 the kubelet postpones terminating sidecar containers until the main application container has fully stopped.
 The sidecar containers are then shut down in the opposite order of their appearance in the Pod specification.
 This approach ensures that the sidecars remain operational, supporting other containers within the Pod,

--- a/content/en/docs/reference/glossary/api-eviction.md
+++ b/content/en/docs/reference/glossary/api-eviction.md
@@ -19,7 +19,7 @@ using a client of the kube-apiserver, like the `kubectl drain` command.
 When an `Eviction` object is created, the API server terminates the Pod. 
 
 API-initiated evictions respect your configured [`PodDisruptionBudgets`](/docs/tasks/run-application/configure-pdb/)
-and [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-lifecycle#pod-termination).
+and [`terminationGracePeriodSeconds`](/docs/concepts/workloads/pods/pod-termination/).
 
 API-initiated eviction is not the same as [node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/).
 

--- a/content/en/docs/reference/glossary/garbage-collection.md
+++ b/content/en/docs/reference/glossary/garbage-collection.md
@@ -19,7 +19,7 @@ cluster resources.
 
 Kubernetes uses garbage collection to clean up resources like
 [unused containers and images](/docs/concepts/architecture/garbage-collection/#containers-images),
-[failed Pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection),
+[failed Pods](/docs/concepts/workloads/pods/pod-termination/#pod-garbage-collection),
 [objects owned by the targeted resource](/docs/concepts/overview/working-with-objects/owners-dependents/),
 [completed Jobs](/docs/concepts/workloads/controllers/ttlafterfinished/), and resources
 that have expired or failed.

--- a/content/en/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/en/docs/tasks/administer-cluster/safely-drain-node.md
@@ -43,7 +43,7 @@ before the drain can proceed.
 You can use `kubectl drain` to safely evict all of your pods from a
 node before you perform maintenance on the node (e.g. kernel upgrade,
 hardware maintenance, etc.). Safe evictions allow the pod's containers
-to [gracefully terminate](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+to [gracefully terminate](/docs/concepts/workloads/pods/pod-termination/)
 and will respect the PodDisruptionBudgets you have specified.
 
 {{< note >}}

--- a/content/en/docs/tasks/run-application/force-delete-stateful-set-pod.md
+++ b/content/en/docs/tasks/run-application/force-delete-stateful-set-pod.md
@@ -50,7 +50,7 @@ For the above to lead to graceful termination, the Pod **must not** specify a
 `pod.Spec.TerminationGracePeriodSeconds` of 0. The practice of setting a
 `pod.Spec.TerminationGracePeriodSeconds` of 0 seconds is unsafe and strongly discouraged
 for StatefulSet Pods. Graceful deletion is safe and will ensure that the Pod
-[shuts down gracefully](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+[shuts down gracefully](/docs/concepts/workloads/pods/pod-termination/)
 before the kubelet deletes the name from the apiserver.
 
 A Pod is not deleted automatically when a node is unreachable.

--- a/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
+++ b/content/en/docs/tutorials/services/pods-and-endpoint-termination-flow.md
@@ -30,7 +30,7 @@ a simple nginx web server to demonstrate the concept.
 ## Example flow with endpoint termination
 
 The following is the example flow described in the 
-[Termination of Pods](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+[Termination of Pods](/docs/concepts/workloads/pods/pod-termination/)
 document.
 
 Let's say you have a Deployment containing a single `nginx` replica


### PR DESCRIPTION
### Description

The "Termination of Pods" section in the Pod Lifecycle page has grown large and made the overall page hard to read.
In this PR, I move that detailed content into a new dedicated page (`pod-termination.md`), and leave a short summary with a link to it on the Pod Lifecycle page. The content in the `pod-termination` page is kept almost unchanged from the original Pod Lifecycle page (just relocated and add what's next section).

The #pod-termination anchor stays on that summary so existing inbound links keep working, and the internal links across the English docs that pointed at the moved subsections are updated to point at the new page and its anchors.

### Issue

Related to #55307

Previews:
https://deploy-preview-56041--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/pods/pod-termination/
https://deploy-preview-56041--kubernetes-io-main-staging.netlify.app/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination