### PR TITLE
Add docs for CompositePodGroup

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/gang-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/gang-scheduling.md
@@ -43,8 +43,66 @@ The process follows these steps for each PodGroup:
    Instead, they are moved to the unschedulable queue to wait for cluster resources to free up,
    allowing other workloads to be scheduled in the meantime.
 
+## Hierarchical gang scheduling with CompositePodGroups
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
+are enabled, gang scheduling extends its support to `CompositePodGroups`.
+
+Contrary to `PodGroups` that group Pods, `CompositePodGroups` group child groups together - either
+`PodGroups` or other `CompositePodGroups`. `CompositePodGroup` specifies a scheduling policy that
+applies to its child groups during scheduling:
+
+* `gang` policy with a `minGroupCount` field, specifying the minimum number of child groups (either
+  `CompositePodGroup` or `PodGroup` objects) that must be scheduled together as a single unit
+  atomically.
+* `basic` policy which indicates that child groups can be scheduled independently.
+
+`gang` policy is useful for multi-component workloads that require all-or-nothing scheduling across
+multiple child groups, ensuring that a minimum number of child groups are scheduled together. An
+example workload with such needs is replicated AI training.
+
+`basic` policy can be used for workloads that comprise multiple groups of Pods each of which can be
+scheduled as an independent gang, e.g. for AI inference workloads.
+
+### Hierarchical quorum
+
+The `GangScheduling` plugin holds the root `CompositePodGroup` from entering the active scheduling
+queue in the `PreEnqueue` phase until it satisfies the **hierarchical quorum**. This quorum is
+evaluated bottom-up, from leaf `PodGroup` objects up to the root `CompositePodGroup`:
+
+- A leaf `PodGroup` **satisfies quorum** if and only if the `PodGroup` object exists and can
+  potentially meet its scheduling policy criteria:
+  - For a `gang` policy: at least `minCount` of its constituent Pods have been created.
+  - For a `basic` policy: at least one of its constituent Pods has been created.
+- A `CompositePodGroup` **satisfies quorum** if and only if the `CompositePodGroup` object exists
+  and can potentially meet its scheduling policy criteria:
+  - For a `gang` policy: at least `minGroupCount` of its direct child groups satisfy quorum.
+  - For a `basic` policy: at least one of its direct child groups satisfies quorum.
+- The overall **hierarchical quorum** is satisfied if and only if the root `CompositePodGroup`
+  satisfies the quorum.
+
+Ultimately, a root `CompositePodGroup` is admitted into the active scheduling queue if and only if
+it satisfies the hierarchical quorum and there is at least one pending Pod that belongs to one of
+its descendant `PodGroups`.
+
+### Placement feasibility
+
+The `GangScheduling` plugin's `PlacementFeasible` method supports evaluation for both
+`PodGroups` and `CompositePodGroups`. It is invoked by the scheduling cycle before starting child
+evaluation and after evaluating each child group of a `CompositePodGroup`.
+
+By taking into account the number of child groups that were successfully scheduled and the child
+groups that were not evaluated in the scheduling cycle just yet, `PlacementFeasible` determines
+whether the group's policy constraint is still achievable, allowing the scheduling cycle to abort
+the evaluation of the `CompositePodGroup` early if its underlying scheduling policy cannot be
+satisfied anymore.
+
 ## {{% heading "whatsnext" %}}
 
 * Learn about the [PodGroup API](/docs/concepts/workloads/podgroup-api/) and its [lifecycle](/docs/concepts/workloads/podgroup-api/lifecycle/).
+* Read about the [CompositePodGroup API](/docs/concepts/workloads/compositepodgroup-api/).
 * Read about [PodGroup scheduling policies](/docs/concepts/workloads/workload-api/policies/).
 * Read about [PodGroup scheduling](/docs/concepts/scheduling-eviction/podgroup-scheduling/).

--- a/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/pod-priority-preemption.md
@@ -182,6 +182,20 @@ priority Pod may be scheduled sooner than Pods with lower priority if
 its scheduling requirements are met. If such Pod cannot be scheduled, the
 scheduler will continue and try to schedule other lower priority Pods.
 
+#### CompositePodGroups and scheduling order
+
+{{< feature-state feature_gate_name="CompositePodGroup">}}
+
+When the `CompositePodGroup` feature gate is enabled, the scheduler treats the following objects as
+units of scheduling that can be enqueued:
+
+- Standalone Pods - Pods that are not part of any PodGroup,
+- Standalone PodGroups - PodGroups that do not specify `ParentCompositePodGroup`,
+- Root CompositePodGroups - CompositePodGroups that do not specify `ParentCompositePodGroup`.
+
+These objects specify a `priority` field value of which is used to determine their position in the
+active scheduling queue.
+
 ## Preemption
 
 When Pods are created, they go to a queue and wait to be scheduled. The

--- a/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
@@ -129,6 +129,97 @@ For consistent behavior throughout the entire cycle, the algorithm requires that
 share the same `.spec.schedulerName`. This requirement is validated before the cycle starts,
 and the PodGroup is rejected if the constraint is not met.
 
+## Hierarchical scheduling with CompositePodGroups
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
+are enabled, the scheduler extends the PodGroup scheduling cycle to support multi-level group
+hierarchies.
+
+In a hierarchical workload, Pods belong to leaf `PodGroup` objects, which in turn specify parent
+`CompositePodGroup` resources up to the root `CompositePodGroup`. The scheduler evaluates the entire
+hierarchy of groups as a single, unified scheduling unit.
+
+### Hierarchical scheduling cycle execution
+
+After observing a root `CompositePodGroup`, the scheduler places it in the scheduling queue as long
+as there is at least one pending Pod that belongs to that root's group hierarchy.
+
+Once the root `CompositePodGroup` satisfies the
+[hierarchical quorum](/docs/concepts/scheduling-eviction/gang-scheduling/#Hierarchical-quorum), it
+enters the active scheduling queue from which it can be popped by the scheduling cycle. The flow of
+the scheduling cycle for `CompositePodGroups` is as follows:
+
+1. **Unified cluster snapshot and validation**: The scheduler takes a snapshot of cluster resources
+   to mirror the latest observed cluster state. It verifies that the shape of the group hierarchy
+   popped from the queue matches the snapshotted hierarchy and validates the configuration
+   consistency of the hierarchy (such as identical `.spec.schedulerName` and priority across member
+   Pods).
+   
+   If the hierarchy shape changed concurrently or fails the validation, the cycle halts and requeues
+   the root `CompositePodGroup`.
+
+2. **Top-down candidate placement generation**: At each level of the hierarchy, before evaluating
+   child groups, the scheduler invokes `PlacementGeneratePlugin` plugins to generate candidate
+   placements (subsets of nodes) for the group being evaluated.
+   
+   Candidate placements for a child `CompositePodGroup` or leaf `PodGroup` are generated exclusively
+   from the subset of nodes belonging to the parent group's currently evaluated placement. For the
+   root `CompositePodGroup`, candidate placements are generated across all available cluster nodes.
+
+3. **Recursive subtree simulation and feasibility check**: The scheduler evaluates each candidate
+   placement for a `CompositePodGroup` by temporarily assuming that placement in the cluster
+   snapshot and recursively scheduling its child groups:
+   * **Recursive traversal**: The scheduler traverses child groups in a pre-sorted order, invoking
+     itself recursively from the `CompositePodGroup` down to leaf `PodGroup` objects. For each leaf
+     `PodGroup`, the scheduler runs the placement scheduling algorithm scoped to the parent's
+     candidate placement to make tentative Pod assignments in memory.
+   * **Feasibility checks**: After evaluating each child group, the scheduler invokes
+     `PlacementFeasible` plugins to determine whether the parent group's scheduling policy can
+     still be met:
+     * If the policy constraints remain achievable (or are already satisfied), the scheduler continues
+       evaluating subsequent sibling groups.
+     * If the policy constraints can no longer be satisfied, the scheduler immediately aborts the evaluation
+       of that `CompositePodGroup` and reverts all tentative in-memory Pod assignments made for that group.
+   * **Simulation rollback**: After simulating a candidate placement (regardless of success or failure),
+     the scheduler reverts the tentative node reservations made during that simulation before
+     evaluating the next candidate placement.
+
+4. **Placement scoring and subtree commitment**: Once all candidate placements for a
+   `CompositePodGroup` have been evaluated:
+   * **Scoring**: If one or more candidate placements are feasible, the scheduler invokes
+     `PlacementScorePlugin` plugins to score all feasible candidate placements. The scoring plugins
+     evaluate the combined proposed Pod assignments across all descendant leaf `PodGroup` objects in
+     the subtree and select the placement with the highest overall score.
+   * **Commitment**: After selecting the winning placement, the scheduler commits (assumes) the
+     tentative Pod assignments corresponding to that optimal placement in memory. This ensures that
+     subsequent sibling group evaluations or parent-level evaluations observe consistent, optimal
+     scheduling decisions for that subtree.
+     
+     If no feasible placement is found among all generated candidates, the entire `CompositePodGroup`
+     is considered unschedulable.
+
+5. **Atomic binding**: If the root-level recursive evaluation succeeds and at least one Pod was
+   successfully scheduled, the scheduler commits the Pod assignments by proceeding to the binding
+   cycle.
+
+   Otherwise, the entire `CompositePodGroup` is considered unschedulable.
+
+### Limitations
+
+Similar to how the PodGroup scheduling algorithm relies on specific Pod sorting, the hierarchical
+scheduling algorithm relies on a specific sorting of child groups within every `CompositePodGroup`
+hierarchy. As a result, it may fail to find a valid placement that could have been discovered by
+processing the child groups in a different order.
+
+In addition, because the scheduler evaluates group hierarchies using a greedy approach:
+
+* Finding a valid placement is not guaranteed in all cases, even if one exists in the cluster.
+* Even when the scheduler successfully finds a valid placement for a `CompositePodGroup` hierarchy,
+  that placement is not guaranteed to be optimal across the cluster.
+
 ## PodGroup conditions
 
 After a PodGroup scheduling cycle completes, the scheduler updates conditions on the
@@ -163,8 +254,18 @@ You can check conditions with:
 kubectl get podgroup <name> -o jsonpath='{.status.conditions}'
 ```
 
+## CompositePodGroup conditions
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+CompositePodGroup API exposes the `status.conditions` field as well.
+
+In v1.37, the scheduler does not populate this field, however.
+
 ## {{% heading "whatsnext" %}}
 
 * Learn about the [Workload API](/docs/concepts/workloads/workload-api/).
+* Read about the [CompositePodGroup API](/docs/concepts/workloads/compositepodgroup-api/) and its [lifecycle](/docs/concepts/workloads/compositepodgroup-api/lifecycle/).
+* Learn about [Topology-aware workload scheduling](/docs/concepts/workloads/workload-api/topology-aware-scheduling/).
 * See how to [reference a Workload](/docs/concepts/workloads/pods/workload-reference/) in a Pod.
 * Read about [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/).

--- a/content/en/docs/concepts/scheduling-eviction/topology-aware-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-aware-scheduling.md
@@ -70,6 +70,51 @@ profiles:
                 weight: 3
 ```
 
+## Multi-level topology placements
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
+are enabled, the Topology-Aware Scheduling plugins extend their support to multi-level
+`CompositePodGroup` hierarchies. These plugins are called for `CompositePodGroups` during
+[hierarchical scheduling](/docs/concepts/scheduling-eviction/podgroup-scheduling).
+
+### Candidate placement generation
+
+For workloads defined with a `CompositePodGroup` hierarchy, the `TopologyPlacement` plugin generates
+candidate placements top-down across the group hierarchy by successive subdivision:
+
+* For a root `CompositePodGroup`, `TopologyPlacement` generates candidate placements across all
+  available cluster nodes by grouping nodes based on the distinct values of the requested topology
+  `key`.
+* For a child `CompositePodGroup` or leaf `PodGroup`, `TopologyPlacement` generates candidate
+  placements confined in the placement assumed by the parent group. It subdivides the set of nodes
+  from the parent group's placement by grouping those nodes based on the child group's requested
+  topology `key`.
+
+{{< note >}}
+If a topology constraint is not specified, the `TopologyPlacement` plugin generates a single
+candidate placement equivalent to the parent placement.
+
+Similarly, if the root group does not specify any topology constraint, the plugin generates a single
+candidate placement corresponding to all available nodes in the cluster. This is also true for
+single-level workloads using the `PodGroup` API where no topology constraint is specified.
+{{< /note >}}
+
+### Placement scoring
+
+When scoring a candidate placement for a `CompositePodGroup`, the scoring plugins apply similar
+logic to the single-level `PodGroup` case:
+
+* `PodGroupPodsCount`: Scores candidate placements based on the total number of Pods (both
+  already scheduled and newly assumed) across all descendant leaf `PodGroups` of that
+  `CompositePodGroup`. Candidate placements capable of accommodating a higher total number of Pods
+  across the subhierarchy receive higher scores.
+* `NodeResourcesFit`: Aggregates the resource requests of all proposed Pods across all descendant
+  `PodGroups` of that `CompositePodGroup` and evaluates resource utilization across all nodes within
+  the candidate placement's domain.
+
 ## {{% heading "whatsnext" %}}
 
 * Learn more about [Topology-aware scheduling API](/docs/concepts/workloads/workload-api/topology-aware-scheduling/).

--- a/content/en/docs/concepts/scheduling-eviction/workload-aware-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/workload-aware-preemption.md
@@ -56,6 +56,36 @@ and it attempts to preempt a Pod belonging to a PodGroup, it does **not**
 respect the `priority` or `disruptionMode` fields of that PodGroup.
 {{< /note >}}
 
+### Preemption for CompositePodGroups
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
+are enabled, workload-aware preemption provides support for `CompositePodGroups` as well.
+
+The underlying preemption mechanism is the same as for `PodGroups` - if the scheduler needs to free
+up capacity to place the root `CompositePodGroup`, it evaluates preemption for the entire group
+hierarchy, rather than for individual pods.
+
+`CompositePodGroups` can be selected as preemption victims as well. The victim selection process is
+adjusted to take `CompositePodGroups` into account in the following way:
+
+1. Victim importance hierarchy:
+   - `CompositePodGroups` are considered more important than standalone `PodGroups` of the same
+     priority.
+   - For two `CompositePodGroups` of the same priority, the one with more members (larger size) is
+     considered more important.
+
+2. Disruption mode: Similar to `PodGroups`, `CompositePodGroups` specify
+   [disruption mode](/docs/concepts/workloads/workload-api/disruption-and-priority/) that determines
+   how its child groups should be treated during preemption.
+
+Besides workload-aware preemption, `CompositePodGroups` can be selected as preemption victims by
+default Pod preemption during Pod scheduling cycle, alongside `PodGroups` and Pods. Default Pod
+preemption shares the victim importance hierarchy logic with the workload-aware preemption and
+respects the `disruptionMode` field of `CompositePodGroups`.
+
 ## {{% heading "whatsnext" %}}
 
 * Learn more about [PodGroup Priority and Disruption](/docs/concepts/workloads/workload-api/disruption-and-priority/).

--- a/content/en/docs/concepts/workloads/compositepodgroup-api/_index.md
+++ b/content/en/docs/concepts/workloads/compositepodgroup-api/_index.md
@@ -1,0 +1,214 @@
+---
+title: CompositePodGroup API
+weight: 25
+no_list: true
+---
+
+<!-- overview -->
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+A `CompositePodGroup` is a runtime object that represents a non-leaf node in a multi-level workload
+hierarchy. While the [Workload API](/docs/concepts/workloads/workload-api/) defines static scheduling
+policy templates, `CompositePodGroup` and `PodGroup` objects are the runtime counterparts that
+carry policies and hierarchy references for a specific workload instance.
+
+<!-- body -->
+
+## What is a CompositePodGroup?
+
+The `CompositePodGroup` API resource is part of the `scheduling.k8s.io/v1alpha3`
+{{< glossary_tooltip text="API group" term_id="api-group" >}}. Your cluster must have that API
+group enabled, as well as the `CompositePodGroup`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
+before you can use this API.
+
+A `CompositePodGroup` represents a grouping of child groups (which can be `CompositePodGroup` or
+`PodGroup` objects). It carries scheduling policies, disruption modes, priority
+settings, and optional topology constraints that apply collectively across its child groups.
+
+## API structure
+
+A `CompositePodGroup` consists of a `spec` that defines the desired scheduling behavior
+for its child groups, and a `status` subresource.
+
+### Scheduling policy
+
+Each `CompositePodGroup` carries a [scheduling policy](/docs/concepts/workloads/workload-api/policies/)
+(`basic` or `gang`) in `spec.schedulingPolicy`. When a workload controller creates a
+`CompositePodGroup`, this policy is copied from the `Workload`'s `CompositePodGroupTemplate`
+at creation time.
+
+For a `gang` policy on a `CompositePodGroup`, the `minGroupCount` field specifies the
+minimum number of child groups that must be schedulable simultaneously:
+
+```yaml
+spec:
+  schedulingPolicy:
+    gang:
+      minGroupCount: 2
+```
+
+### Parent group reference
+
+Non-root `CompositePodGroup` resources specify their parent group using
+`spec.parentCompositePodGroupName`. Root `CompositePodGroup` objects leave this field unset.
+
+```yaml
+spec:
+  parentCompositePodGroupName: root-group-0
+```
+
+### Workload reference
+
+The `spec.workloadRef` field links the `CompositePodGroup` back to the
+`CompositePodGroupTemplate` in the `Workload` object it was derived from.
+
+```yaml
+spec:
+  workloadRef:
+    workloadName: hierarchical-workload
+    templateName: replica-group
+```
+
+### Status
+
+The `CompositePodGroup` API schema includes a `status` subresource. In the alpha release,
+the `status` field is present in the API type, but `kube-scheduler` does not update or
+populate status conditions for `CompositePodGroup` objects. Status tracking for composite
+groups will be implemented in future releases.
+
+## Creating a CompositePodGroup
+
+Workload controllers create `CompositePodGroup` objects automatically from `Workload`
+templates at runtime.
+
+The following manifest creates a root `CompositePodGroup` with a gang scheduling policy
+that requires at least 2 child groups to be schedulable simultaneously:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: CompositePodGroup
+metadata:
+  name: root-group-0
+  namespace: default
+spec:
+  workloadRef:
+    workloadName: hierarchical-workload
+    templateName: root
+  schedulingPolicy:
+    gang:
+      minGroupCount: 2
+```
+
+You can inspect `CompositePodGroup` resources in your cluster:
+
+```shell
+kubectl get compositepodgroups
+```
+
+To view details for a specific composite group:
+
+```shell
+kubectl describe compositepodgroup root-group-0
+```
+
+## How it fits together
+
+The relationship between controllers, Workloads, CompositePodGroups, PodGroups, and
+Pods follows this pattern:
+
+1. The workload controller creates a `Workload` defining a tree of
+   `CompositePodGroupTemplates` and leaf `PodGroupTemplates`.
+2. For each runtime instance, the controller creates a root `CompositePodGroup`,
+   descendant `CompositePodGroup` objects, and leaf `PodGroup` objects in a top-down manner.
+3. The controller creates `Pods` that reference their leaf `PodGroup` via
+   `spec.schedulingGroup.podGroupName`.
+
+The following example illustrates a complete manifest hierarchy for a two-level workload:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: Workload
+metadata:
+  name: hierarchical-workload
+  namespace: default
+spec:
+  compositePodGroupTemplates:
+  - name: root
+    schedulingPolicy:
+      gang:
+        minGroupCount: 2
+    podGroupTemplates:
+    - name: workers-a
+      schedulingPolicy:
+        gang:
+          minCount: 4
+    - name: workers-b
+      schedulingPolicy:
+        gang:
+          minCount: 4
+---
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: CompositePodGroup
+metadata:
+  name: root-group-0
+  namespace: default
+spec:
+  workloadRef:
+    workloadName: hierarchical-workload
+    templateName: root
+  schedulingPolicy:
+    gang:
+      minGroupCount: 2
+---
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: PodGroup
+metadata:
+  name: workers-a-0
+  namespace: default
+spec:
+  parentCompositePodGroupName: root-group-0
+  workloadRef:
+    workloadName: hierarchical-workload
+    templateName: workers-a
+  schedulingPolicy:
+    gang:
+      minCount: 4
+---
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: PodGroup
+metadata:
+  name: workers-b-0
+  namespace: default
+spec:
+  parentCompositePodGroupName: root-group-0
+  workloadRef:
+    workloadName: hierarchical-workload
+    templateName: workers-b
+  schedulingPolicy:
+    gang:
+      minCount: 4
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: worker-a-0
+  namespace: default
+spec:
+  schedulingGroup:
+    podGroupName: workers-a-0
+  containers:
+  - name: worker
+    image: registry.k8s.io/pause:3.9
+```
+
+The `Workload` acts as a long-lived policy template, while `CompositePodGroup` and
+`PodGroup` resources handle per-instance runtime scheduling state.
+
+## {{% heading "whatsnext" %}}
+
+* Read about the [CompositePodGroup lifecycle](/docs/concepts/workloads/compositepodgroup-api/lifecycle/).
+* Learn about the [Workload API](/docs/concepts/workloads/workload-api/) and template definitions.
+* See how leaf groups are structured in the [PodGroup API](/docs/concepts/workloads/podgroup-api/).
+* Read about [PodGroup scheduling policies](/docs/concepts/workloads/workload-api/policies/).
+* Learn about [Workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/).

--- a/content/en/docs/concepts/workloads/compositepodgroup-api/lifecycle.md
+++ b/content/en/docs/concepts/workloads/compositepodgroup-api/lifecycle.md
@@ -1,0 +1,70 @@
+---
+title: CompositePodGroup Lifecycle
+content_type: concept
+weight: 10
+---
+
+<!-- overview -->
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+A [CompositePodGroup](/docs/concepts/workloads/compositepodgroup-api/) represents a non-leaf node
+in a multi-level `PodGroup` hierarchy. Unlike `PodGroup` resources, `CompositePodGroup` resources do
+not directly contain Pods. Instead, they maintain a hierarchy of descendant `CompositePodGroup` and
+`PodGroup` objects and carry scheduling policies that apply to its children groups.
+
+<!-- body -->
+
+## Ownership and garbage collection
+
+A `CompositePodGroup` object, together with its descendant `CompositePodGroup` and `PodGroup`
+resources, is owned by the workload controller that created it via Kubernetes `ownerReferences`.
+When the owning workload object gets deleted, cascading garbage collection automatically deletes the
+associated group hierarchy.
+
+`CompositePodGroup` names must be unique within a namespace and must be valid
+[DNS subdomains](/docs/concepts/overview/working-with-objects/names#dns-subdomain-names).
+
+## Creation ordering
+
+To ensure proper hierarchy resolution and scheduling, workload controllers create resources in a
+top-down order:
+
+1. **`Workload`**: Defines static templates (`CompositePodGroupTemplates` and `PodGroupTemplates`).
+2. **Root `CompositePodGroup`**: Created with `spec.workloadRef` pointing to the root template in
+   the `Workload`.
+3. **Descendant `CompositePodGroups` and `PodGroups`**: Created top-down. Each child group specifies
+   its parent by using `spec.parentCompositePodGroupName` and its template using `spec.workloadRef`.
+4. **`Pods`**: Created with `spec.schedulingGroup.podGroupName` pointing to their leaf `PodGroup`.
+
+If a group references a parent `CompositePodGroup` that does not exist, or if a Pod references
+a `PodGroup` that has not yet been created, the scheduler holds off scheduling until all parent
+resources in the hierarchy exist.
+
+## Limitations and validation rules
+
+- **Consistent scheduler name**: All Pods across an entire `CompositePodGroup` hierarchy must use
+  the same `spec.schedulerName`. If a mismatch is detected, the scheduler rejects the hierarchy as
+  unschedulable.
+- **Consistent priority**: All Pods across an entire `CompositePodGroup` hierarchy must specify the
+  same value of `spec.priority` which must be equal to the priority specified by the root group. If
+  a mismatch is detected, the scheduler rejects the hierarchy as unschedulable.
+- **Consistent preemption policy**: All Pods across an entire `CompositePodGroup` hierarchy must use
+  the same `spec.preemptionPolicy`. In addition, when the
+  [PodGroupPreemptionPolicy](/docs/reference/command-line-tools-reference/feature-gates/podgroup-preemption-policy/)
+  feature gate is enabled, the root group's preemption policy must be equal to the one specified by
+  the Pods. If a mismatch is detected, the scheduler rejects the hierarchy as unschedulable.
+- **Maximum nesting depth**: The group-template hierarchy supports a maximum depth of 4 levels.
+- **List item limit**: The maximum number of child `CompositePodGroupTemplates` and
+  `PodGroupTemplates` at any level of a `Workload` is 8.
+- **Immutable gang group count**: The `spec.schedulingPolicy.gang.minGroupCount` field on a
+  `CompositePodGroup` is immutable after creation.
+- **Immutable hierarchy references**: `spec.parentCompositePodGroupName` on groups and
+  `spec.schedulingGroup` on Pods are immutable once set.
+
+## {{% heading "whatsnext" %}}
+
+* Read the [CompositePodGroup API](/docs/concepts/workloads/compositepodgroup-api/) overview.
+* Learn about the [Workload API](/docs/concepts/workloads/workload-api/) and template definitions.
+* See how leaf groups are structured in the [PodGroup API](/docs/concepts/workloads/podgroup-api/).
+* Read about [PodGroup scheduling policies](/docs/concepts/workloads/workload-api/policies/).
+* Learn about [Workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/).

--- a/content/en/docs/concepts/workloads/podgroup-api/_index.md
+++ b/content/en/docs/concepts/workloads/podgroup-api/_index.md
@@ -198,6 +198,26 @@ The Workload acts as a long-lived policy definition, while PodGroups handle the
 transient, per-instance runtime state. This separation means that status updates for
 individual PodGroups do not contend on the shared Workload object.
 
+## Parent group
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate is enabled, a `PodGroup` can act as a leaf node in a multi-level group hierarchy that
+consists of `PodGroups` and `CompositePodGroups`. A `PodGroup` can specify its parent group using the
+`spec.parentCompositePodGroupName` field. Organizing a workload into a hierarchy of groups can be
+used to express multi-level gang scheduling requirements, multi-level topology constraints and
+disruption fate-sharing across parts of the workload.
+
+For more details on hierarchical group structures and multi-level gang scheduling, see the
+[CompositePodGroup API](/docs/concepts/workloads/compositepodgroup-api/) overview.
+
+{{< note >}}
+A `PodGroup` that specifies `spec.parentCompositePodGroupName` must also specify `spec.workloadRef`,
+linking the `PodGroup` back to its template in the `Workload`. Standalone `PodGroup` objects
+(created without a `spec.workloadRef`) are not allowed to specify a parent `CompositePodGroup`.
+{{< /note >}}
+
 ## {{% heading "whatsnext" %}}
 
 * Learn about the [PodGroup lifecycle](/docs/concepts/workloads/podgroup-api/lifecycle/) in detail.

--- a/content/en/docs/concepts/workloads/pods/scheduling-group.md
+++ b/content/en/docs/concepts/workloads/pods/scheduling-group.md
@@ -48,16 +48,26 @@ When you set `spec.schedulingGroup`, the scheduler looks up the referenced
   lifecycle. The scheduler tries to place at least `minCount` `Pods` in the group
   simultaneously; none of them bind to nodes unless the minimum is met.
 
-## Missing PodGroup reference
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate is enabled, a `PodGroup` may also specify a parent `CompositePodGroup`. In a hierarchical
+workload, scheduling is governed by policies defined across the entire group tree (such as multi-level
+gang scheduling or topology constraints).
+
+## Missing group references
 
 If a `Pod` references a `PodGroup` that does not yet exist, the `Pod` remains pending.
-The scheduler automatically reconsiders the `Pod` once the `PodGroup` is created.
+Similarly, if the referenced `PodGroup` specifies a parent `CompositePodGroup` (via
+`spec.parentCompositePodGroupName`) that has not been created yet, scheduling does not start and
+the `Pod` remains pending until the entire group hierarchy exists in the cluster.
 
-This applies regardless of whether the eventual policy is `basic` or `gang`,
-because the scheduler requires the `PodGroup` to determine the policy.
+The scheduler automatically reconsiders the `Pod` once all required `PodGroup` and
+`CompositePodGroup` resources exist.
 
 ## {{% heading "whatsnext" %}}
 
 * Learn about the [PodGroup API](/docs/concepts/workloads/podgroup-api/) and its lifecycle.
+* Read about the [CompositePodGroup API](/docs/concepts/workloads/compositepodgroup-api/).
 * Read about [PodGroup scheduling policies](/docs/concepts/workloads/workload-api/policies/).
 * Understand the [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/) algorithm.

--- a/content/en/docs/concepts/workloads/workload-api/_index.md
+++ b/content/en/docs/concepts/workloads/workload-api/_index.md
@@ -79,6 +79,96 @@ The `controllerRef` field links the Workload back to the specific high-level obj
 such as a [Job](/docs/concepts/workloads/controllers/job/) or a custom CRD. This is useful for observability and tooling.
 This data is not used to schedule or manage the Workload.
 
+### CompositePodGroupTemplates
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
+are enabled, you can use `CompositePodGroupTemplates` to define multi-level, hierarchical scheduling
+requirements in a `Workload`. These requirements can include enforcing nested topology constraints
+across different layers of cluster infrastructure (multi-level topology-aware scheduling),
+all-or-nothing scheduling across child groups (multi-level gang scheduling), or group-level
+disruption policies.
+
+`CompositePodGroupTemplates` can be defined using the `spec.compositePodGroupTemplates` field in the
+`Workload` API. At runtime, workload controllers create [CompositePodGroup](/docs/concepts/workloads/compositepodgroup-api/)
+and [PodGroup](/docs/concepts/workloads/podgroup-api/) objects from these templates to maintain the runtime
+scheduling state of the hierarchy. While `PodGroup` objects manage groups of Pods at the leaves,
+`CompositePodGroup` objects represent non-leaf groups that enforce scheduling policies across child groups.
+
+{{< note >}}
+In a `Workload` specification, `spec.compositePodGroupTemplates` and `spec.podGroupTemplates`
+fields form a union: a `Workload` must define either `spec.podGroupTemplates` (for flat
+workloads) or `spec.compositePodGroupTemplates` (for hierarchical workloads), but cannot
+specify both.
+{{< /note >}}
+
+#### Structure and constraints
+
+The `spec.compositePodGroupTemplates` field defines non-leaf templates in a group-template
+hierarchy tree. Each entry represents a template for a `CompositePodGroup` and can contain:
+
+- **Child templates**: Nested `CompositePodGroupTemplates` (for intermediate non-leaf
+  groups) or `PodGroupTemplates` (for leaf groups containing Pods).
+- **Scheduling policy**: Specifies how child groups within this composite group are
+  scheduled:
+  - `basic`: Child groups are admitted and scheduled independently.
+  - `gang`: Enforces multi-level all-or-nothing scheduling across child groups.
+    Requires `minGroupCount`, which specifies the minimum number of child groups
+    that must be schedulable simultaneously for the composite group to be feasible.
+- **Scheduling constraints**: Optional
+  [topology constraints](/docs/concepts/workloads/workload-api/topology-aware-scheduling/)
+  for multi-level topology-aware scheduling.
+- **Priority, preemption policy and disruption mode**: Optional `priorityClassName`,
+  `disruptionMode` (`Single` or `All`) and `preemptionPolicy` for
+  [workload-aware preemption](/docs/concepts/workloads/workload-api/disruption-and-priority/).
+
+To ensure cluster stability and control-plane efficiency, the group-template hierarchy
+enforces the following limits:
+
+- **Maximum nesting depth**: The group-template hierarchy supports a maximum depth of
+  4 levels.
+- **List limit**: Every `compositePodGroupTemplates` and `podGroupTemplates` list is strictly
+  capped at a maximum of 8 items.
+
+{{< note >}}
+Right now, you cannot add new or remove existing `CompositePodGroupTemplates`. You can only change
+the `minCount` value in the gang scheduling policy defined in the leaf `PodGroupTemplates`.
+{{< /note >}}
+
+#### Example
+
+The following example defines a hierarchical `Workload` with a `CompositePodGroup` template
+that enforces gang scheduling across two child `PodGroup` templates (`minGroupCount: 2`),
+each specifying its own gang scheduling policy:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: Workload
+metadata:
+  name: gang-of-gangs-workload
+  namespace: default
+spec:
+  compositePodGroupTemplates:
+  - name: root
+    schedulingPolicy:
+      gang:
+        # Requires both child PodGroups to be schedulable together
+        minGroupCount: 2
+    podGroupTemplates:
+    - name: workers-a
+      schedulingPolicy:
+        gang:
+          # Requires 4 Pods in this group to be schedulable
+          minCount: 4
+    - name: workers-b
+      schedulingPolicy:
+        gang:
+          # Requires 4 Pods in this group to be schedulable
+          minCount: 4
+```
+
 ## Gang scheduling with Jobs
 
 {{< feature-state feature_gate_name="WorkloadWithJob" >}}

--- a/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
+++ b/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
@@ -37,6 +37,30 @@ allowing independent disruption of a single pod from a PodGroup.
 The `PodGroup` mode emphasizes "all-or-nothing" semantics for disruption.
 It instructs the scheduler that all pods from the PodGroup have to be disrupted together.
 
+## CompositePodGroup
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+A `CompositePodGroup` can also declare a `disruptionMode` in its specification, which controls
+how the scheduler disrupts child groups within the composite group during preemption events.
+
+The API supports two disruption modes for `CompositePodGroups`:
+
+- **`Single`**: Allows individual child groups within the `CompositePodGroup` to be disrupted
+  independently during preemption.
+- **`All`**: Enforces all-or-nothing disruption semantics across the `CompositePodGroup` hierarchy.
+  If any Pod contained in the hierarchy below this `CompositePodGroup` has to be preempted, all of
+  the Pods from the entire hierarchy must be preempted.
+
+If not specified, the mode defaults to `Single`.
+
+{{< note >}}
+In v1.37, a group can set its disruption mode to `All` and have child groups that have a mode set to
+`Single`. In such case, the top-level `All` mode overrides the descendant `Single` modes.
+
+This configuration is discouraged due to unclear semantics.
+{{< /note >}}
+
 ## Pod group priority
 
 PodGroup uses the same concept of [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) as single Pods.
@@ -62,6 +86,52 @@ metadata:
 spec:
   priorityClassName: high-priority
 ```
+
+### CompositePodGroup priority
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+`CompositePodGroup` API has `priorityClassName` and `priority` fields as well and their resolution
+is performed in the same way as for the `PodGroups`, through the priority admission controller.
+
+The priority of a root `CompositePodGroup` acts as the authoritative priority for all child groups
+and Pods within its hierarchy during
+[workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) events.
+All Pods within a single group hierarchy must share the exact same priority and must be equal to the
+priority of the root `CompositePodGroup`.
+
+The value of priority is also used for the ordering of root `CompositePodGroups` in the scheduling
+active queue.
+
+{{< note >}}
+In v1.37, the scheduler doesn't validate if the non-root groups have priority value that is equal to
+the priority of the root `CompositePodGroup`.
+{{< /note >}}
+
+### PreemptionPolicy in CompositePodGroup
+
+{{< feature-state feature_gate_name="PodGroupPreemptionPolicy" >}}
+
+The `CompositePodGroup` API has the `preemptionPolicy` field as well and its resolution is performed
+in the exact same way as for the `PodGroup` API.
+
+The value of `preemptionPolicy` of the root `CompositePodGroup` determines whether
+[workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) can be
+invoked to fit its Pods during scheduling if needed:
+
+- `PreemptLowerPriority` policy allows preempting victims with lower priority,
+- `Never` policy disables workload-aware preemption for that root `CompositePodGroup`.
+
+All Pods within a single group hierarchy must share the exact same preemption policy which must be
+equal to the preemption policy of the root `CompositePodGroup`.
+
+If the feature flag is disabled, the root `CompositePodGroup` will be allowed to perform preemption
+unless one of the Pods that belongs to the group hierarchy has `preemptionPolicy` set to `Never`.
+
+{{< note >}}
+In v1.37, when the feature gate is enabled, the scheduler doesn't validate if the non-root groups
+have preemption policy that is equal to the preemption policy of the root `CompositePodGroup`.
+{{< /note >}}
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/workloads/workload-api/policies.md
+++ b/content/en/docs/concepts/workloads/workload-api/policies.md
@@ -66,6 +66,45 @@ Workload's templates only affect newly created PodGroups, not existing ones.
 For standalone PodGroups (created without a Workload), you set `spec.schedulingPolicy`
 directly on the PodGroup itself.
 
+## Policies in CompositePodGroups
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
+are enabled, `CompositePodGroupTemplates` in a Workload and the `CompositePodGroup` objects also
+declare a scheduling policy.
+
+While a scheduling policy in a `PodGroup` governs a collection of individual Pods, a
+`CompositePodGroup` scheduling policy governs its direct **child groups** (which can be both
+`CompositePodGroup` and `PodGroup` objects).
+
+### Policy types for CompositePodGroups
+
+Similar to `PodGroups`, the `spec.schedulingPolicy` field of a `CompositePodGroup` supports two
+types:
+
+- **`basic`**: Child groups within the `CompositePodGroup` are evaluated and admitted independently.
+- **`gang`**: Enforces multi-level all-or-nothing scheduling across child groups. The
+  `CompositePodGroup` is schedulable only if at least `minGroupCount` child groups can be scheduled
+  simultaneously.
+
+```yaml
+schedulingPolicy:
+  gang:
+    # The minimum number of child groups that must be schedulable
+    # simultaneously for this composite group to be admitted.
+    minGroupCount: 2
+```
+
+### Setting composite policies via templates
+
+When using the [Workload API](/docs/concepts/workloads/workload-api/), scheduling policies for
+`CompositePodGroups` are defined inside `CompositePodGroupTemplates`. Workload controllers copy the
+`schedulingPolicy` specified in the templates into each `CompositePodGroup` created at runtime.
+Unlike leaf `PodGroupTemplates` where `minCount` can be updated, `minGroupCount` in a
+`CompositePodGroupTemplate` is immutable.
+
 ## {{% heading "whatsnext" %}}
 
 * See the [PodGroup API](/docs/concepts/workloads/podgroup-api/) for how policies are carried at runtime.

--- a/content/en/docs/concepts/workloads/workload-api/topology-aware-scheduling.md
+++ b/content/en/docs/concepts/workloads/workload-api/topology-aware-scheduling.md
@@ -85,6 +85,171 @@ spec:
       - key: topology.example.com/rack
 ```
 
+## Multi-level topology-aware scheduling
+
+{{< feature-state feature_gate_name="CompositePodGroup" >}}
+
+Complex workloads might require co-location of their Pods at different levels of the cluster
+infrastructure. For example, an entire workload may need to run within a single availability zone,
+while different parts of that workload may require strict co-location within specific server racks.
+
+Such multi-level co-location requirements can be expressed using the `CompositePodGroup` API and
+by specifying topology constraints at different levels of a group hierarchy.
+
+Using the `CompositePodGroup` API requires enabling the
+[`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+feature gate and the
+`scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}.
+
+### Multi-level topology constraints resolution
+
+Every group inside a `CompositePodGroup` hierarchy can specify a topology constraint which
+guarantees that all descendant Pods of that group will be scheduled in the same topology domain,
+matching that group's constraint.
+
+During [hierarchical scheduling](/docs/concepts/scheduling-eviction/podgroup-scheduling), the
+scheduler resolves these constraints in a **top-down** manner. Specifically, topology domains that
+are considered during scheduling of a child group are confined within a topology domain that
+corresponds to the placement assumed by the parent group.
+
+Kubernetes does not impose any strict requirements on the physical hierarchy of topology labels - topology
+keys are arbitrary node labels. However, the order in which you specify topology constraints from
+parent to child determines the order in which the scheduler subdivides topology domains.
+
+{{< note >}}
+As of Kubernetes v1.37, you can specify only a single topology constraint in each
+`CompositePodGroup`.
+{{< /note >}}
+
+### Example
+
+The following example configures a `Workload` where the parent `CompositePodGroupTemplate`
+constrains the entire workload to a single availability zone (`topology.example.com/zone`), while
+two child `PodGroupTemplate` entries (`workers` and `driver`) constrain their respective
+Pods to server racks (`topology.example.com/rack`) within that zone:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: Workload
+metadata:
+  name: example-workload
+spec:
+  compositePodGroupTemplates:
+  - name: root
+    schedulingPolicy:
+      gang:
+        minGroupCount: 2
+    schedulingConstraints:
+      topology:
+      - key: topology.example.com/zone
+    podGroupTemplates:
+    - name: workers
+      schedulingPolicy:
+        gang:
+          minCount: 8
+      schedulingConstraints:
+        topology:
+        - key: topology.example.com/rack
+    - name: driver
+      schedulingPolicy:
+        gang:
+          minCount: 1
+      schedulingConstraints:
+        topology:
+        - key: topology.example.com/rack
+```
+
+After creating the `Workload` object, the corresponding group objects are created as follows:
+
+- Root `CompositePodGroup` referencing the `root` template.
+- Two child `PodGroup` objects (`workers` and `driver`), each referencing the root
+  `CompositePodGroup` as their parent group.
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: CompositePodGroup
+metadata:
+  name: workload-root
+spec:
+  workloadRef:
+    workloadName: example-workload
+    templateName: root
+  schedulingPolicy:
+    gang:
+      minGroupCount: 2
+  schedulingConstraints:
+    topology:
+    - key: topology.example.com/zone
+---
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PodGroup
+metadata:
+  name: workload-workers
+spec:
+  parentCompositePodGroupName: workload-root
+  workloadRef:
+    workloadName: example-workload
+    templateName: workers
+  schedulingPolicy:
+    gang:
+      minCount: 8
+  schedulingConstraints:
+    topology:
+    - key: topology.example.com/rack
+---
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PodGroup
+metadata:
+  name: workload-driver
+spec:
+  parentCompositePodGroupName: workload-root
+  workloadRef:
+    workloadName: example-workload
+    templateName: driver
+  schedulingPolicy:
+    gang:
+      minCount: 1
+  schedulingConstraints:
+    topology:
+    - key: topology.example.com/rack
+```
+
+During scheduling, the scheduler first selects an availability zone for `workload-root`. It then
+subdivides the nodes in that zone by rack to find feasible rack placements for `workload-workers`
+and `workload-driver` within the selected zone.
+
+For example, consider a cluster with five nodes labeled as follows:
+
+| Node | `topology.example.com/zone` | `topology.example.com/rack` |
+| --- | --- | --- |
+| `node-a` | `zone-1` | `rack-1` |
+| `node-b` | `zone-1` | `rack-1` |
+| `node-c` | `zone-1` | `rack-2` |
+| `node-d` | `zone-2` | `rack-1` |
+| `node-e` | `zone-2` | `rack-3` |
+
+When processing `workload-root`, the scheduler evaluates candidate placements across all cluster
+nodes based on the `topology.example.com/zone` topology key:
+
+| Evaluated candidate placement | Nodes in candidate placement |
+| --- | --- |
+| `zone-1` | `node-a`, `node-b`, `node-c` |
+| `zone-2` | `node-d`, `node-e` |
+
+When evaluating candidate placements for `workload-workers`, the scheduler subdivides only the nodes
+within the placement assumed by `workload-root` based on the `topology.example.com/rack` topology key:
+
+| Parent placement | Evaluated candidate placement | Nodes in candidate placement |
+| --- | --- | --- |
+| `zone-1` | `rack-1` | `node-a`, `node-b` |
+| `zone-1` | `rack-2` | `node-c` |
+| `zone-2` | `rack-1` | `node-d` |
+| `zone-2` | `rack-3` | `node-e` |
+
+Candidate placements generated for the sibling `workload-driver` PodGroup are identical to those
+generated for `workload-workers`, since both groups specify the same topology key
+(`topology.example.com/rack`).
+
 ## {{% heading "whatsnext" %}}
 
 * Learn about [pod group policies](/docs/concepts/workloads/workload-api/policies/).

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/CompositePodGroup.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/CompositePodGroup.md
@@ -1,0 +1,17 @@
+---
+title: CompositePodGroup
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.37"
+---
+
+Enable hierarchical gang scheduling for [CompositePodGroups](/docs/concepts/workloads/compositepodgroup-api/) and PodGroups.
+
+Enabling the `CompositePodGroup` feature gate requires that the `GenericWorkload` and `TopologyAwareWorkloadScheduling`
+feature gates are enabled as well.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/PodGroupPreemptionPolicy.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/PodGroupPreemptionPolicy.md
@@ -1,0 +1,16 @@
+---
+title: PodGroupPreemptionPolicy
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.37"
+---
+
+Enables the support for `PreemptionPolicy` field in [PodGroup API](/docs/concepts/workloads/podgroup-api/) and [Workload API](/docs/concepts/workloads/workload-api/).
+
+When enabled, if a PodGroup has `PreemptionPolicy: Never` it will not perform workload aware preemption.


### PR DESCRIPTION
### Description

Add docs related to CompositePodGroup API and update already existing WAS-specific docs to take the CompositePodGroup API into account.

### Issue

https://github.com/kubernetes/enhancements/issues/6012