### PR TITLE
docs: fix broken command examples in tasks

### DIFF
--- a/content/en/docs/tasks/administer-cluster/controller-manager-leader-migration.md
+++ b/content/en/docs/tasks/administer-cluster/controller-manager-leader-migration.md
@@ -82,13 +82,13 @@ the `system::leader-locking-kube-controller-manager` role. This task guide assum
 that the name of the migration lease is `cloud-provider-extraction-migration`.
 
 ```shell
-kubectl patch -n kube-system role 'system::leader-locking-kube-controller-manager' -p '{"rules": [ {"apiGroups":[ "coordination.k8s.io"], "resources": ["leases"], "resourceNames": ["cloud-provider-extraction-migration"], "verbs": ["create", "list", "get", "update"] } ]}' --type=merge`
+kubectl patch -n kube-system role 'system::leader-locking-kube-controller-manager' -p '{"rules": [ {"apiGroups":[ "coordination.k8s.io"], "resources": ["leases"], "resourceNames": ["cloud-provider-extraction-migration"], "verbs": ["create", "list", "get", "update"] } ]}' --type=merge
 ```
 
 Do the same to the `system::leader-locking-cloud-controller-manager` role.
 
 ```shell
-kubectl patch -n kube-system role 'system::leader-locking-cloud-controller-manager' -p '{"rules": [ {"apiGroups":[ "coordination.k8s.io"], "resources": ["leases"], "resourceNames": ["cloud-provider-extraction-migration"], "verbs": ["create", "list", "get", "update"] } ]}' --type=merge`
+kubectl patch -n kube-system role 'system::leader-locking-cloud-controller-manager' -p '{"rules": [ {"apiGroups":[ "coordination.k8s.io"], "resources": ["leases"], "resourceNames": ["cloud-provider-extraction-migration"], "verbs": ["create", "list", "get", "update"] } ]}' --type=merge
 ```
 
 ### Initial Leader Migration configuration

--- a/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes.md
@@ -41,7 +41,7 @@ To install containerd, first run the following command:
 
   ```PowerShell
   curl.exe -LO https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/Install-Containerd.ps1
-  ``````
+  ```
 
 Then run the following command, but first replace `CONTAINERD_VERSION` with a recent release
 from the [containerd repository](https://github.com/containerd/containerd/releases).

--- a/content/en/docs/tasks/debug/debug-application/debug-service.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-service.md
@@ -448,7 +448,7 @@ Inside the Kubernetes system is a control loop which evaluates the selector of
 every Service and saves the results into one or more EndpointSlice objects.
 
 ```shell
-kubectl get endpointslices -l k8s.io/service-name=hostnames
+kubectl get endpointslices -l kubernetes.io/service-name=hostnames
 
 NAME              ADDRESSTYPE   PORTS   ENDPOINTS
 hostnames-ytpni   IPv4          9376    10.244.0.5,10.244.0.6,10.244.0.7

--- a/content/en/docs/tasks/manage-kubernetes-objects/storage-version-migration.md
+++ b/content/en/docs/tasks/manage-kubernetes-objects/storage-version-migration.md
@@ -328,7 +328,7 @@ This migration can be achieved through _Storage Version Migration_ to migrate al
   spec:
     resource:
       group: example.com
-      resource: SelfieRequest
+      resource: selfierequests
   ```
 
   Create the object using _kubectl_ as follows:

--- a/content/en/docs/tasks/network/extend-service-ip-ranges.md
+++ b/content/en/docs/tasks/network/extend-service-ip-ranges.md
@@ -106,7 +106,7 @@ You can increase the number of IP addresses available for Services, by creating 
 that extends or adds new IP address ranges.
 
 ```sh
-cat <EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1
 kind: ServiceCIDR
 metadata:


### PR DESCRIPTION
A few command examples in the tasks docs don't run as written.

- `network/extend-service-ip-ranges`: `cat <EOF` redirects stdin from a file named EOF; the heredoc needs `cat <<EOF` (the closing `EOF` confirms the intent).
- `manage-kubernetes-objects/storage-version-migration`: `spec.resource.resource` takes the plural resource name. The CRD's `plural` is `selfierequests` and the sibling example uses `secrets`, so the kind `SelfieRequest` is wrong here.
- `debug/debug-application/debug-service`: the EndpointSlice label is `kubernetes.io/service-name`, so the selector `k8s.io/service-name` matches nothing.
- `administer-cluster/kubeadm/adding-windows-nodes`: the PowerShell block is closed with six backticks instead of three.
- `administer-cluster/controller-manager-leader-migration`: both `kubectl patch` commands end with a stray backtick that would be passed to the shell.
