### PR TITLE
Fixing typos and clarity in the TLS task sections in docs

### DIFF
--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -23,7 +23,7 @@ This overview covers `kubectl` syntax, describes the command operations, and pro
 For details about each command, including all the supported flags and subcommands, see the
 [kubectl](/docs/reference/kubectl/generated/kubectl/) reference documentation.
 
-For a overview, see [The kubectl command-line tool](/docs/concepts/overview/kubectl/).
+For an overview, see [The kubectl command-line tool](/docs/concepts/overview/kubectl/).
 For installation instructions, see [Installing kubectl](/docs/tasks/tools/#kubectl);
 for a quick guide, see the [cheat sheet](/docs/reference/kubectl/quick-reference/).
 If you're used to using the `docker` command-line tool,

--- a/content/en/docs/tasks/tls/certificate-issue-client-csr.md
+++ b/content/en/docs/tasks/tls/certificate-issue-client-csr.md
@@ -1,5 +1,5 @@
 ---
-title: Issue a Certificate for a Kubernetes API Client Using A CertificateSigningRequest
+title: Issue a Certificate for a Kubernetes API Client Using a CertificateSigningRequest
 api_metadata:
 - apiVersion: "certificates.k8s.io/v1"
   kind: "CertificateSigningRequest"
@@ -22,7 +22,7 @@ authenticate and invoke an API. First, this user must have an [X.509](https://ww
 issued by an authority that your Kubernetes cluster trusts. The client must then present that certificate to the Kubernetes API.
 
 You use a [CertificateSigningRequest](/docs/reference/access-authn-authz/certificate-signing-requests/)
-as part of this process, and either you or some other principal must approve the request.
+as part of this process, either you or some other principal must approve the request.
 
 
 You will create a private key, and then get a certificate issued, and finally configure
@@ -41,7 +41,7 @@ If you have alternative or additional security mechanisms around authorization, 
 
 ## Create private key
 
-In this step, you create a private key. You need to keep this document secret; anyone who has it can impersonate the user.
+In this step, you create a private key. You need to keep this private key secret; anyone who has it can impersonate the user.
 
 ```shell
 # Create a private key
@@ -55,7 +55,7 @@ This is not the same as the similarly-named CertificateSigningRequest API; the f
 CertificateSigningRequest.
 {{< /note >}}
 
-It is important to set CN and O attribute of the CSR. CN is the name of the user and O is the group that this user will belong to.
+It is important to set the CN and O attributes of the CSR. CN is the name of the user, and O is the group that this user will belong to.
 You can refer to [RBAC](/docs/reference/access-authn-authz/rbac/) for standard groups.
 
 ```shell
@@ -72,7 +72,7 @@ cat myuser.csr | base64 | tr -d "\n"
 ```
 
 Create a [CertificateSigningRequest](/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1/)
-and submit it to a Kubernetes Cluster via kubectl. Below is a snippet of shell that you can use to generate the
+and submit it to a Kubernetes cluster via kubectl. Below is a snippet of shell that you can use to generate the
 CertificateSigningRequest.
 
 ```shell
@@ -104,7 +104,7 @@ kubectl apply -f myuser.yaml --server-side
 
 Some points to note:
 
-- `usages` has to be `client auth`. For other Kubernetes signers, the permitted key usages may differ. See [Kubernetes signers](/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers) for the supported key usages for each signer.
+- `usages` has to be `client auth`
 - `expirationSeconds` could be made longer (i.e. `864000` for ten days) or shorter (i.e. `3600` for one hour).
   You cannot request a duration shorter than 10 minutes.
 - `request` is the base64 encoded value of the CSR file content.
@@ -127,7 +127,7 @@ kubectl certificate approve myuser
 
 ## Get the certificate
 
-Retrieve the certificate from the CSR, to check it looks OK.
+Retrieve the certificate from the CSR to check that it looks OK.
 
 ```shell
 kubectl get csr/myuser -o yaml
@@ -143,7 +143,7 @@ kubectl get csr myuser -o jsonpath='{.status.certificate}'| base64 -d > myuser.c
 
 ## Configure the certificate into kubeconfig
 
-The next step is to add this user into the kubeconfig file.
+The next step is to add this user to the kubeconfig file.
 
 First, you need to add new credentials:
 
@@ -173,8 +173,7 @@ If you don't use Kubernetes RBAC, skip this step and make the appropriate change
 your cluster actually uses.
 {{< /note >}}
 
-With the certificate created it is time to define the Role and RoleBinding for
-this user to access Kubernetes cluster resources.
+With the certificate created, it is time to define the Role and RoleBinding for this user to access Kubernetes cluster resources.
 
 This is a sample command to create a Role for this new user:
 

--- a/content/en/docs/tasks/tls/certificate-rotation.md
+++ b/content/en/docs/tasks/tls/certificate-rotation.md
@@ -23,11 +23,11 @@ This page shows how to enable and configure certificate rotation for the kubelet
 
 ## Overview
 
-The kubelet uses certificates for authenticating to the Kubernetes API.  By
-default, these certificates are issued with one year expiration so that they do
+The kubelet uses certificates to authenticate with the Kubernetes API.  By
+default, these certificates are issued with a one-year expiration so that they do
 not need to be renewed too frequently.
 
-Kubernetes contains [kubelet certificate
+Kubernetes contains the [kubelet certificate
 rotation](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/),
 that will automatically generate a new key and request a new certificate from
 the Kubernetes API as the current certificate approaches expiration. Once the
@@ -56,9 +56,9 @@ status of certificate signing requests using:
 kubectl get csr
 ```
 
-Initially a certificate signing request from the kubelet on a node will have a
-status of `Pending`. If the certificate signing requests meets specific
-criteria, it will be auto approved by the controller manager, then it will have
+Initially, a certificate signing request from the kubelet on a node will have a
+status of `Pending`. If the certificate signing request meets specific
+criteria, it will be auto-approved by the controller manager, and then it will have
 a status of `Approved`. Next, the controller manager will sign a certificate,
 issued for the duration specified by the 
 `--cluster-signing-duration` parameter, and the signed certificate

--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -10,10 +10,10 @@ reviewers:
 <!-- overview -->
 
 Kubernetes provides a `certificates.k8s.io` API, which lets you provision TLS
-certificates signed by a Certificate Authority (CA) that you control. These CA
+certificates signed by a Certificate Authority (CA) that you control. These CAs
 and certificates can be used by your workloads to establish trust.
 
-`certificates.k8s.io` API uses a protocol that is similar to the [ACME
+The `certificates.k8s.io` API uses a protocol that is similar to the [ACME
 draft](https://github.com/ietf-wg-acme/acme/).
 
 {{< note >}}
@@ -45,7 +45,7 @@ install it via your operating system's software sources, or fetch it from
 Trusting the [custom CA](#configuring-your-cluster-to-provide-signing) from an application running as a pod usually requires
 some extra application configuration. You will need to add the CA certificate
 bundle to the list of CA certificates that the TLS client or server trusts. For
-example, you would do this with a golang TLS config by parsing the certificate
+example, you would do this with a Golang TLS config by parsing the certificate
 chain and adding the parsed certificates to the `RootCAs` field in the
 [`tls.Config`](https://pkg.go.dev/crypto/tls#Config) struct.
 
@@ -68,7 +68,8 @@ The following section demonstrates how to create a TLS certificate for a
 Kubernetes service accessed through DNS.
 
 {{< note >}}
-This tutorial uses CFSSL: Cloudflare's PKI and TLS toolkit [click here](https://blog.cloudflare.com/introducing-cfssl/) to know more.
+This tutorial uses CFSSL: Cloudflare's PKI and TLS toolkit See the Cloudflare blog
+article [Introducing CFSSL - CloudFlare's PKI toolkit](https://blog.cloudflare.com/introducing-cfssl/) for more information.
 {{< /note >}}
 
 ## Create a certificate signing request
@@ -97,7 +98,7 @@ EOF
 Where `192.0.2.24` is the service's cluster IP,
 `my-svc.my-namespace.svc.cluster.local` is the service's DNS name,
 `10.0.34.2` is the pod's IP and `my-pod.my-namespace.pod.cluster.local`
-is the pod's DNS name. You should see the output similar to:
+is the pod's DNS name. You should see output similar to:
 
 ```
 2022/02/01 11:45:32 [INFO] generate received request
@@ -113,7 +114,7 @@ is still to be created.
 
 ## Create a CertificateSigningRequest object to send to the Kubernetes API
 
-Generate a CSR manifest (in YAML), and send it to the API server. You can do that by
+Generate a CSR manifest (in YAML) and send it to the API server. You can do that by
 running the following command:
 
 ```shell
@@ -140,7 +141,7 @@ A specific `signerName` must be requested.
 View documentation for [supported signer names](/docs/reference/access-authn-authz/certificate-signing-requests/#signers)
 for more information.
 
-The CSR should now be visible from the API in a Pending state. You can see
+The CSR should now be visible in the API in a Pending state. You can see
 it by running:
 
 ```shell
@@ -169,7 +170,7 @@ Events: <none>
 ## Get the CertificateSigningRequest approved {#get-the-certificate-signing-request-approved}
 
 Approving the [certificate signing request](/docs/reference/access-authn-authz/certificate-signing-requests/)
-is either done by an automated approval process or on a one off basis by a cluster
+is either done by an automated approval process or on a one-off basis by a cluster
 administrator. If you're authorized to approve a certificate request, you can do that
 manually using `kubectl`; for example:
 
@@ -308,7 +309,7 @@ kubectl create secret tls server --cert server.crt --key server-key.pem
 secret/server created
 ```
 
-Finally, you can populate `ca.pem` into a {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}}
+Finally, you can store `ca.pem` in a {{< glossary_tooltip text="ConfigMap" term_id="configmap" >}}
 and use it as the trust root to verify the serving certificate:
 
 ```shell
@@ -336,7 +337,7 @@ that fall on the approver **and** the repercussions of issuing a specific certif
 before you grant the `approve` permission.
 {{< /caution >}}
 
-Whether a machine or a human using kubectl as above, the role of the _approver_ is
+Whether the approver is a machine or a human using kubectl as above, the role of the _approver_ is
 to verify that the CSR satisfies two requirements:
 
 1. The subject of the CSR controls the private key used to sign the CSR. This

--- a/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
+++ b/content/en/docs/tasks/tls/manual-rotation-of-ca-certificates.md
@@ -24,8 +24,8 @@ This page shows how to manually rotate the certificate authority (CA) certificat
 {{< caution >}}
 Make sure to back up your certificate directory along with configuration files and any other necessary files.
 
-This approach assumes operation of the Kubernetes control plane in a HA configuration with multiple API servers.
-Graceful termination of the API server is also assumed so clients can cleanly disconnect from one API server and
+This approach assumes operation of the Kubernetes control plane in an HA configuration with multiple API servers.
+Graceful termination of the API server is also assumed, so clients can cleanly disconnect from one API server and
 reconnect to another.
 
 Configurations with a single API server will experience unavailability while the API server is being restarted.
@@ -42,10 +42,10 @@ Configurations with a single API server will experience unavailability while the
 
    {{< note >}}
    The files specified by the kube-controller-manager flags `--client-ca-file` and `--cluster-signing-cert-file`
-   cannot be CA bundles. If these flags and `--root-ca-file` point to the same `ca.crt` file which is now a
-   bundle (includes both old and new CA) you will face an error. To workaround this problem you can copy the new CA
+   cannot be CA bundles. If these flags and `--root-ca-file` point to the same `ca.crt` file, which is now a
+   bundle (includes both old and new CA), you will face an error. To workaround this problem, you can copy the new CA
    to a separate file and make the flags `--client-ca-file` and `--cluster-signing-cert-file` point to the copy.
-   Once `ca.crt` is no longer a bundle you can restore the problem flags to point to `ca.crt` and delete the copy.
+   Once `ca.crt` is no longer a bundle, you can restore the problem flags to point to `ca.crt` and delete the copy.
 
    [Issue 1350](https://github.com/kubernetes/kubeadm/issues/1350) for kubeadm tracks an bug with the
    kube-controller-manager being unable to accept a CA bundle.
@@ -53,18 +53,18 @@ Configurations with a single API server will experience unavailability while the
 
 1. Wait for the controller manager to update `ca.crt` in the service account Secrets to include both old and new CA certificates.
 
-    If any Pods are started before new CA is used by API servers, the new Pods get this update and will trust both
+    If any Pods are started before the new CA is used by API servers, the new Pods get this update and will trust both
     old and new CAs.
 
 1. Restart all pods using in-cluster configurations (for example: kube-proxy, CoreDNS, etc) so they can use the
    updated certificate authority data from Secrets that link to ServiceAccounts.
 
-   * Make sure CoreDNS, kube-proxy and other Pods using in-cluster configurations are working as expected.
+   * Make sure CoreDNS, kube-proxy, and other Pods using in-cluster configurations are working as expected.
 
-1. Append the both old and new CA to the file against `--client-ca-file` and `--kubelet-certificate-authority`
+1. Append both old and new CA to the file against `--client-ca-file` and `--kubelet-certificate-authority`
    flag in the `kube-apiserver` configuration.
 
-1. Append the both old and new CA to the file against `--client-ca-file` flag in the `kube-scheduler` configuration.
+1. Append both old and new CA to the file against the `--client-ca-file` flag in the `kube-scheduler` configuration.
 
 1. Update certificates for user accounts by replacing the content of `client-certificate-data` and `client-key-data`
    respectively.
@@ -88,20 +88,20 @@ Configurations with a single API server will experience unavailability while the
       [aggregated API servers](/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) or
       webhook handlers to trust the new CA certificates.
 
-   1. Restart the kubelet by update the file against `clientCAFile` in kubelet configuration and
+   1. Restart the kubelet by updating the file against `clientCAFile` in the kubelet configuration and
       `certificate-authority-data` in `kubelet.conf` to use both the old and new CA on all nodes.
 
       If your kubelet is not using client certificate rotation, update `client-certificate-data` and
-      `client-key-data` in `kubelet.conf` on all nodes along with the kubelet client certificate file
+      `client-key-data` in `kubelet.conf` on all nodes, along with the kubelet client certificate file
       usually found in `/var/lib/kubelet/pki`.
 
-   1. Restart API servers with the certificates (`apiserver.crt`, `apiserver-kubelet-client.crt` and
-      `front-proxy-client.crt`) signed by new CA.
+   1. Restart API servers with the certificates (`apiserver.crt`, `apiserver-kubelet-client.crt`, and
+      `front-proxy-client.crt`), signed by the new CA.
       You can use the existing private keys or new private keys.
-      If you changed the private keys then update these in the Kubernetes certificates directory as well.
+      If you changed the private keys, then update these in the Kubernetes certificates directory as well.
 
-      Since the Pods in your cluster trust both old and new CAs, there will be a momentarily disconnection
-      after which pods' Kubernetes clients reconnect to the new API server.
+      Since the Pods in your cluster trust both old and new CAs, there will be a momentary disconnection
+      after which, pods' Kubernetes clients reconnect to the new API server.
       The new API server uses a certificate signed by the new CA.
 
       * Restart the {{< glossary_tooltip term_id="kube-scheduler" text="kube-scheduler" >}} to use and
@@ -132,7 +132,7 @@ Configurations with a single API server will experience unavailability while the
       see [configure pod disruption budget](/docs/tasks/run-application/configure-pdb/).
       {{< /note >}}
 
-        Depending on how you use StatefulSets you may also need to perform similar rolling replacement.
+        Depending on how you use StatefulSets, you may also need to perform a similar rolling replacement.
 
 1. If your cluster is using bootstrap tokens to join nodes, update the ConfigMap `cluster-info` in the `kube-public`
    namespace with new CA.
@@ -160,10 +160,10 @@ Configurations with a single API server will experience unavailability while the
       * All pods using an in-cluster kubeconfig will eventually need to be restarted to pick up the new Secret,
         so that no Pods are relying on the old cluster CA.
 
-   1. Restart the control plane components by removing the old CA from the kubeconfig files and the files against
+   1. Restart the control plane components by removing the old CA from the kubeconfig files and the files against it
       `--client-ca-file`, `--root-ca-file` flags resp.
 
-   1. On each node, restart the kubelet by removing the old CA from file against the `clientCAFile` flag
+   1. On each node, restart the kubelet by removing the old CA from the file against the `clientCAFile` flag
       and from the kubelet kubeconfig file. You should carry this out as a rolling update.
 
       If your cluster lets you make this change, you can also roll it out by replacing nodes rather than


### PR DESCRIPTION
**Improve clarity and fix grammar issues in TLS documentation**

This PR improves the clarity and fixes grammar issues across the TLS task documentation pages, making the content more precise and easier to understand for users implementing TLS in Kubernetes, and these are the files I modified :
- content/en/docs/reference/kubectl/_index.md
- content/en/docs/tasks/tls/certificate-issue-client-csr.md
- content/en/docs/tasks/tls/certificate-rotation.md
- content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
- content/en/docs/tasks/tls/certificate-rotation.md