### PR TITLE
Fix SupplementalGroupsPolicy feature gate link (zh-cn)

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/SupplementalGroupsPolicy.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/SupplementalGroupsPolicy.md
@@ -17,7 +17,7 @@ stages:
 
 <!--
 Enables support for fine-grained SupplementalGroups control.
-For more details, see [Configure fine-grained SupplementalGroups control for a Pod](/content/en/docs/tasks/configure-pod-container/security-context/#supplementalgroupspolicy).
+For more details, see [Configure fine-grained SupplementalGroups control for a Pod](/docs/tasks/configure-pod-container/security-context/#supplementalgroupspolicy).
 -->
 启用对细粒度 SupplementalGroups 控制的支持。
 有关细节请参见[为 Pod 配置细粒度 SupplementalGroups 控制](/zh-cn/docs/tasks/configure-pod-container/security-context/#supplementalgroupspolicy)。


### PR DESCRIPTION
Fixes the broken link in the commented English source of the Chinese `SupplementalGroupsPolicy` feature gate page. The link pointed to `/content/en/docs/...`, which 404s; it should be `/docs/...`.

Split out from #56005 per review feedback to keep the English change and the Chinese localization in separate PRs.

/language zh