### PR TITLE
Fix navbar search contrast over light announcement banners

### DIFF
--- a/assets/scss/_k8s_search.scss
+++ b/assets/scss/_k8s_search.scss
@@ -10,6 +10,20 @@
   border-color: rgba(255, 255, 255, 0.2);
 }
 
+header:has(#announcement.display-announcement) .td-navbar:not(.navbar-bg-onscroll) .td-search .td-search__input {
+  background-color: var(--bs-body-bg);
+  border-color: var(--bs-secondary-color);
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: 0 0.125rem 0.375rem rgba(0, 0, 0, 0.16);
+  color: var(--bs-body-color);
+
+  &::placeholder {
+    color: var(--bs-secondary-color);
+    opacity: 1;
+  }
+}
+
 // PageFind Styles
 
 #search .pagefind-ui form {
@@ -21,4 +35,3 @@
     margin-left: 1rem;
   }
 }
-

--- a/assets/scss/_k8s_search.scss
+++ b/assets/scss/_k8s_search.scss
@@ -10,6 +10,8 @@
   border-color: rgba(255, 255, 255, 0.2);
 }
 
+/* This is a workaround until we formally add support for announcements with
+   light backgrounds. */
 header:has(#announcement.display-announcement) .td-navbar:not(.navbar-bg-onscroll) .td-search .td-search__input {
   background-color: var(--bs-body-bg);
   border-color: var(--bs-secondary-color);


### PR DESCRIPTION
Fixes #56074

## What this changes
- add a targeted navbar search style when an announcement banner is active and the navbar has not switched to its scrolled state yet
- give the top-nav search input a visible background, border, shadow, and placeholder color so it stays readable over light announcement banners
- leave the existing scrolled navbar styling unchanged

## Testing
- ran `git diff --check`
- ran `npm ci`
- ran `make container-serve segments=en`
- verified the search input is visible on the home page and docs pages at widths above 1500px when the light announcement banner is present
- verified the top-nav search remains hidden below 1500px
- verified the scrolled navbar state still uses the existing styling

## AI use disclosure
- AI assistance was used to help draft and implement this change.
- The final diff, wording, and local verification steps were reviewed before opening the PR.