### PR TITLE
Documentaion update deployment invalid syntax

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -646,7 +646,7 @@ in your cluster, you can set up an autoscaler for your Deployment and choose the
 Pods you want to run based on the CPU utilization of your existing Pods.
 
 ```shell
-kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80%
+kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu=80%
 ```
 The output is similar to this:
 ```


### PR DESCRIPTION
this was the error that i have face durring studing  there is syntax issue for 
and there is simple fix removing -present

kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80%

error: invalid argument "80%" for "--cpu-percent" flag: strconv.ParseInt: parsing "80%": invalid syntax See 'kubectl autoscale --help' for usage.

to

kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu=80%

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #