### PR TITLE
Include mirror article attribution in blog layout

### DIFF
--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -19,6 +19,9 @@ other = """<p>This page is automatically generated.</p><p>If you plan to report 
 [banner_acknowledgement]
 other = "Hide this notice"
 
+[blog_mirrored_originally_published_at]
+other = 'This is a mirror of the <a href="{{ .canonicalUrl }}">original article</a>.'
+
 [blog_post_show_more]
 other = "Show More Posts..."
 

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -13,6 +13,15 @@
 		{{ end -}}
 	</header>
 	{{ .Content }}
+
+	{{ with .Params.canonicalUrl }}
+		<p class="fst-italic text-muted">
+			Originally published at <a href="{{ . }}">{{ . }}</a>.
+		</p>
+	{{ end }}
+
+
+
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />
 		{{- partial "disqus-comment.html" . -}}

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -16,7 +16,7 @@
 
 	{{ with .Params.canonicalUrl }}
 		<p class="fst-italic text-muted">
-			Originally published at <a href="{{ . }}">{{ . }}</a>.
+			{{ T "blog_mirrored_originally_published_at" (dict "canonicalUrl" .) | safeHTML }}
 		</p>
 	{{ end }}
 


### PR DESCRIPTION
**Adds a one-line attribution at the bottom of mirrored articles. When canonicalUrl is set in the article's front matter, a line renders at the foot of the article linking back to the original source.**

- Added `blog_mirrored_originally_published_at` key to `en.toml` 

- Updated the blog layout to use Hugo's `T` function to render the notice using the translation key instead of a hardcoded string

<img width="1464" height="907" alt="Screenshot 2026-06-25 at 3 12 51 PM" src="https://github.com/user-attachments/assets/e7854486-17d3-4c29-8dcd-397192713789" />


**Next steps :** To add the key in other languages files in i18n folder 
