### PR TITLE
Fix kubectl command syntax for autoscaling

### DIFF
--- a/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/en/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -100,7 +100,7 @@ on the algorithm.
 Create the HorizontalPodAutoscaler:
 
 ```shell
-kubectl autoscale deployment php-apache --cpu=50% --min=1 --max=10
+kubectl autoscale deployment php-apache --cpu-percent=50 --min=1 --max=10
 ```
 
 ```


### PR DESCRIPTION
syntax is altered

error: unknown flag: --cpu

help file states correct option: 

 --cpu-percent=-1:
        The target average CPU utilization (represented as a percent of requested CPU) over all the pods. If it's not
        specified or negative, a default autoscaling policy will be used.