### PR TITLE
fix: correct URL formatting in release data shortcode

### DIFF
--- a/layouts/shortcodes/release-data.html
+++ b/layouts/shortcodes/release-data.html
@@ -35,11 +35,11 @@
 {{- end -}}
 <p>
 {{ T "release_full_details_initial_text" }} {{ $dataVersion }}
-<a href="/releases/patch-releases/#{{ replace $dataVersion `.` `-` }}">{{ T "release_schedule" }}</a> {{ T "conjunction_1" }}
+<a href="{{ relLangURL (printf "/releases/patch-releases/#%s" (replace $dataVersion `.` `-`)) }}">{{ T "release_schedule" }}</a> {{ T "conjunction_1" }}
 <a hreflang="en" href="https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-{{ $dataVersion }}.md">{{ T "release_changelog" }}</a>
 </p>
 <p>
-    <a href="{{ relLangURL (printf "/releases/%s/" $dataVersion) }}/">{{ T "release_details" }}</a>
+    <a href="{{ relLangURL (printf "/releases/%s/" $dataVersion) }}">{{ T "release_details" }}</a>
 </p>
 </div>
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

This pull request contains a fix for the shortcode used to display information about current and past releases.

The extra "/" character at the end of links such as `http://k8s.io/releases/1.36/` has been removed.

The creation of the link `http://k8s.io/releases/patch-releases/#1-36` has also been updated to lead to localized pages if they are available.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #