### PR TITLE
Publish blog article sig-storage-spotlight-2026

### DIFF
--- a/content/en/blog/_posts/2026/sig-storage-spotlight-2026.md
+++ b/content/en/blog/_posts/2026/sig-storage-spotlight-2026.md
@@ -1,7 +1,8 @@
 ---
 layout: blog
 title: "Spotlight on SIG Storage"
-draft: true
+date: 2026-06-15
+canonical_url: https://www.kubernetes.dev/blog/2026/06/15/sig-storage-spotlight-2026
 slug: sig-storage-spotlight-2026
 author: "Darshan Murthy (Apple)"
 ---


### PR DESCRIPTION
Based on the discussion in the k/contributor site PR : https://github.com/kubernetes/contributor-site/pull/727
The mirror blog now has the updated date and the canonical url