### PR TITLE
docs: document annotation value size limit and character set

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/annotations.md
+++ b/content/en/docs/concepts/overview/working-with-objects/annotations.md
@@ -76,7 +76,9 @@ If the prefix is omitted, the annotation Key is presumed to be private to the us
 The `kubernetes.io/` and `k8s.io/` prefixes are reserved for Kubernetes core components.
 
 Valid annotation values have no character set restrictions — unlike label values, annotation values may contain any string, including special characters, whitespace, and structured data such as JSON or YAML.
-However, the total size of all annotations on a single object (keys and values combined) must not exceed 256 kB.
+If you plan to store binary data (such as [CBOR](https://cbor.io/)),
+the Kubernetes project recommends that you base64 encode it.
+However, the total size of **all** annotations on a single object (keys and values combined) must not exceed 256 KiB.
 
 For example, here's a manifest for a Pod that has the annotation `imageregistry: https://hub.docker.com/` :
 

--- a/content/en/docs/concepts/overview/working-with-objects/annotations.md
+++ b/content/en/docs/concepts/overview/working-with-objects/annotations.md
@@ -75,6 +75,9 @@ If the prefix is omitted, the annotation Key is presumed to be private to the us
 
 The `kubernetes.io/` and `k8s.io/` prefixes are reserved for Kubernetes core components.
 
+Valid annotation values have no character set restrictions — unlike label values, annotation values may contain any string, including special characters, whitespace, and structured data such as JSON or YAML.
+However, the total size of all annotations on a single object (keys and values combined) must not exceed 256 kB.
+
 For example, here's a manifest for a Pod that has the annotation `imageregistry: https://hub.docker.com/` :
 
 ```yaml


### PR DESCRIPTION
Fixes #56242
What this PR does
Adds a note about annotation value constraints to the "Syntax and character set" section of the annotations documentation page, similar to how the labels page documents its value constraints.
Why
The annotations page clearly documented the key format (prefix, name, length, character set) but said nothing about values — leaving users to wonder if there are character restrictions or size limits. This is a common source of confusion since labels have strict value constraints, but annotations intentionally do not.
Changes
Added two sentences to the "Syntax and character set" section clarifying that:

Annotation values have no character set restrictions (unlike label values) and can contain any string including special characters, whitespace, or structured data like JSON/YAML
The total size of all annotations on a single object must not exceed 256 kB

Preview
[k8s.io/docs/concepts/overview/working-with-objects/annotations/](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)