### PR TITLE
[zh-cn] Fix ClusterTrustBundle API reference link

### DIFF
--- a/content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -4,8 +4,8 @@ api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
   override_link_text: "CSR v1"
-- apiVersion: "certificates.k8s.io/v1alpha1"
-  kind: "ClusterTrustBundle"  
+- apiVersion: "certificates.k8s.io/v1beta1"
+  kind: "ClusterTrustBundle"
 content_type: concept
 weight: 60
 ---
@@ -20,8 +20,8 @@ api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
   override_link_text: "CSR v1"
-- apiVersion: "certificates.k8s.io/v1alpha1"
-  kind: "ClusterTrustBundle"  
+- apiVersion: "certificates.k8s.io/v1beta1"
+  kind: "ClusterTrustBundle"
 content_type: concept
 weight: 60
 -->


### PR DESCRIPTION
## Summary
- Update the zh-cn Certificate Signing Requests page metadata for `ClusterTrustBundle` from `certificates.k8s.io/v1alpha1` to `certificates.k8s.io/v1beta1`.
- Keep the localized file's commented English source metadata in sync with the active front matter.
- This allows the `page-api-reference` shortcode to resolve the existing ClusterTrustBundle API reference instead of rendering `%!s(<nil>)`.

## Reproduction
On the zh-cn Certificate Signing Requests page, the "阅读 ClusterTrustBundle 相关内容" bullet uses `{{< page-api-reference kind="ClusterTrustBundle" >}}`. With the stale `api_metadata` entry for `certificates.k8s.io/v1alpha1`, the shortcode cannot find the generated API reference page and can render `%!s(<nil>)`.

## Root cause
The page front matter still pointed `ClusterTrustBundle` at `certificates.k8s.io/v1alpha1`, but the generated API reference page is `content/en/docs/reference/kubernetes-api/certificates/cluster-trust-bundle-v1beta1.md` with `apiVersion: "certificates.k8s.io/v1beta1"`. The shortcode matches `kind` and `apiVersion`, so the stale metadata did not create a map entry for `ClusterTrustBundle`.

## Changes
- Change the zh-cn page `api_metadata` entry for `ClusterTrustBundle` to `certificates.k8s.io/v1beta1`.
- Update the matching commented English source metadata in the same localized file.
- Remove trailing whitespace from those metadata lines.

## Tests
- `awk 'prev ~ /apiVersion: "certificates.k8s.io\\/v1beta1"/ && $0 ~ /kind: "ClusterTrustBundle"/ {found=1} /^---$/ && seen++ {exit} {prev=$0} END {if (!found) exit 1; print "zh-cn page metadata points to ClusterTrustBundle v1beta1"}' content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md`
- `test -f content/en/docs/reference/kubernetes-api/certificates/cluster-trust-bundle-v1beta1.md`
- `git diff --check origin/main..HEAD`

## Screenshots/Logs
- Not applicable; this is a front matter metadata fix.
- Local Hugo render was not run because `hugo` is not installed in this environment.

## Issue
Related to #56092.
