### PR TITLE
KEP-5311 - Promote RelaxedServiceNameValidation to stable

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/RelaxedServiceNameValidation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/RelaxedServiceNameValidation.md
@@ -13,6 +13,11 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.36"
+    toVersion: "1.36"
+  - stage: stable
+    locked: true
+    defaultValue: true
+    fromVersion: "1.37"
 
 ---
 


### PR DESCRIPTION
### Description

KEP-5311 - Promote RelaxedServiceNameValidation to stable

### Issue

Related to https://github.com/kubernetes/kubernetes/pull/134493

/assign danwinship 