### PR TITLE
docs(readme): add container-image build step to container workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ To build the site in a container, run the following:
 ```bash
 # You can set $CONTAINER_ENGINE to the name of any Docker-like container tool
 
+# Build the container image
+make container-image
+
 # Render the full website
 make container-serve
 


### PR DESCRIPTION
## Description

- Adds the missing make container-image step to the README’s container workflow documentation.

- This makes it clear that users need to build the container image before running make container-serve, helping first-time contributors successfully run the website in a container environment.