### PR TITLE
Mirror blog article headlamp-cluster-api-plugin

### DIFF
--- a/content/en/blog/_posts/2026/headlamp-cluster-api-plugin/index.md
+++ b/content/en/blog/_posts/2026/headlamp-cluster-api-plugin/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Introducing the Cluster API plugin for Headlamp (headlamp-k8s/plugins)"
-draft: true
+date: 2026-06-17
+canonical_url: https://www.kubernetes.dev/blog/2026/06/17/headlamp-cluster-api-plugin
 layout: blog
 slug: headlamp-cluster-api-plugin
 author: "[Chayan Das](https://github.com/ChayanDass) (independent)"


### PR DESCRIPTION
Mirror the blog article from contributor-site.

Changes:

* Added `canonicalUrl`
* Added the publication date
* Removed `draft: true`

Reference: kubernetes/contributor-site#776
