### PR TITLE
[en] Fix ClusterTrustBundle API reference link

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -9,8 +9,8 @@ api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
   override_link_text: "CSR v1"
-- apiVersion: "certificates.k8s.io/v1alpha1"
-  kind: "ClusterTrustBundle"  
+- apiVersion: "certificates.k8s.io/v1beta1"
+  kind: "ClusterTrustBundle"
 content_type: concept
 weight: 60
 ---


### PR DESCRIPTION
## Summary
- Update the English Certificate Signing Requests page metadata for `ClusterTrustBundle` from `certificates.k8s.io/v1alpha1` to `certificates.k8s.io/v1beta1`.
- This lets the `page-api-reference` shortcode resolve the existing ClusterTrustBundle API reference page instead of rendering `%!s(<nil>)`.

## Reproduction
On `/docs/reference/access-authn-authz/certificate-signing-requests/#what-s-next`, the "Read about the ClusterTrustBundle API" bullet rendered `%!s(<nil>)` instead of a link.

## Root cause
The page front matter still pointed `ClusterTrustBundle` at `certificates.k8s.io/v1alpha1`, but the generated English API reference page is `content/en/docs/reference/kubernetes-api/certificates/cluster-trust-bundle-v1beta1.md` with `apiVersion: "certificates.k8s.io/v1beta1"`. The shortcode builds API reference links by matching `kind` and `apiVersion`, so the stale metadata produced no map entry for `ClusterTrustBundle`.

## Changes
- Change the English page `api_metadata` entry for `ClusterTrustBundle` to `certificates.k8s.io/v1beta1`.
- Remove trailing whitespace on that front matter line.
- Keep this PR scoped to the English page; the zh-cn page can be handled in a separate localization PR as suggested on the issue.

## Tests
- `awk 'prev ~ /apiVersion: "certificates.k8s.io\\/v1beta1"/ && $0 ~ /kind: "ClusterTrustBundle"/ {found=1} {prev=$0} END {if (!found) exit 1; print "page metadata points to ClusterTrustBundle v1beta1"}' content/en/docs/reference/access-authn-authz/certificate-signing-requests.md`
- `awk 'BEGIN{inmeta=0} /^---$/ {if (!inmeta) {inmeta=1; next} else {inmeta=0; exit}} inmeta && /apiVersion: "certificates.k8s.io\\/v1beta1"/ {version=1} inmeta && /kind: "ClusterTrustBundle"/ {kind=1} END {if (!(version && kind)) exit 1; print "API reference front matter is ClusterTrustBundle v1beta1"}' content/en/docs/reference/kubernetes-api/certificates/cluster-trust-bundle-v1beta1.md`
- `git diff --check origin/main..HEAD`

## Screenshots/Logs
- Not applicable; this is a front matter metadata fix.
- Local Hugo render was not run because `hugo` is not installed in this environment.

## Issue
Related to #56092.
