### PR TITLE
Add workflow and script to track draft blog posts

### DIFF
--- a/.github/workflows/update-blogs-wiki.yml
+++ b/.github/workflows/update-blogs-wiki.yml
@@ -1,5 +1,3 @@
-update-blogs-wiki
-
 name: Update Draft Blogs Wiki
 
 on:

--- a/.github/workflows/update-blogs-wiki.yml
+++ b/.github/workflows/update-blogs-wiki.yml
@@ -1,0 +1,24 @@
+update-blogs-wiki
+
+name: Update Draft Blogs Wiki
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # daily
+
+
+jobs:
+  update-wiki:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run draft blog scanner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: bash scripts/find-draft-blogs.sh

--- a/scripts/find-draft-blogs.sh
+++ b/scripts/find-draft-blogs.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# This script scans the blog directory for posts merged into main but still marked draft: true,
+# then writes a summary table to the repo wiki for visibility.
+set -euo pipefail
+
+# Configuration
+REPO="${REPO:?REPO environment variable must be set}"
+GH_TOKEN="${GH_TOKEN:?GH_TOKEN environment variable must be set}"
+BASE_REF="${BASE_REF:-main}"
+WIKI_REPO="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.wiki.git"
+WIKI_DIR="$(mktemp -d)/wiki"
+WIKI_PAGE="Draft-Blog-Tracker.md"
+CURRENT_YEAR=$(date +%Y)
+
+trap 'rm -rf /tmp/draft_rows.txt "${WIKI_DIR}"' EXIT
+
+echo "Scanning ${REPO} (${BASE_REF}) for draft blog posts..."
+
+# Fetch the full file tree, filter to this year's blog posts, then check each
+# file's front matter for draft: true. Outputs one markdown table row per match.
+gh api "repos/${REPO}/git/trees/${BASE_REF}?recursive=1" \
+  --jq '.tree[].path' \
+| grep -E "^content/en/blog/_posts/(${CURRENT_YEAR})/([^/]+/)?[^/]+\.md$" \
+| while read -r path; do
+    content="$(gh api \
+      -H "Accept: application/vnd.github.raw" \
+      "repos/${REPO}/contents/${path}?ref=${BASE_REF}" 2>/dev/null || true)"
+
+    # Skip if file couldn't be fetched
+    [ -z "$content" ] && continue
+    echo "$content" | grep -q '"status":"404"' && continue
+
+    # Skip if not a draft
+    DRAFT_LINE=$(echo "$content" | tr -d '\r' | grep -iE '^draft:[[:space:]]*true[[:space:]]*$' || true)
+    [ -z "$DRAFT_LINE" ] && continue
+
+    TITLE=$(echo "$content" | tr -d '\r' | grep -m1 -E '^title:' \
+      | sed 's/^title:[[:space:]]*//' | tr -d '"'"'" || echo "(no title)")
+    GH_URL="https://github.com/${REPO}/blob/${BASE_REF}/${path}"
+    echo "| ${TITLE} | \`${path}\` | [View](${GH_URL}) |"
+done > /tmp/draft_rows.txt
+
+# Early exit if nothing found
+ROW_COUNT=$(wc -l < /tmp/draft_rows.txt | tr -d ' ')
+if [ "$ROW_COUNT" -eq 0 ]; then
+  echo "No draft blogs found. Wiki will not be updated."
+  exit 0
+fi
+
+echo "Found ${ROW_COUNT} draft blog(s). Updating wiki..."
+
+# Clone wiki, write updated page, and push only if there are changes
+git clone "$WIKI_REPO" "$WIKI_DIR"
+
+cat > "${WIKI_DIR}/${WIKI_PAGE}" <<EOF
+# Blog Posts Pending Publication
+
+These blog posts have been merged into main but still marked \`draft: true\` awaiting final publication.
+
+## Pending Publication
+| Title | Path | Link |
+|-------|------|------|
+$(cat /tmp/draft_rows.txt)
+EOF
+
+cd "$WIKI_DIR"
+git config user.email "draft-blog-bot@users.noreply.github.com"
+git config user.name "github-actions[bot]"
+git add "$WIKI_PAGE"
+git diff --cached --quiet && echo "No changes to wiki." && exit 0
+git commit -m "chore: update draft blog list [$(date -u '+%Y-%m-%d')]"
+git push


### PR DESCRIPTION
## Problem
When a blog post PR is merged into `main`, a follow-up PR is still needed to set `draft: false` to publish it. There is no tracking for which posts are merged but still unpublished.

## Solution
Adds a daily workflow that scans `main` for `draft: true` blog posts and updates the Wiki page . Maintainers can check the **Draft-Blog-Tracker** wiki page  to see which posts still are unpublished .

## Changes
- `.github/workflows/update-draft-wiki.yml` : runs daily and on manual trigger
- `scripts/find-draft-blogs.sh` — checks front matter and updates the wiki