### PR TITLE
[zh-cn]sync DeclarativeValidationTakeover InPlacePodLevelResourcesVerticalScaling

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
@@ -9,7 +9,18 @@ stages:
   - stage: beta
     defaultValue: false
     fromVersion: "1.33"
+    toVersion: "1.35"
+  - stage: deprecated
+    defaultValue: false
+    fromVersion: "1.36"
 ---
+
+<!--
+Deprecated: in favor of [DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/).
+-->
+已弃用：由
+[DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/)
+取代。
 
 <!--
 When enabled, along with the [DeclarativeValidation](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation/)

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/InPlacePodLevelResourcesVerticalScaling.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/InPlacePodLevelResourcesVerticalScaling.md
@@ -9,6 +9,10 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.35"
+    toVersion: "1.35"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.36"
 ---
 
 <!--


### PR DESCRIPTION
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/InPlacePodLevelResourcesVerticalScaling.md