### PR TITLE
Add blog post about publishing Kubernetes SIG images to registry.k8s.io

### DIFF
--- a/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/dependency-overview.svg
+++ b/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/dependency-overview.svg
@@ -1,0 +1,116 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 720" font-family="Arial, Helvetica, sans-serif" font-size="13" role="img" aria-labelledby="dependency-title dependency-desc">
+  <title id="dependency-title">First-time registry.k8s.io image publishing dependencies</title>
+  <desc id="dependency-desc">The application repo provides the Cloud Build configuration and a signed release tag. The tag triggers a kubernetes/test-infra postsubmit job, which pushes a staging image to the staging registry. In kubernetes/k8s.io, the staging Google Group must be created before the staging registry. The staging image and image promoter configuration, with OWNERS validation from Kubernetes organization membership, promote the image to registry.k8s.io.</desc>
+  <defs>
+    <marker id="dep-arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#37474f"/>
+    </marker>
+    <style>
+      .edge { stroke: #37474f; stroke-width: 1.6; fill: none; }
+      .label-box { fill: #ffffff; stroke: #cfd8dc; stroke-width: 1; }
+      .label-text { fill: #37474f; font-size: 11.5px; }
+      .title { fill: #111111; font-weight: 700; }
+      .body { fill: #111111; }
+      .prod-title { fill: #2e7d32; font-weight: 700; }
+      .prod-body { fill: #2e7d32; }
+    </style>
+  </defs>
+  <rect width="980" height="720" fill="#ffffff"/>
+
+  <!-- edges (drawn first, under the boxes) -->
+  <g class="edge">
+    <path d="M165,140 L165,230" marker-end="url(#dep-arrow)"/>                  <!-- APP -> TAG -->
+    <path d="M290,105 L330,105 L330,245 L365,245" marker-end="url(#dep-arrow)"/> <!-- APP -> JOB -->
+    <path d="M815,140 L815,230" marker-end="url(#dep-arrow)"/>                  <!-- GRP -> REG -->
+    <path d="M690,265 L625,265" marker-end="url(#dep-arrow)"/>                  <!-- REG -> JOB -->
+    <path d="M290,265 L365,265" marker-end="url(#dep-arrow)"/>                  <!-- TAG -> JOB -->
+    <path d="M495,300 L495,390" marker-end="url(#dep-arrow)"/>                  <!-- JOB -> STG -->
+    <path d="M495,460 L495,530" marker-end="url(#dep-arrow)"/>                  <!-- STG -> PROM -->
+    <path d="M690,425 L655,425 L655,565 L625,565" marker-end="url(#dep-arrow)"/> <!-- ORG -> PROM -->
+    <path d="M495,600 L495,640" marker-end="url(#dep-arrow)"/>                  <!-- PROM -> PROD -->
+  </g>
+
+  <!-- nodes -->
+  <!-- row 0 -->
+  <g>
+    <rect x="40" y="70" width="250" height="70" rx="6" fill="#fff8e1" stroke="#f0b429" stroke-width="1.4"/>
+    <text x="165" y="93" text-anchor="middle" class="title">application repo</text>
+    <text x="165" y="113" text-anchor="middle" class="body">cloudbuild.yaml</text>
+    <text x="165" y="131" text-anchor="middle" class="body">make release-staging</text>
+
+    <rect x="690" y="70" width="250" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
+    <text x="815" y="100" text-anchor="middle" class="title">kubernetes/k8s.io</text>
+    <text x="815" y="121" text-anchor="middle" class="body">staging Google Group</text>
+  </g>
+
+  <!-- row 1 -->
+  <g>
+    <rect x="40" y="230" width="250" height="70" rx="6" fill="#fff8e1" stroke="#f0b429" stroke-width="1.4"/>
+    <text x="165" y="260" text-anchor="middle" class="title">application repo</text>
+    <text x="165" y="281" text-anchor="middle" class="body">signed release tag</text>
+
+    <rect x="365" y="230" width="260" height="70" rx="6" fill="#e9f7fb" stroke="#2f9ab7" stroke-width="1.4"/>
+    <text x="495" y="260" text-anchor="middle" class="title">kubernetes/test-infra</text>
+    <text x="495" y="281" text-anchor="middle" class="body">image-pushing postsubmit job</text>
+
+    <rect x="690" y="230" width="250" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
+    <text x="815" y="260" text-anchor="middle" class="title">kubernetes/k8s.io</text>
+    <text x="815" y="281" text-anchor="middle" class="body">staging registry (Terraform)</text>
+  </g>
+
+  <!-- row 2 -->
+  <g>
+    <rect x="365" y="390" width="260" height="70" rx="6" fill="#eceff1" stroke="#90a4ae" stroke-width="1.4"/>
+    <text x="495" y="420" text-anchor="middle" class="title">staging image</text>
+    <text x="495" y="441" text-anchor="middle" class="body">k8s-staging-images</text>
+
+    <rect x="690" y="390" width="250" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
+    <text x="815" y="420" text-anchor="middle" class="title">kubernetes/org</text>
+    <text x="815" y="441" text-anchor="middle" class="body">org membership for OWNERS</text>
+  </g>
+
+  <!-- row 3 -->
+  <g>
+    <rect x="365" y="530" width="260" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
+    <text x="495" y="553" text-anchor="middle" class="title">kubernetes/k8s.io</text>
+    <text x="495" y="573" text-anchor="middle" class="body">image promoter config</text>
+    <text x="495" y="591" text-anchor="middle" class="body">OWNERS / images.yaml / manifest</text>
+  </g>
+
+  <!-- row 4 -->
+  <g>
+    <rect x="365" y="640" width="260" height="56" rx="6" fill="#e8f5e9" stroke="#43a047" stroke-width="1.4"/>
+    <text x="495" y="664" text-anchor="middle" class="prod-title">registry.k8s.io image</text>
+    <text x="495" y="683" text-anchor="middle" class="prod-body">&lt;project&gt;/&lt;image&gt;:v&lt;version&gt;</text>
+  </g>
+
+  <!-- edge labels -->
+  <g>
+    <rect x="92" y="177" width="146" height="22" rx="4" class="label-box"/>
+    <text x="165" y="192" text-anchor="middle" class="label-text">release target exists</text>
+
+    <rect x="268" y="154" width="124" height="22" rx="4" class="label-box"/>
+    <text x="330" y="169" text-anchor="middle" class="label-text">job runs this build</text>
+
+    <rect x="774" y="177" width="82" height="22" rx="4" class="label-box"/>
+    <text x="815" y="192" text-anchor="middle" class="label-text">create first</text>
+
+    <rect x="593" y="204" width="128" height="22" rx="4" class="label-box"/>
+    <text x="657" y="219" text-anchor="middle" class="label-text">push target exists</text>
+
+    <rect x="268" y="204" width="124" height="22" rx="4" class="label-box"/>
+    <text x="330" y="219" text-anchor="middle" class="label-text">triggers postsubmit</text>
+
+    <rect x="506" y="345" width="132" height="22" rx="4" class="label-box"/>
+    <text x="572" y="360" text-anchor="middle" class="label-text">pushes staging image</text>
+
+    <rect x="401" y="485" width="88" height="22" rx="4" class="label-box"/>
+    <text x="445" y="500" text-anchor="middle" class="label-text">source image</text>
+
+    <rect x="641" y="485" width="122" height="22" rx="4" class="label-box"/>
+    <text x="702" y="500" text-anchor="middle" class="label-text">OWNERS validation</text>
+
+    <rect x="511" y="615" width="72" height="22" rx="4" class="label-box"/>
+    <text x="547" y="630" text-anchor="middle" class="label-text">promotes</text>
+  </g>
+</svg>

--- a/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/dependency-overview.svg
+++ b/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/dependency-overview.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 720" font-family="Arial, Helvetica, sans-serif" font-size="13" role="img" aria-labelledby="dependency-title dependency-desc">
   <title id="dependency-title">First-time registry.k8s.io image publishing dependencies</title>
-  <desc id="dependency-desc">The application repo provides the Cloud Build configuration and a signed release tag. The tag triggers a kubernetes/test-infra postsubmit job, which pushes a staging image to the staging registry. In kubernetes/k8s.io, the staging Google Group must be created before the staging registry. The staging image and image promoter configuration, with OWNERS validation from Kubernetes organization membership, promote the image to registry.k8s.io.</desc>
+  <desc id="dependency-desc">The image-owning repository provides the Cloud Build configuration and a signed release tag. The tag triggers a kubernetes/test-infra postsubmit job, which pushes a staging image to the staging registry. In kubernetes/k8s.io, the staging Google Group must be created before the staging registry. The staging image and image promoter configuration, with OWNERS validation from Kubernetes organization membership, promote the image to registry.k8s.io.</desc>
   <defs>
     <marker id="dep-arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
       <path d="M0,0 L8,3 L0,6 z" fill="#37474f"/>
@@ -34,7 +34,7 @@
   <!-- row 0 -->
   <g>
     <rect x="40" y="70" width="250" height="70" rx="6" fill="#fff8e1" stroke="#f0b429" stroke-width="1.4"/>
-    <text x="165" y="93" text-anchor="middle" class="title">application repo</text>
+    <text x="165" y="93" text-anchor="middle" class="title">image-owning repo</text>
     <text x="165" y="113" text-anchor="middle" class="body">cloudbuild.yaml</text>
     <text x="165" y="131" text-anchor="middle" class="body">make release-staging</text>
 
@@ -46,7 +46,7 @@
   <!-- row 1 -->
   <g>
     <rect x="40" y="230" width="250" height="70" rx="6" fill="#fff8e1" stroke="#f0b429" stroke-width="1.4"/>
-    <text x="165" y="260" text-anchor="middle" class="title">application repo</text>
+    <text x="165" y="260" text-anchor="middle" class="title">image-owning repo</text>
     <text x="165" y="281" text-anchor="middle" class="body">signed release tag</text>
 
     <rect x="365" y="230" width="260" height="70" rx="6" fill="#e9f7fb" stroke="#2f9ab7" stroke-width="1.4"/>

--- a/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/ghcr-vs-official-path.svg
+++ b/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/ghcr-vs-official-path.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 360" font-family="Arial, Helvetica, sans-serif" font-size="13" role="img" aria-label="Two flows compared: the ghcr.io approach is blocked, while the official path leads to registry.k8s.io.">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#37474f"/>
+    </marker>
+    <marker id="arrowdash" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#c62828"/>
+    </marker>
+  </defs>
+
+  <!-- group A: ghcr.io approach -->
+  <rect x="10" y="20" width="640" height="130" rx="8" fill="#fafafa" stroke="#bdbdbd" stroke-dasharray="4 3"/>
+  <text x="30" y="42" fill="#616161" font-weight="bold">The ghcr.io approach (blocked)</text>
+
+  <g>
+    <rect x="30" y="70" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+    <text x="95" y="100" text-anchor="middle">tag push</text>
+
+    <rect x="190" y="70" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+    <text x="255" y="100" text-anchor="middle">GitHub Actions</text>
+
+    <rect x="350" y="70" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+    <text x="415" y="100" text-anchor="middle">push to ghcr.io</text>
+
+    <rect x="510" y="70" width="130" height="50" rx="6" fill="#fdecea" stroke="#e57373"/>
+    <text x="575" y="94" text-anchor="middle" fill="#c62828">stays private</text>
+    <text x="575" y="110" text-anchor="middle" fill="#c62828">no release path</text>
+
+    <line x1="160" y1="95" x2="186" y2="95" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="320" y1="95" x2="346" y2="95" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="480" y1="95" x2="506" y2="95" stroke="#c62828" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#arrowdash)"/>
+  </g>
+
+  <!-- group B: official path -->
+  <rect x="10" y="190" width="960" height="150" rx="8" fill="#fafafa" stroke="#bdbdbd"/>
+  <text x="30" y="212" fill="#616161" font-weight="bold">The official path</text>
+
+  <g>
+    <rect x="30" y="245" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+    <text x="95" y="275" text-anchor="middle">tag push</text>
+
+    <rect x="190" y="245" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+    <text x="255" y="275" text-anchor="middle">Prow postsubmit</text>
+
+    <rect x="350" y="245" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+    <text x="415" y="275" text-anchor="middle">Cloud Build</text>
+
+    <rect x="510" y="245" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+    <text x="575" y="275" text-anchor="middle">staging registry</text>
+
+    <rect x="670" y="245" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+    <text x="735" y="275" text-anchor="middle">image promoter</text>
+
+    <rect x="830" y="245" width="130" height="50" rx="6" fill="#e8f5e9" stroke="#66bb6a"/>
+    <text x="895" y="275" text-anchor="middle" fill="#2e7d32">registry.k8s.io</text>
+
+    <line x1="160" y1="270" x2="186" y2="270" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="320" y1="270" x2="346" y2="270" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="480" y1="270" x2="506" y2="270" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="640" y1="270" x2="666" y2="270" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <line x1="800" y1="270" x2="826" y2="270" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  </g>
+</svg>

--- a/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/index.md
@@ -1,0 +1,395 @@
+---
+layout: blog
+title: "Publishing a Kubernetes SIG's Images to registry.k8s.io"
+draft: true
+slug: publishing-images-to-registry-k8s-io
+author: >
+  [Kahiro Okina](https://github.com/kahirokunn) (Craftsman Software, Inc.)
+---
+
+My first instinct was to use a release path I had seen in many GitHub-hosted
+open source projects: build the image in GitHub Actions, push it to `ghcr.io`,
+and publish from there.
+
+Inside the `kubernetes-sigs` GitHub organization, that path stopped short. I
+could build the images, but I could not point users at GHCR as an official
+Kubernetes project distribution path. I learned in the `#github-management`
+channel on the [Kubernetes Slack](https://slack.k8s.io/) that GHCR is not
+supported for that role. Publishing the two images through the official route,
+`registry.k8s.io`, ended up involving four repositories:
+`kubernetes-sigs/cluster-inventory-api`,
+[`kubernetes/k8s.io`](https://github.com/kubernetes/k8s.io),
+[`kubernetes/test-infra`](https://github.com/kubernetes/test-infra), and
+[`kubernetes/org`](https://github.com/kubernetes/org).
+
+The two images that finally shipped were:
+
+```none
+registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+```
+
+The first successful `registry.k8s.io` release was `v0.1.2`; after I found a
+mistake, I re-released the images as `v0.1.3`.
+
+This post has two parts. Part 1 follows the `cluster-inventory-api` case: how the
+plan changed and where the release path broke down. Part 2 turns that experience
+into the procedure I wish I had at the start. `cluster-inventory-api` is a
+[SIG Multicluster](https://github.com/kubernetes/community/tree/master/sig-multicluster)
+project, but the procedure is not specific to that SIG.
+
+## Why an image needed to be distributed at all
+
+Cluster Inventory API is a SIG Multicluster project for helping applications and
+tools discover, interact with, and make placement decisions across multiple
+Kubernetes clusters. Its first major component is the `ClusterProfile` API, which
+represents one cluster and the information consumers need to use it.
+
+Some `ClusterProfile` entries point at access-provider plugins, such as
+[`secretreader`](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/main/plugins/secretreader/cmd/plugin),
+that resolve how to reach a cluster. These plugins support being used as
+[image volumes](/docs/tasks/configure-pod-container/image-volumes/).
+
+The work started when Kueue's MultiKueue work asked for the `secretreader` plugin
+to be provided as a reusable artifact
+([cluster-inventory-api#34](https://github.com/kubernetes-sigs/cluster-inventory-api/issues/34)).
+
+## Part 1: the road to publication
+
+### 1. The original plan was ghcr.io
+
+The first plan was to use a GitHub Actions workflow to build `plugins/*` with
+Docker Buildx on tag pushes and publish to GHCR (`ghcr.io`)
+([cluster-inventory-api#40](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/40)).
+Along the way I added a `RELEASE.md`, `v0.1.0` was released, and the push to
+GHCR succeeded.
+
+But I could not change the published package's visibility from private to public.
+
+### 2. Rebuilding the release workflow
+
+When I asked in the `#github-management` channel on the Kubernetes Slack, the
+answer was clear:
+
+> We don't support GHCR, which is why it's locked down. You can find more about
+> how to publish official artifact images here:
+> https://github.com/kubernetes/k8s.io/tree/main/artifacts#staging-buckets
+
+GHCR was never going to work, so the workflow had to move to `registry.k8s.io`.
+On the project side, that meant dropping the GitHub Actions workflow that pushed
+to `ghcr.io` and replacing it with a path driven by
+[Prow](https://docs.prow.k8s.io/) (the Kubernetes project's CI/CD system) and
+Google Cloud Build
+([cluster-inventory-api#53](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/53)).
+In practice, I added a `cloudbuild.yaml` and a `make release-staging` target so
+that a tag push could build and push images to a staging registry on
+Kubernetes-owned infrastructure instead of the project's own CI.
+
+{{< figure src="ghcr-vs-official-path.svg" alt="Two flows compared. In the ghcr.io approach, a tag push triggers GitHub Actions and pushes to ghcr.io, where the image stays private and has no release path. In the official path, a tag push triggers a Prow postsubmit job, which runs Cloud Build and pushes to a staging registry. The image promoter then copies the image to registry.k8s.io." >}}
+
+That PR merged, so the project repository could now describe how to build a
+staging image. But the infrastructure that receives that image did not exist
+yet.
+
+### 3. Untangling the infrastructure dependencies
+
+Publishing to `registry.k8s.io` requires two pieces: a staging registry in
+`kubernetes/k8s.io`, and a postsubmit job in `kubernetes/test-infra` that
+triggers the build. A postsubmit is a Prow job that runs after a merge or tag,
+unlike a presubmit that runs on pull requests.
+
+These two pieces have to be set up in order. The staging registry is managed
+with Terraform, and its config names the Google Group that gets push (writer)
+access — so the group has to exist before the registry is applied, or the apply
+stops at that permission assignment:
+
+1. Create the Google Group
+   ([kubernetes/k8s.io#9385](https://github.com/kubernetes/k8s.io/pull/9385)).
+2. Create the staging registry
+   ([kubernetes/k8s.io#9347](https://github.com/kubernetes/k8s.io/pull/9347)),
+   whose Terraform points at that group as the one allowed to push.
+
+I also tripped over a naming rule I did not know about: the staging access group
+name has an 18-character limit on its suffix. My first choice,
+`k8s-infra-staging-cluster-inventory-api@kubernetes.io`, was too long and had to
+be shortened to `k8s-infra-staging-cluster-inv-api@kubernetes.io`
+([kubernetes/k8s.io#9402](https://github.com/kubernetes/k8s.io/pull/9402)). If
+your project name is long, decide on a short form up front.
+
+Once a maintainer with the right permissions applied these, the staging registry
+and group had writer access. The `test-infra` postsubmit job
+([kubernetes/test-infra#36821](https://github.com/kubernetes/test-infra/pull/36821))
+merged too, and Prow picked up the new job automatically.
+Cutting a tag at this point finally produced a staging image.
+
+### 4. Promoting from staging to registry.k8s.io
+
+With a staging image in place, the next step is configuring its promotion to
+`registry.k8s.io`
+([kubernetes/k8s.io#9499](https://github.com/kubernetes/k8s.io/pull/9499)). That
+first promotion used a manually authored `kubernetes/k8s.io` PR because the
+project did not have image promoter configuration yet: an entry in `images.yaml`
+listing the images to promote, a `promoter-manifest.yaml` file mapping the
+staging repository to the production registry path, and an `OWNERS` file naming
+who can approve this promotion. For subsequent releases,
+[`kpromo`](https://github.com/kubernetes-sigs/promo-tools) can generate the
+promotion pull request by updating `images.yaml` for the new tag. If you are
+curious how that machinery works, see
+[The Invisible Rewrite: Modernizing the Kubernetes Image Promoter](/blog/2026/03/17/image-promoter-rewrite/).
+
+Review then flagged something I had not anticipated: the `OWNERS` file listed a
+user who was not a member of the Kubernetes GitHub organization. Image-promotion
+`OWNERS` must be organization members, and at the time neither I nor the other
+reviewer was. I opened PRs to add the two of us to `kubernetes/org`
+([kubernetes/org#6385](https://github.com/kubernetes/org/pull/6385),
+[kubernetes/org#6386](https://github.com/kubernetes/org/pull/6386)).
+
+After approval from the SIG Multicluster leads, the promotion PR merged and the
+`v0.1.2` images were promoted to `registry.k8s.io/cluster-inventory-api/`. I
+confirmed the production images could be pulled, published the GitHub release,
+and announced the result in the relevant issues and on Slack.
+
+## Part 2: how to publish a new image to registry.k8s.io
+
+This is the procedure for a Kubernetes SIG publishing images under
+`registry.k8s.io/<project>/...` for the first time. The repositories involved and
+their dependencies look like this:
+
+{{< figure src="dependency-overview.svg" alt="A dependency graph for first-time registry.k8s.io image publishing. The application repo provides cloudbuild.yaml and make release-staging, and a signed release tag triggers the kubernetes/test-infra image-pushing postsubmit job. In kubernetes/k8s.io, a staging Google Group must exist before the staging registry can be created, and that registry is the job's push target. The postsubmit job pushes the staging image. That staging image, together with image promoter config in kubernetes/k8s.io and OWNERS validation through kubernetes/org membership, promotes the image to registry.k8s.io." class="diagram-large" clicktozoom="true" caption="First-time setup dependencies for publishing a Kubernetes SIG's image to registry.k8s.io." >}}
+
+### Before you start: choose registry paths, tag policy, and owners
+
+- The project name and registry path, for example `cluster-inventory-api` maps to
+  `registry.k8s.io/cluster-inventory-api/<image>:<tag>`.
+- The staging repository name, for example
+  `us-central1-docker.pkg.dev/k8s-staging-images/cluster-inventory-api`.
+- The image names, for example `secretreader` and `kubeconfig-secretreader`.
+- The tag policy. Here the repository's release tag and the image tag are kept in
+  lockstep, such as `v0.1.2`.
+- Which SIG owns the project, and who reviews and approves.
+- Whether the people you want in the promotion `OWNERS` file are Kubernetes
+  organization members. If not, request membership in `kubernetes/org` first.
+- The staging access group name. Its suffix has an 18-character limit.
+
+Throughout Part 2, `<project>` is the registry path segment (for example
+`cluster-inventory-api`), `<image>` is an image name (for example
+`secretreader`), `<version>` is the numeric release version (for example
+`0.1.2`, so `v<version>` is `v0.1.2`), and `<yourname>` is your GitHub username.
+
+### 1. Make the application repo build images
+
+Set up the repository so that a tag push can build and push a staging image. You
+need:
+
+- a `RELEASE.md`,
+- a `cloudbuild.yaml` (the `test-infra` job in step 4 invokes this to build and
+  push the image),
+- a Dockerfile and/or Make target to build the image,
+- a release target that pushes to the staging registry (for example
+  `make release-staging`),
+- release verification steps that confirm the release completed successfully.
+
+References:
+[cluster-inventory-api#53](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/53)
+(moving to the Prow/Cloud Build approach) and
+[cluster-inventory-api#57](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/57)
+(passing the staging repository explicitly to `kpromo`).
+
+### 2. Add a Google Group for staging artifacts
+
+Add a Google Group that has push access to the staging registry, in your SIG's
+group configuration under `groups/` in `kubernetes/k8s.io`. The two PRs below
+show the exact entries to add (including the fix for getting the group to
+reconcile): [kubernetes/k8s.io#9385](https://github.com/kubernetes/k8s.io/pull/9385),
+[kubernetes/k8s.io#9402](https://github.com/kubernetes/k8s.io/pull/9402).
+
+- Check that the group name fits the 18-character limit.
+- Get approval from the SIG leads or chairs.
+
+Do this first: if the group does not exist, the Terraform apply for the staging
+registry in the next step stops while assigning writer access.
+
+### 3. Add a staging registry in kubernetes/k8s.io
+
+Add an Artifact Registry staging repository under the `k8s-staging-images`
+project. Update the Terraform so that the writer group and reader permissions
+are set correctly. Reference:
+[kubernetes/k8s.io#9347](https://github.com/kubernetes/k8s.io/pull/9347).
+
+### 4. Add an image-pushing postsubmit job in kubernetes/test-infra
+
+Add a job under `config/jobs/image-pushing/` that runs the application repo's
+`cloudbuild.yaml` on a tag push or postsubmit and pushes to the staging
+registry. Reference:
+[kubernetes/test-infra#36821](https://github.com/kubernetes/test-infra/pull/36821).
+
+Confirm the job name, repository, branch/tag trigger, staging project, and the
+reference to the `cloudbuild.yaml`.
+
+If the staging registry and writer group are not in place yet, the job will run
+but fail because the permission or repository is missing.
+
+### 5. Push a release tag to build a staging image
+
+With everything above in place, push a
+[signed tag](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags)
+from the application repo:
+
+```bash
+git tag -s v<version>
+git push origin v<version>
+gh release create v<version> --draft --generate-notes --verify-tag
+```
+
+Then verify the staging image:
+
+```bash
+docker manifest inspect us-central1-docker.pkg.dev/k8s-staging-images/<project>/<image>:v<version>
+```
+
+Keep the GitHub release as a draft and publish it only after the promotion to
+production is done. Note that tag events are not processed retroactively: tags
+created before the release pipeline existed will not produce a staging image.
+
+### 6. Add the image promoter configuration in kubernetes/k8s.io
+
+Open a normal `kubernetes/k8s.io` PR that adds the configuration for this
+project:
+
+- `registry.k8s.io/images/k8s-staging-<project>/OWNERS`,
+- `registry.k8s.io/images/k8s-staging-<project>/images.yaml` (the promotion
+  target),
+- `registry.k8s.io/manifests/k8s-staging-<project>/promoter-manifest.yaml`.
+
+For the first promotion, include the digest and tag entries for the staging image
+or images in `images.yaml`.
+
+Everyone listed in `OWNERS` must already be a Kubernetes organization member.
+For the first promotion PR, get `/lgtm` from a SIG lead. References:
+[kubernetes/k8s.io#9499](https://github.com/kubernetes/k8s.io/pull/9499) and the
+organization membership PRs
+[kubernetes/org#6385](https://github.com/kubernetes/org/pull/6385) and
+[kubernetes/org#6386](https://github.com/kubernetes/org/pull/6386).
+
+### 7. Verify the release and publish it
+
+Once the promotion PR merges, run the project's release verification and confirm
+the production image is available:
+
+```bash
+docker manifest inspect registry.k8s.io/<project>/<image>:v<version>
+```
+
+When that works, publish the draft GitHub release and announce it in the related
+issues and on Slack.
+
+### A recommended order for the first setup
+
+Because of the dependencies, the first time through goes most smoothly in this
+order:
+
+1. `kubernetes/org`: Kubernetes organization membership
+2. application repo: image build, `release-staging` target, `cloudbuild.yaml`
+3. `kubernetes/k8s.io`: staging Google Group
+4. `kubernetes/k8s.io`: staging registry
+5. `kubernetes/test-infra`: image-pushing postsubmit job
+6. application repo: push the release tag, verify the staging image
+7. `kubernetes/k8s.io`: image promoter configuration and promotion entry
+8. verify the release, publish the GitHub release
+
+Starting with membership makes PR validation easier because CI can run without
+waiting for `/ok-to-test`.
+
+### Where to ask for help
+
+Several of these steps depend on other people: reviewers, approvers, and SIG
+leads. Expect to wait on reviews between steps rather than finishing in one
+sitting. On the [Kubernetes Slack](https://slack.k8s.io/), these channels line
+up with the work:
+
+| Channel | Use it for |
+| --- | --- |
+| `#github-management` | Repository access, GHCR questions, and Kubernetes organization membership |
+| `#sig-k8s-infra` | The staging Google Group and staging registry |
+
+## After the first time, it is much lighter
+
+Once the initial setup is done, routine releases are far simpler:
+
+1. For this project, open a release proposal issue (lazy consensus: no
+   objections within two weeks counts as approval).
+2. Push a signed tag:
+
+   ```bash
+   git tag -s v<version>
+   git push origin v<version>
+   ```
+
+3. Create a draft GitHub release:
+
+   ```bash
+   gh release create v<version> --draft --generate-notes --verify-tag
+   ```
+
+4. Confirm the `test-infra` postsubmit pushed the staging image:
+
+   ```bash
+   docker manifest inspect us-central1-docker.pkg.dev/k8s-staging-images/<project>/<image>:v<version>
+   ```
+
+5. Create the promotion PR with `kpromo pr` (install it from
+   [promo-tools](https://github.com/kubernetes-sigs/promo-tools)). Pass
+   `--staging-repo` to name the Artifact Registry staging repository explicitly:
+
+   ```bash
+   kpromo pr \
+     --fork <yourname> \
+     --project <project> \
+     --tag v<version> \
+     --staging-repo us-central1-docker.pkg.dev/k8s-staging-images/<project>
+   ```
+
+6. Have the promotion PR in `kubernetes/k8s.io` reviewed, approved, and merged.
+7. Run the project's release verification and confirm the production image is
+   available:
+
+   ```bash
+   docker manifest inspect registry.k8s.io/<project>/<image>:v<version>
+   ```
+
+8. Publish the draft GitHub release.
+9. Announce in the release proposal issue, related issues, and on Slack.
+
+## Wrapping up
+
+What started as "push to `ghcr.io` from GitHub Actions" turned into work across
+four repositories. If you are publishing images under `registry.k8s.io`, the
+order above should give you a clearer path.
+
+## Acknowledgments
+
+This publication only happened because many people made time for review,
+coordination, release guidance, and behind-the-scenes support.
+
+Special thanks to [Mike Ng](https://github.com/mikeshng) and
+[Laura Lorenz](https://github.com/lauralorenz) for keeping the release moving across
+time zones: when I could not attend meetings, they joined on my behalf,
+connected me with the right people, and helped coordinate the work across SIG
+Multicluster. Thanks to [Jian Qiu](https://github.com/qiujian16) for
+careful implementation reviews, and to SIG Multicluster lead
+[Stephen Kitt](https://github.com/skitt) for reviewing the release process and
+helping clarify the rules for publishing. I am also grateful to
+[Arnaud M.](https://github.com/ameukam), who quickly reviewed the
+`kubernetes/k8s.io` pull requests and guided the infrastructure and promotion
+changes through to completion. I am thankful to everyone else who supported
+this effort in many different ways.
+
+## References
+
+- [v0.1.2 release](https://github.com/kubernetes-sigs/cluster-inventory-api/releases/tag/v0.1.2)
+- [Using Plugin OCI Images](https://github.com/kubernetes-sigs/cluster-inventory-api/blob/main/docs/plugin-images.md)
+- [Image volumes](/docs/tasks/configure-pod-container/image-volumes/)
+- [registry.k8s.io: faster, cheaper and Generally Available (GA)](/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/)
+- [Publishing official artifact images (`kubernetes/k8s.io/artifacts`)](https://github.com/kubernetes/k8s.io/tree/main/artifacts#staging-buckets)
+- [`kpromo` (promo-tools)](https://github.com/kubernetes-sigs/promo-tools)
+- [Kubernetes Slack](https://slack.k8s.io/)

--- a/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/index.md
@@ -16,7 +16,7 @@ could build the images, but I could not point users at GHCR as an official
 Kubernetes project distribution path. I learned in the `#github-management`
 channel on the [Kubernetes Slack](https://slack.k8s.io/) that GHCR is not
 supported for that role. Publishing the two images through the official route,
-`registry.k8s.io`, ended up involving the application repository
+`registry.k8s.io`, ended up involving the image-owning repository
 (`kubernetes-sigs/cluster-inventory-api`) and three Kubernetes infrastructure or
 configuration repositories:
 [`kubernetes/k8s.io`](https://github.com/kubernetes/k8s.io),
@@ -81,7 +81,7 @@ Kubernetes-owned infrastructure instead of the project's own CI.
 
 {{< figure src="ghcr-vs-official-path.svg" alt="Two flows compared. In the ghcr.io approach, a tag push triggers GitHub Actions and pushes to ghcr.io, where the image stays private and has no release path. In the official path, a tag push triggers a Prow postsubmit job, which runs Cloud Build and pushes to a staging registry. The image promoter then copies the image to registry.k8s.io." >}}
 
-That PR merged, so the project repository could now describe how to build a
+That PR merged, so the image-owning repository could now describe how to build a
 staging image. But the infrastructure that receives that image did not exist
 yet.
 
@@ -159,7 +159,7 @@ This is the procedure for a Kubernetes SIG publishing images under
 `registry.k8s.io/<project>/...` for the first time. The repositories involved and
 their dependencies look like this:
 
-{{< figure src="dependency-overview.svg" alt="A dependency graph for first-time registry.k8s.io image publishing. The application repo provides cloudbuild.yaml and make release-staging, and a signed release tag triggers the kubernetes/test-infra image-pushing postsubmit job. In kubernetes/k8s.io, a staging Google Group must exist before the staging registry can be created, and that registry is the job's push target. The postsubmit job pushes the staging image. That staging image, together with image promoter config in kubernetes/k8s.io and OWNERS validation through kubernetes/org membership, promotes the image to registry.k8s.io." class="diagram-large" clicktozoom="true" caption="First-time setup dependencies for publishing a Kubernetes SIG's image to registry.k8s.io." >}}
+{{< figure src="dependency-overview.svg" alt="A dependency graph for first-time registry.k8s.io image publishing. The image-owning repository provides cloudbuild.yaml and make release-staging, and a signed release tag triggers the kubernetes/test-infra image-pushing postsubmit job. In kubernetes/k8s.io, a staging Google Group must exist before the staging registry can be created, and that registry is the job's push target. The postsubmit job pushes the staging image. That staging image, together with image promoter config in kubernetes/k8s.io and OWNERS validation through kubernetes/org membership, promotes the image to registry.k8s.io." class="diagram-large" clicktozoom="true" caption="First-time setup dependencies for publishing a Kubernetes SIG's image to registry.k8s.io." >}}
 
 ### Before you start: choose registry paths, tag policy, and owners
 
@@ -180,7 +180,7 @@ Throughout Part 2, `<project>` is the registry path segment (for example
 `secretreader`), `<version>` is the numeric release version (for example
 `0.1.2`, so `v<version>` is `v0.1.2`), and `<yourname>` is your GitHub username.
 
-### 1. Make the application repo build images
+### 1. Make the image-owning repository build images
 
 Set up the repository so that a tag push can build and push a staging image. You
 need:
@@ -222,7 +222,7 @@ are set correctly. Reference:
 
 ### 4. Add an image-pushing postsubmit job in kubernetes/test-infra
 
-Add a job under `config/jobs/image-pushing/` that runs the application repo's
+Add a job under `config/jobs/image-pushing/` that runs the image-owning repository's
 `cloudbuild.yaml` on a tag push or postsubmit and pushes to the staging
 registry. Reference:
 [kubernetes/test-infra#36821](https://github.com/kubernetes/test-infra/pull/36821).
@@ -237,7 +237,7 @@ but fail because the permission or repository is missing.
 
 With everything above in place, push a
 [signed tag](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags)
-from the application repo:
+from the image-owning repository:
 
 ```bash
 git tag -s v<version>
@@ -293,11 +293,11 @@ Because of the dependencies, the first time through goes most smoothly in this
 order:
 
 1. `kubernetes/org`: Kubernetes organization membership
-2. application repo: image build, `release-staging` target, `cloudbuild.yaml`
+2. image-owning repository: image build, `release-staging` target, `cloudbuild.yaml`
 3. `kubernetes/k8s.io`: staging Google Group
 4. `kubernetes/k8s.io`: staging registry
 5. `kubernetes/test-infra`: image-pushing postsubmit job
-6. application repo: push the release tag, verify the staging image
+6. image-owning repository: push the release tag, verify the staging image
 7. `kubernetes/k8s.io`: image promoter configuration and promotion entry
 8. verify the release, publish the GitHub release
 

--- a/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/_posts/2026/publishing-images-to-registry-k8s-io/index.md
@@ -16,21 +16,15 @@ could build the images, but I could not point users at GHCR as an official
 Kubernetes project distribution path. I learned in the `#github-management`
 channel on the [Kubernetes Slack](https://slack.k8s.io/) that GHCR is not
 supported for that role. Publishing the two images through the official route,
-`registry.k8s.io`, ended up involving four repositories:
-`kubernetes-sigs/cluster-inventory-api`,
+`registry.k8s.io`, ended up involving the application repository
+(`kubernetes-sigs/cluster-inventory-api`) and three Kubernetes infrastructure or
+configuration repositories:
 [`kubernetes/k8s.io`](https://github.com/kubernetes/k8s.io),
 [`kubernetes/test-infra`](https://github.com/kubernetes/test-infra), and
 [`kubernetes/org`](https://github.com/kubernetes/org).
 
-The two images that finally shipped were:
-
-```none
-registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
-registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
-```
-
-The first successful `registry.k8s.io` release was `v0.1.2`; after I found a
-mistake, I re-released the images as `v0.1.3`.
+The two plugin images for the `cluster-inventory-api` project ultimately shipped
+under `registry.k8s.io`.
 
 This post has two parts. Part 1 follows the `cluster-inventory-api` case: how the
 plan changed and where the release path broke down. Part 2 turns that experience
@@ -58,8 +52,8 @@ to be provided as a reusable artifact
 
 ### 1. The original plan was ghcr.io
 
-The first plan was to use a GitHub Actions workflow to build `plugins/*` with
-Docker Buildx on tag pushes and publish to GHCR (`ghcr.io`)
+The first plan was to use a GitHub Actions workflow to build container images for
+`plugins/*` on tag pushes and publish to GHCR (`ghcr.io`)
 ([cluster-inventory-api#40](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/40)).
 Along the way I added a `RELEASE.md`, `v0.1.0` was released, and the push to
 GHCR succeeded.
@@ -148,6 +142,16 @@ After approval from the SIG Multicluster leads, the promotion PR merged and the
 `v0.1.2` images were promoted to `registry.k8s.io/cluster-inventory-api/`. I
 confirmed the production images could be pulled, published the GitHub release,
 and announced the result in the relevant issues and on Slack.
+
+The two images that finally shipped were:
+
+```none
+registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+```
+
+The first successful `registry.k8s.io` release was `v0.1.2`; after I found a
+mistake, I re-released the images as `v0.1.3`.
 
 ## Part 2: how to publish a new image to registry.k8s.io
 


### PR DESCRIPTION
## Description

This PR adds an English Kubernetes blog post about publishing a Kubernetes SIG's container images through `registry.k8s.io`.

The post uses the `secretreader` and `kubeconfig-secretreader` images of `cluster-inventory-api` as a concrete example.
It explains why GHCR is not the official distribution path for Kubernetes project images, then documents the first-time setup across:

- the application repository
- `kubernetes/k8s.io`
- `kubernetes/test-infra`
- `kubernetes/org`

It also includes two SVG diagrams that compare the GHCR and official publication
paths and show the dependency order for first-time `registry.k8s.io` setup.

## Issue

N/A

/area blog
