### PR TITLE
fix: update SIG Release versioning link

### DIFF
--- a/content/en/docs/reference/using-api/_index.md
+++ b/content/en/docs/reference/using-api/_index.md
@@ -39,7 +39,7 @@ The JSON and Protobuf serialization schemas follow the same guidelines for
 schema changes. The following descriptions cover both formats.
 
 The API versioning and software versioning are indirectly related.
-The [API and release versioning proposal](https://git.k8s.io/sig-release/release-engineering/versioning.md)
+The [API and release versioning proposal](https://git.k8s.io/sig-release/release-engineering/reference/versioning.md#kubernetes-release-versioning)
 describes the relationship between API versioning and software versioning.
 
 Different API versions indicate different levels of stability and support. You

--- a/content/en/releases/release.md
+++ b/content/en/releases/release.md
@@ -125,7 +125,7 @@ The general labeling process should be consistent across artifact types.
   referring to a release MAJOR.MINOR `vX.Y` version.
 
   See also
-  [release versioning](https://git.k8s.io/sig-release/release-engineering/versioning.md).
+  [release versioning](https://git.k8s.io/sig-release/release-engineering/reference/versioning.md#kubernetes-release-versioning).
 
 - *release branch*: Git branch `release-X.Y` created for the `vX.Y` milestone.
 


### PR DESCRIPTION
### Description

This PR updates outdated SIG Release versioning links in the English documentation.

### Changes

* Replaced deprecated SIG Release versioning URLs with the current reference URL.
* Updated affected English documentation pages referencing the outdated link.

Localized documentation updates will be submitted in separate pull requests.

### Issue

Closes #56068 