### PR TITLE
Doc KEP-5996: Add kubelet configuration "defaultPodSysctls" in documentation

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DefaultPodSysctls.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DefaultPodSysctls.md
@@ -1,0 +1,14 @@
+---
+title: DefaultPodSysctls
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.37"
+---
+
+Enables the `defaultPodSysctls` field in [KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/), allowing Node administrators to specify a default set of namespaced kernel parameters (sysctls) that the `kubelet` applies to all Pods on the Node. See [Setting Sysctls for All Pods](/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-all-pods) for more details.

--- a/content/en/docs/reference/node/what-happens-on-restart.md
+++ b/content/en/docs/reference/node/what-happens-on-restart.md
@@ -75,6 +75,10 @@ containers against the desired state. During this period of time, the following 
   [kubernetes/kubernetes#123859](https://github.com/kubernetes/kubernetes/issues/123859)
   for the discussion and details.
 
+* If the kubelet configuration is updated, restarting the kubelet does not dynamically
+  reapply most configuration settings to already running Pods. Most updated settings
+  apply only to newly created Pods.
+
 Overall, in a healthy cluster a kubelet restart does not break running
 workloads. On large clusters with overcommitted nodes, however, the
 re-initialization load and the paused garbage collection and eviction can

--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -194,3 +194,93 @@ is recommended to use
 [_taints and toleration_ feature](/docs/reference/generated/kubectl/kubectl-commands/#taint) or
 [taints on nodes](/docs/concepts/scheduling-eviction/taint-and-toleration/)
 to schedule those pods onto the right nodes.
+
+## Setting Sysctls for All Pods
+
+{{< feature-state feature_gate_name="DefaultPodSysctls" >}}
+
+You can configure a default set of kernel parameters (sysctls) that the `kubelet`
+applies to all Pods running on a Linux Node, including {{< glossary_tooltip text="static Pods" term_id="static-pod" >}}.
+This is useful when Node administrators need to enforce consistent kernel parameter
+tuning across all workloads on a Node or within a Node group (for example,
+adjusting TCP buffer sizes for high-performance networking) without requiring
+every Pod specification to individually set `securityContext.sysctls`.
+
+To use this feature, enable the `DefaultPodSysctls`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
+for the `kubelet` and specify key-value pairs in the `defaultPodSysctls` field
+of your
+[KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/).
+
+The `defaultPodSysctls` field supports all namespaced sysctls (`kernel.shm*`,
+`kernel.msg*`, `kernel.sem`, `kernel.domainname`, `fs.mqueue.*`, `net.*`, and
+`user.*`), covering both _safe_ and _unsafe_ sysctls. Because these defaults
+are configured directly by the Node administrator on the `kubelet`, you do not
+need to allow-list unsafe sysctls in `allowedUnsafeSysctls`.
+
+The following example configures the `kubelet` to apply default sysctls across
+multiple namespaced subsystems (networking, IPC, and user namespaces) to all
+Pods on the Node:
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+featureGates:
+  DefaultPodSysctls: true
+defaultPodSysctls:
+  # Network namespace sysctls (skipped if Pod uses hostNetwork: true)
+  net.ipv4.ip_forward: "1"
+  net.ipv4.tcp_rmem: "4096 87380 16777216"
+  net.ipv4.tcp_wmem: "4096 65536 16777216"
+  net.core.somaxconn: "1024"
+  # IPC namespace sysctls (skipped if Pod uses hostIPC: true)
+  kernel.shmall: "1048576"
+  kernel.msgmax: "65536"
+  kernel.sem: "250 32000 32 128"
+  fs.mqueue.msg_max: "1024"
+  # User namespace sysctls (skipped if Pod shares the host user namespace)
+  user.max_user_namespaces: "1000"
+```
+
+### Precedence and Overriding
+
+Values explicitly set in a Pod's `spec.securityContext.sysctls` always override
+the matching default values specified in the `kubelet`'s `defaultPodSysctls`. Overrides
+are applied individually on a per-key basis: if a Pod specifies a value for a sysctl
+that is also defined in `defaultPodSysctls`, the Pod-level setting takes precedence
+for that specific sysctl, while other defaults continue to apply. Note that there are
+no groups of connected sysctl settings; if your workload overrides a sysctl that is part
+of a related group (for example, networking buffer sizes), the Pod specification must
+account for all related settings as needed.
+
+### Host Namespaces and Filtering
+
+The `kubelet` applies default sysctls during Pod sandbox creation only if the Pod
+runs in a separate namespace for the corresponding subsystem. If a Pod shares a
+host namespace, default sysctls for that namespace are skipped for that Pod:
+
+- `net.*` sysctls are skipped if the Pod uses host networking (`hostNetwork: true`).
+- IPC sysctls (`kernel.sem`, `kernel.msg*`, `kernel.shm*`, `fs.mqueue.*`) are
+  skipped if the Pod uses host IPC (`hostIPC: true`).
+- `user.*` sysctls are skipped if the Pod shares the host user namespace
+  (`hostUsers: true` or unset).
+- UTS sysctls (`kernel.domainname`) are skipped if the Pod uses host networking
+  (`hostNetwork: true`).
+
+### Validation and Limitations
+
+The `kubelet` validates `defaultPodSysctls` during startup. Non-namespaced
+sysctls, invalid sysctl names, or duplicate keys will prevent the `kubelet` from
+starting.
+
+In addition, certain `net.*` sysctls might be unnamespaced depending on your
+kernel version. Specifying an unnamespaced `net.*` sysctl in `defaultPodSysctls`
+will cause Pod sandbox creation to fail with a `FailedCreatePodSandBox` error.
+The Pod will keep retrying to create a sandbox forever. Ensure that all
+specified sysctls are namespaced on your Node's kernel.
+
+Changes to `defaultPodSysctls` apply only to newly created Pods. The `kubelet`
+does not dynamically reconfigure existing Pods (see [What Happens After a Node Restart](/docs/reference/node/what-happens-on-restart/#impact-of-a-kubelet-restart)).
+Existing Pods continue to run with the sysctls applied when their sandbox was created.
+If you want existing Pods to adopt the updated default sysctls, you must recreate those
+Pods (for example, by cordoning and draining the Node).


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

This PR adds documentation for the new `defaultPodSysctls` Kubelet configuration option introduced in **[KEP-5996: Support Default Pod Sysctls in Kubelet Configuration](https://github.com/kubernetes/enhancements/issues/5996)** ([kubernetes/kubernetes#140052](https://github.com/kubernetes/kubernetes/pull/140052)) as an Alpha feature in Kubernetes v1.37.

It updates the **[Using sysctls in a Kubernetes Cluster](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/)** tutorial (`content/en/docs/tasks/administer-cluster/sysctl-cluster.md`) with a new section **`## Setting Sysctls for All Pods`** that explains how cluster administrators can configure node-level default kernel parameters for all Pods running on a Linux node.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Enhancement: https://github.com/kubernetes/enhancements/issues/5996
k/k PR: https://github.com/kubernetes/kubernetes/pull/140052

Closes: #