### PR TITLE
Fix ClusterTrustBundle API version link

### DIFF
--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -9,7 +9,7 @@ api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
   override_link_text: "CSR v1"
-- apiVersion: "certificates.k8s.io/v1alpha1"
+- apiVersion: "certificates.k8s.io/v1beta1"
   kind: "ClusterTrustBundle"  
 content_type: concept
 weight: 60

--- a/content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -4,7 +4,7 @@ api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
   override_link_text: "CSR v1"
-- apiVersion: "certificates.k8s.io/v1alpha1"
+- apiVersion: "certificates.k8s.io/v1beta1"
   kind: "ClusterTrustBundle"  
 content_type: concept
 weight: 60
@@ -20,7 +20,7 @@ api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
   override_link_text: "CSR v1"
-- apiVersion: "certificates.k8s.io/v1alpha1"
+- apiVersion: "certificates.k8s.io/v1beta1"
   kind: "ClusterTrustBundle"  
 content_type: concept
 weight: 60

--- a/content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/zh-cn/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -4,7 +4,7 @@ api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
   override_link_text: "CSR v1"
-- apiVersion: "certificates.k8s.io/v1beta1"
+- apiVersion: "certificates.k8s.io/v1alpha1"
   kind: "ClusterTrustBundle"  
 content_type: concept
 weight: 60
@@ -20,7 +20,7 @@ api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
   override_link_text: "CSR v1"
-- apiVersion: "certificates.k8s.io/v1beta1"
+- apiVersion: "certificates.k8s.io/v1alpha1"
   kind: "ClusterTrustBundle"  
 content_type: concept
 weight: 60


### PR DESCRIPTION
### Description

Updates the ClusterTrustBundle API version reference from `certificates.k8s.io/v1alpha1` to `certificates.k8s.io/v1beta1` in the certificate signing requests documentation.

This fixes the broken "Read about the ClusterTrustBundle API" link that currently renders as `%!s(<nil>)`.

Also updates the corresponding zh-cn documentation page to keep both localizations in sync.

### Issue

Closes: #56092
