### PR TITLE
KEP-961: update maxUnavailable on by default in 1.37

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -361,7 +361,7 @@ unavailable Pod in the range `0` to `replicas - 1`, it will be counted towards
 `maxUnavailable`.
 
 {{< note >}}
-The `maxUnavailable` field is in Beta stage and it is disabled by default.
+The `maxUnavailable` field is in Beta stage and it is enabled by default.
 {{< /note >}}
 
 ### Forced rollback

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MaxUnavailableStatefulSet.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MaxUnavailableStatefulSet.md
@@ -17,6 +17,10 @@ stages:
   - stage: beta
     defaultValue: false
     fromVersion: "1.35.4"
+    toVersion: "1.36"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.37"
 ---
 Enables setting the `maxUnavailable` field for the
 [rolling update strategy](/docs/concepts/workloads/controllers/statefulset/#rolling-updates)


### PR DESCRIPTION
### Description
Update docs for maxUnavailable StatefulSet to be on by default starting from 1.37.

### Issue
KEP: https://github.com/kubernetes/enhancements/issues/961

/sig apps
/assign @helayoty 