### PR TITLE
[zh-cn]  Add Chinese translations for two Kubernetes glossary terms.

### DIFF
--- a/content/zh-cn/docs/reference/glossary/condition.md
+++ b/content/zh-cn/docs/reference/glossary/condition.md
@@ -1,0 +1,36 @@
+---
+title: 状况（Condition）
+id: condition
+full_link: /zh-cn/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
+short_description: >
+  状况表示 Kubernetes 资源的当前状态，提供资源某些方面是否为真的信息。
+
+aka:
+tags:
+- fundamental
+---
+<!--
+title: Condition
+id: condition
+full_link: /docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
+short_description: >
+  A condition represents the current state of a Kubernetes resource, providing information about whether certain aspects of the resource are true.
+
+aka:
+tags:
+- fundamental
+-->
+
+<!--
+A condition is a field in a Kubernetes resource's status that describes the current state of that resource.
+-->
+状况（Condition）是 Kubernetes 资源状态（status）中的一个字段，用于描述该资源的当前状态。
+
+<!--more-->
+
+<!--
+Conditions provide a standardized way for Kubernetes components to communicate the status of resources. Each condition has a `type`, a `status` (True, False, or Unknown), and optional fields like `reason` and `message` that provide additional details. For example, a Pod might have conditions like `Ready`, `ContainersReady`, or `PodScheduled`.
+-->
+状况为 Kubernetes 组件提供了标准化的方式来传达资源的状态。每个状况包含一个 `type`（类型）、
+一个 `status`（状态，取值为 True、False 或 Unknown），以及可选的 `reason`（原因）和 `message`（消息）
+字段来提供额外细节。例如，Pod 可能拥有 `Ready`、`ContainersReady` 或 `PodScheduled` 等状况。

--- a/content/zh-cn/docs/reference/glossary/san.md
+++ b/content/zh-cn/docs/reference/glossary/san.md
@@ -1,0 +1,38 @@
+---
+title: 主题备用名称（Subject Alternative Name）
+id: san
+full_link: https://datatracker.ietf.org/doc/html/rfc4985
+short_description: >
+  X.509 证书的扩展字段，用于标识证书所适用的主机名或 IP 地址。
+
+aka:
+tags:
+- security
+---
+<!--
+title: Subject Alternative Name
+id: san
+full_link: https://datatracker.ietf.org/doc/html/rfc4985
+short_description: >
+   An X.509 certificate extension to identify what hostname or IP address the certificate applies to.
+
+aka:
+tags:
+- security
+-->
+
+<!--
+Subject Alternative Name is an {{< glossary_tooltip text="X.509 certificate" term_id="certificate" >}}
+extension that allows identities to be bound to the subject of the certificate.
+-->
+主题备用名称（Subject Alternative Name）是 {{< glossary_tooltip text="X.509 证书" term_id="certificate" >}}
+的扩展字段，允许将身份标识绑定到证书的主体。
+
+<!--more-->
+
+<!--
+The [standard](https://datatracker.ietf.org/doc/html/rfc4985) defines identities represented
+as an email address, a DNS name, an IP address or a Uniform Resource Identifier (URI).
+-->
+该[标准](https://datatracker.ietf.org/doc/html/rfc4985)定义了多种身份标识表示形式，
+包括电子邮件地址、DNS 名称、IP 地址或统一资源标识符（URI）。


### PR DESCRIPTION
Add Chinese translations for two Kubernetes glossary terms:

- Subject Alternative Name (主题备用名称)
- Condition (状况)

Both follow the standard zh-cn glossary translation format with bilingual frontmatter and commented original English text.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #