### PR TITLE
Fix typos in manual documentation pages

### DIFF
--- a/content/en/docs/concepts/cluster-administration/node-autoscaling.md
+++ b/content/en/docs/concepts/cluster-administration/node-autoscaling.md
@@ -207,7 +207,7 @@ Main differences between Cluster Autoscaler and Karpenter:
   them to new versions).
 * Cluster Autoscaler doesn't support auto-provisioning, the Node groups it can provision from have
   to be pre-configured. Karpenter supports auto-provisioning, so the user only has to configure a
-  set of constraints for the provisioned Nodes, instead of fully configuring homogenous groups.
+  set of constraints for the provisioned Nodes, instead of fully configuring homogeneous groups.
 * Cluster Autoscaler provides cloud provider integrations directly, which means that they're a part
   of the Kubernetes project. For Karpenter, the Kubernetes project publishes Karpenter as a library
   that cloud providers can integrate with to build a Node autoscaler.

--- a/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
@@ -84,7 +84,7 @@ It iterates over the Pods and performs the following for each:
 
 Placement scheduling algorithm is an alternative PodGroup scheduling algorithm, which uses
 [scheduling plugins](/docs/reference/scheduling/config/#scheduling-plugins) to find the optimal
-placement for the considered PodGroup. Users can accomodate the algorithm to their specific needs
+placement for the considered PodGroup. Users can accommodate the algorithm to their specific needs
 by using and configuring plugins.
 
 The algorithm proceeds in three main phases for a given PodGroup:

--- a/content/en/docs/concepts/storage/storage-limits.md
+++ b/content/en/docs/concepts/storage/storage-limits.md
@@ -98,7 +98,7 @@ If a volume attachment operation fails with a `ResourceExhausted` error (gRPC co
 
 {{< feature-state feature_gate_name="VolumeLimitScaling" >}}
 
-If `VolumeLimitScaling` [feature gate](/docs/reference/command-line-tools-reference/feature-gates#VolumeLimitScaling) is enabled and a CSI driver has corresponding `CSIDriver` object installed with `spec.preventPodSchedulingIfMissing` set to true then scheduler will prevent pod placement to nodes that do not yet have CSI driver installed.  For exmaple:
+If `VolumeLimitScaling` [feature gate](/docs/reference/command-line-tools-reference/feature-gates#VolumeLimitScaling) is enabled and a CSI driver has corresponding `CSIDriver` object installed with `spec.preventPodSchedulingIfMissing` set to true then scheduler will prevent pod placement to nodes that do not yet have CSI driver installed.  For example:
 
 ```yaml
 apiVersion: storage.k8s.io/v1

--- a/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
+++ b/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
@@ -47,7 +47,7 @@ If the priority class is not found, the PodGroup is rejected.
 When `priorityClassName` is not set for a PodGroup, Kubernetes looks for a default (a PriorityClass with `globalDefault` set true)
 If there is no PriorityClass with `globalDefault` set true, a PodGroup with no `priorityClassName` has priority zero.
 
-The priority of the PodGroup is an authorative priority for all pods in the group during [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) events, even when priorities of individual pods forming this PodGroup differ.
+The priority of the PodGroup is an authoritative priority for all pods in the group during [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) events, even when priorities of individual pods forming this PodGroup differ.
 
 The following YAML is an example of a PodGroup configuration that uses the `high-priority` PriorityClass,
 which maps to the integer priority value of 1000000.


### PR DESCRIPTION
**Description:**

This PR follows @lmktfy's guidance from #56102 . It contains only the
manual documentation fixes, with old blog posts and auto‑generated pages excluded.

Fixes four spelling mistakes found using the `codespell` spell‑checker and
manually verified. No AI tools were used to generate content.

**Fixes:**

- `accomodate` → `accommodate` in `content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md`
- `exmaple` → `example` in `content/en/docs/concepts/storage/storage-limits.md`
- `authorative` → `authoritative` in `content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md`
- `homogenous` → `homogeneous` in `content/en/docs/concepts/cluster-administration/node-autoscaling.md`

**Policy compliance:**

- No changes to blog articles.
- No changes to auto‑generated pages.

Closes: # (none – minor documentation fixes)