### PR TITLE
Clarify Deployment selector orphan behavior

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -356,6 +356,10 @@ A Deployment's label selector is **immutable** after creation;
 it cannot be updated via `kubectl patch`, `kubectl edit`, `kubectl apply`, or tools like `helm upgrade`.
 
 If you must change the selector, you have to delete the Deployment and recreate it.
+If you delete the Deployment normally, Kubernetes also deletes the Deployment's dependent
+ReplicaSets and Pods. The orphaning behavior described below applies when you intentionally
+keep those dependents, for example by deleting the Deployment with `--cascade=orphan`
+before creating the replacement Deployment.
 Exercise great caution and ensure you grasp the following implications:
 
 * **Additions:** When you create a new Deployment with a narrower selector, the new Deployment **must** also have a suitable Pod template.


### PR DESCRIPTION
## Summary

- Clarifies that normal Deployment deletion also deletes dependent ReplicaSets and Pods.
- States that the orphaning behavior in the selector-update section assumes the dependents are intentionally kept, for example with `--cascade=orphan`.

Replaces #56088. The original PR was closed when the fork branch was renamed; that discussion includes feedback from the issue author.

## Reproduction

1. Open the Deployment documentation at `/docs/concepts/workloads/controllers/deployment/#label-selector-updates`.
2. Read the selector update guidance: it first says to delete and recreate the Deployment, then describes old ReplicaSets being orphaned.
3. A normal `kubectl delete deployment <name>` uses cascading deletion, so the old dependents are deleted rather than left for the replacement Deployment scenario described in the bullets.

## Root cause

The section described orphaning behavior immediately after mentioning delete-and-recreate, but did not state that this behavior applies only when the existing dependent ReplicaSets and Pods are intentionally kept before the replacement Deployment is created.

## Changes

- Add a short clarification distinguishing normal deletion from the `--cascade=orphan` path.
- Leave the existing Additions, Value Updates, and Removals behavior descriptions intact.

## Tests

- `git diff --check`
- Not run: Hugo site build (`hugo` is not installed in this local environment).

## Screenshots/Logs

Not applicable; documentation-only text change.

Fixes #56075
