### PR TITLE
Fix grammar and invalid nodeAffinity example in Schedule GPUs

### DIFF
--- a/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
+++ b/content/en/docs/tasks/manage-gpus/scheduling-gpus.md
@@ -88,7 +88,7 @@ by deploying Kubernetes [Node Feature Discovery](https://github.com/kubernetes-s
 NFD detects the hardware features that are available on each node in a Kubernetes cluster.
 Typically, NFD is configured to advertise those features as node labels, but NFD can also add extended resources, annotations, and node taints.
 NFD is compatible with all [supported versions](/releases/version-skew-policy/#supported-versions) of Kubernetes.
-By default NFD create the [feature labels](https://kubernetes-sigs.github.io/node-feature-discovery/master/usage/features.html) for the detected features.
+By default, NFD creates the [feature labels](https://kubernetes-sigs.github.io/node-feature-discovery/master/usage/features.html) for the detected features.
 Administrators can leverage NFD to also taint nodes with specific features, so that only pods that request those features can be scheduled on those nodes.
 
 You also need a plugin for NFD that adds appropriate labels to your nodes; these might be generic
@@ -113,6 +113,7 @@ spec:
             operator: Gt # (greater than)
             values: ["40535"]
           - key: "feature.node.kubernetes.io/pci-10.present" # NFD Feature label
+            operator: In
             values: ["true"] # (optional) only schedule on nodes with PCI device 10
   containers:
     - name: example-vector-add


### PR DESCRIPTION
### Description

This PR makes two small corrections to the Schedule GPUs task page
(`content/en/docs/tasks/manage-gpus/scheduling-gpus.md`):

1. Grammar: "By default NFD create" → "By default, NFD creates" (subject-verb agreement).
2. The Node Feature Discovery `nodeAffinity` example was missing the required `operator` field on one match expression. `operator` is required on a `NodeSelectorRequirement`, so the manifest as written would fail API validation. Added `operator: In`, consistent with the `values: ["true"]` already present.

### Issue

No open issue — these are minor, self-evident documentation fixes.