### PR TITLE
Fix typo in PersistentVolume name retrieval instructions

### DIFF
--- a/content/en/docs/tasks/administer-cluster/change-pv-access-mode-readwriteoncepod.md
+++ b/content/en/docs/tasks/administer-cluster/change-pv-access-mode-readwriteoncepod.md
@@ -60,7 +60,7 @@ and a "cat-pictures-writer" Deployment that uses this PersistentVolumeClaim.
 {{< note >}}
 If your storage plugin supports
 [Dynamic provisioning](/docs/concepts/storage/dynamic-provisioning/),
-the "cat-picutres-pv" will be created for you, but its name may differ. To get
+the "cat-pictures-pv" will be created for you, but its name may differ. To get
 your PersistentVolume's name run:
 
 ```shell


### PR DESCRIPTION
Relatively useless change, but when I was reading through the docs, this threw me off lol.

Corrected text regarding PersistentVolume name retrieval.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #