### PR TITLE
[KEP- 5598] Update docs of Opportunistic Batching with Rescoring 

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
+++ b/content/en/docs/concepts/scheduling-eviction/scheduler-perf-tuning.md
@@ -163,10 +163,14 @@ After going over all the Nodes, it goes back to Node 1.
 
 {{< feature-state feature_gate_name="OpportunisticBatching" >}}
 
-When scheduling large workloads, pod definitions are typically identical and require the scheduler
+When scheduling large workloads, Pods often have equivalent scheduling constraints and require the scheduler
 to perform the same operations over and over again. The [Opportunistic Batching](/docs/reference/command-line-tools-reference/feature-gates/#OpportunisticBatching)
 feature allows the scheduler to reuse the filtering and scoring results between scheduling cycles
 which greatly speeds up the scheduling process.
+
+With rescoring, the scheduler can continue batching in that situation. When the next Pod can still fit on
+the previously chosen Node, the scheduler updates that Node's score and puts it back into the cached candidate list.
+If rescoring does not succeed, the scheduler falls back to the existing behavior and flushes the cache.
 
 Basically, this feature works like:
 1. The scheduler schedules pod-1 and caches the scheduling result.
@@ -180,7 +184,6 @@ We apply this batching scheduling to specific pods that:
 1. Don't have topology spread constraints
 1. Don't have DRA (i.e., don't have any Resource Claims)
 1. Don't request extended resources that are backed by DRA
-1. Scheduled exclusively on nodes (i.e., placing more than one pod on one node invalidates the cache)
 
 Also, to enable this feature, the scheduler configuration needs to:
 1. Disable [default topology spread](/docs/concepts/scheduling-eviction/topology-spread-constraints/#internal-default-constraints) (set empty)


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
KEP-[#5598](https://github.com/kubernetes/enhancements/issues/5598)
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
https://github.com/kubernetes/enhancements/pull/6039

K/K issue:
[ [Scheduling] OpportunisticBatching: redundant synchronous RunFilterPlugins call in batchStateCompatible for low-resource pods #137707](https://github.com/kubernetes/kubernetes/issues/137707)

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->