### PR TITLE
[zh-cn]Configurable Scaling Delay with Pod Resource Exposure

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/pods/downward-api.md
+++ b/content/zh-cn/docs/concepts/workloads/pods/downward-api.md
@@ -278,6 +278,46 @@ for more details.
 : 容器的临时存储的请求值
 
 <!--
+`resource: assigned.cpuset`
+: A container's CPU desired assignments
+-->
+`resource: assigned.cpuset`
+: 容器期望分配的 CPU 
+
+{{< note >}}
+{{< feature-state for_k8s_version="v1.37" feature_gate_name="DownwardAPIAssignedResources" state="alpha" >}}
+<!--
+`resource: assigned.cpuset`
+: A container's CPU **desired** assignments (Linux cpuset format, e.g., `0-3,7,12-15`).
+  Returns empty string when no exclusive CPUs are assigned.
+  Available since Kubernetes 1.37.
+  When combined with [scale-delay-time](/docs/tasks/administer-cluster/cpu-management-policies/#cpu-policy-static-options),
+  this field allows workloads to prepare for CPU removal.
+
+  This field is controlled by the `DownwardAPIAssignedResources` feature gate:
+  - When the feature gate is **disabled**, the `assigned.cpuset` field in pod specs is silently ignored and discarded during validation.
+  - When the feature gate is **enabled**, the `assigned.cpuset` field is validated and accepted in pod specs.
+
+  To avoid errors during Kubernetes upgrades, this feature gate is disabled by default.
+  Enable this feature gate only after all kubelets in the cluster are upgraded to v1.37 or later.
+  Otherwise, Pod creation will fail because kubelets earlier than v1.37 do not recognize the `assigned.cpuset` field.
+-->
+容器**期望** 分配的 CPU （Linux cpuset 格式，例如：`0-3,7,12-15`）。
+当未分配独占 CPU 时返回空字符串。
+自 Kubernetes 1.37 起可用。
+与 [scale-delay-time](/zh-cn/docs/tasks/administer-cluster/cpu-management-policies/#cpu-policy-static-options) 结合使用时，
+该字段允许工作负载为 CPU 移除做准备。
+
+该字段受 `DownwardAPIAssignedResources` 特性门控控制：
+- 当特性门控**禁用**时，Pod spec 中的 `assigned.cpuset` 字段在验证期间会被静默忽略和丢弃。
+- 当特性门控**启用**时，`assigned.cpuset` 字段会在 Pod spec 中被验证并接受。
+
+为避免 Kubernetes 升级期间出现错误，此特性门控默认禁用。
+仅当集群中所有 kubelet 都升级到 v1.37 或更高版本后，才能启用此特性门控。
+否则，Pod 创建将失败，因为 v1.37 之前的 kubelet 不识别 `assigned.cpuset` 字段。
+{{< /note >}}
+
+<!--
 #### Fallback information for resource limits
 
 If CPU and memory limits are not specified for a container, and you use the

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DownwardAPIAssignedResources.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DownwardAPIAssignedResources.md
@@ -1,0 +1,17 @@
+---
+title: DownwardAPIAssignedResources
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.37"
+---
+
+<!--
+Use `DownwardAPIAssignedResources` to control if kube-apiserver allows for mounting new fields in downwardAPI volume for container's CPU desired assignments.
+-->
+使用 `DownwardAPIAssignedResources` 来控制 kube-apiserver 是否允许在 downwardAPI 卷中挂载新字段，用于容器的 CPU 期望分配。

--- a/content/zh-cn/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -290,6 +290,7 @@ The following policy options exist for the static `CPUManager` policy:
 * `distribute-cpus-across-cores` (Alpha，默认隐藏) (1.31 或更高版本)
 * `strict-cpu-reservation` (GA，默认可见) (1.35 或更高版本)
 * `prefer-align-cpus-by-uncorecache` (GA, 默认可见) (1.36 或更高版本)
+* `scale-delay-time` (Alpha, 默认隐藏) (1.37 或更高版本)
 
 <!--
 The `full-pcpus-only` option can be enabled by adding `full-pcpus-only=true` to
@@ -340,6 +341,27 @@ For mode detail about the behavior of the individual options you can configure, 
 如果使用不兼容的选项，kubelet 将无法启动，并在日志中解释所出现的错误。
 
 有关你可以配置的各个选项的行为的模式详细信息，请参阅[节点资源管理](/zh-cn/docs/concepts/policy/node-resource-managers)文档。
+
+<!--
+The `scale-delay-time` option can be enabled by adding `scale-delay-time=<duration>`
+to the `CPUManager` policy options, where `<duration>` is a value between `0s` and `10s`
+(e.g., `5s` or `500ms`). This option ensures a minimum delay before applying updated
+cpuset assignments when a container with exclusive CPUs scales down. This option requires the
+`InPlacePodVerticalScalingExclusiveCPUs` feature gate to be enabled.
+
+When combined with the exposure of assigned CPUs via [Downward API](/docs/concepts/workloads/pods/downward-api/)
+field `assigned.cpuset`, workloads can get desired assigned CPUs in advance,
+which allows latency-sensitive workloads to prepare for CPU removal.
+-->
+`scale-delay-time` 选项可以通过将 `scale-delay-time=<duration>` 添加到
+`CPUManager` 策略选项来启用，其中 `<duration>` 是介于 `0s` 到 `10s` 之间的值
+（例如：`5s` 或 `500ms`）。此选项确保在具有独占 CPU 的容器缩容时，在应用更新的
+cpuset 分配之前有最小延迟时间。此选项需要启用
+`InPlacePodVerticalScalingExclusiveCPUs` 特性门控。
+
+与通过 [Downward API](/zh-cn/docs/concepts/workloads/pods/downward-api/) 的
+`assigned.cpuset` 字段暴露的已分配 CPU 结合使用时，工作负载可以提前获取期望分配的 CPU，
+从而允许延迟敏感型工作负载为 CPU 移除做准备。
 
 <!--
 ## {{% heading "whatsnext" %}}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

- Added the Simplified Chinese translation for the feature of Configurable Scaling Delay with Pod Resource Exposure.
- Preserved the English source in HTML comments following existing zh-cn localization style.

content\zh-cn\docs\concepts\workloads\pods\downward-api.md
content\zh-cn\docs\reference\command-line-tools-reference\feature-gates\DownwardAPIAssignedResources.md
content\zh-cn\docs\tasks\administer-cluster\cpu-management-policies.md

Note:
The EN version for this part is in progress now.
After The EN version submitted, this PR can start review.
