### PR TITLE
[zh-cn] Add Chinese translations for 3 feature gates

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/UserNamespacesHostNetworkSupport.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/UserNamespacesHostNetworkSupport.md
@@ -1,0 +1,19 @@
+---
+title: UserNamespacesHostNetworkSupport
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha 
+    defaultValue: false
+    fromVersion: "1.35"
+---
+
+<!--
+When enabled, pods are allowed to use both `hostNetwork` and
+[User Namespaces](/docs/concepts/workloads/pods/user-namespaces) simultaneously.
+-->
+启用后，Pod 可以同时使用 `hostNetwork` 和
+[用户名字空间](/zh-cn/docs/concepts/workloads/pods/user-namespaces)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/VolumeLimitScaling.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/VolumeLimitScaling.md
@@ -1,0 +1,22 @@
+---
+title: VolumeLimitScaling
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.35"
+---
+
+<!--
+Enables volume limit scaling for CSI drivers. This allows scheduler to
+co-ordinate better with cluster-autoscaler for storage limits.
+See [Storage Limits](/docs/concepts/storage/storage-limits/)
+for more information.
+-->
+启用 CSI 驱动程序的卷限制扩展。这使得调度器能够更好地与
+cluster-autoscaler 协调存储限制。
+详见[存储限制](/zh-cn/docs/concepts/storage/storage-limits/)。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/WorkloadWithJob.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/WorkloadWithJob.md
@@ -1,0 +1,26 @@
+---
+title: WorkloadWithJob
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.36"
+---
+
+<!--
+Enables the Job controller to automatically create
+[Workload](/docs/concepts/workloads/workload-api/) and
+[PodGroup](/docs/reference/kubernetes-api/workload-resources/workload-v1alpha1/) objects
+for [qualifying Jobs](/docs/concepts/workloads/controllers/job#qualifying-criteria).
+See [Integrate with Workload APIs](/docs/concepts/workloads/controllers/job#integrate-with-workload-apis)
+for details.
+-->
+启用 Job 控制器自动为
+[符合条件的 Job](/zh-cn/docs/concepts/workloads/controllers/job#qualifying-criteria) 创建
+[Workload](/zh-cn/docs/concepts/workloads/workload-api/) 和
+[PodGroup](/zh-cn/docs/reference/kubernetes-api/workload-resources/workload-v1alpha1/) 对象。
+详见[与 Workload API 集成](/zh-cn/docs/concepts/workloads/controllers/job#integrate-with-workload-apis)。


### PR DESCRIPTION
Add Chinese translations for 3 feature gate pages:

- **UserNamespacesHostNetworkSupport** (alpha, v1.35)
- **VolumeLimitScaling** (alpha, v1.35)
- **WorkloadWithJob** (alpha, v1.36)

Follows the bilingual format convention.

/area localization
/language zh