### PR TITLE
fix dark-mode note callout heading color

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -111,7 +111,7 @@ div.api-reference-header-note.empty {
   border-color: #428bca;
 
   h4, h4.alert-heading {
-    color: #000;
+    color: var(--bs-body-color);
     display: block;
     float: initial;
     font-size: 1rem;


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
The `{{< note >}}` shortcode renders as `.alert.alert-info`, but its heading text was hard-coded to `color: #000` in `assets/scss/_documentation.scss`. This caused note headings to be unreadable in dark mode.

Update the `.alert.alert-info h4` rule to use `var(--bs-body-color)` so note headings inherit the active theme text color.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

- https://github.com/kubernetes/website/issues/56198