### PR TITLE
Improve german install-kubectl documentation

### DIFF
--- a/content/de/docs/tasks/tools/install-kubectl.md
+++ b/content/de/docs/tasks/tools/install-kubectl.md
@@ -112,7 +112,7 @@ Wenn Sie mit Windows arbeiten und den [Powershell Gallery](https://www.powershel
 
     {{< note >}}Wenn Sie keine `DownloadLocation` angeben, wird `kubectl` im temporären Verzeichnis des Benutzers installiert.{{< /note >}}
 
-    Das Installationsprogramm erstellt `$HOME/.kube` erstellt eine Konfigurationsdatei.
+    Das Installationsprogramm erstellt `$HOME/.kube` und erzeugt eine Konfigurationsdatei.
 
 2. Testen Sie, ob die installierte Version ausreichend aktuell ist:
 

--- a/content/de/docs/tasks/tools/install-kubectl.md
+++ b/content/de/docs/tasks/tools/install-kubectl.md
@@ -112,7 +112,7 @@ Wenn Sie mit Windows arbeiten und den [Powershell Gallery](https://www.powershel
 
     {{< note >}}Wenn Sie keine `DownloadLocation` angeben, wird `kubectl` im temporären Verzeichnis des Benutzers installiert.{{< /note >}}
 
-    Das Installationsprogramm erstellt `$HOME/.kube` und weist es an, eine Konfigurationsdatei zu erstellen
+    Das Installationsprogramm erstellt `$HOME/.kube` erstellt eine Konfigurationsdatei.
 
 2. Testen Sie, ob die installierte Version ausreichend aktuell ist:
 
@@ -218,7 +218,7 @@ Sie können kubectl als Teil des Google Cloud SDK installieren.
 {{% /tab %}}
 {{% tab name="Linux" %}}
 
-1. Laden Sie die neueste Version mit dem Befehl herunter:
+1. Laden Sie die neueste Version mit folgendem Befehl herunter:
 
     ```
     curl -LO https://dl.k8s.io/release/$(curl -LS https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
@@ -247,7 +247,7 @@ Sie können kubectl als Teil des Google Cloud SDK installieren.
 {{% tab name="Windows" %}}
 1. Laden Sie das aktuellste Release {{< skew currentPatchVersion >}} von [diesem link](https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe) herunter.
 
-    Oder, sofern Sie `curl` installiert haven, verwenden Sie den folgenden Befehl:
+    Oder, sofern Sie `curl` installiert haben, verwenden Sie den folgenden Befehl:
 
     ```
     curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/windows/amd64/kubectl.exe
@@ -318,7 +318,7 @@ source /usr/share/bash-completion/bash_completion
 
 Laden Sie Ihre Shell erneut und vergewissern Sie sich, dass bash-completion korrekt installiert ist, indem Sie folgendes eingeben: `type _init_completion`.
 
-### Aktivieren der automatische Vervollständigung von kubectl
+### Aktivieren der automatischen Vervollständigung von kubectl
 
 Sie müssen nun sicherstellen, dass das kubectl-Abschlussskript in allen Ihren Shell-Sitzungen verwendet wird. Es gibt zwei Möglichkeiten, dies zu tun:
 


### PR DESCRIPTION
### Description

Fixes multiple typos in the `install-kubectl` documentation. Additionally improves grammar in some sentences. Just minor changes.