### PR TITLE
[WIP] KEP-5936: Add a feature blog for atomic volume user fields beta in 1.38

### DIFF
--- a/content/en/blog/_posts/2026/atomic-write-volume-user-fields-alpha.md
+++ b/content/en/blog/_posts/2026/atomic-write-volume-user-fields-alpha.md
@@ -1,0 +1,31 @@
+---
+layout: blog
+title: "Define file owner of atomically written volume files"
+slug: atomic-write-volume-user-fields-alpha
+draft: true
+author: >
+  Gavin Lam
+---
+
+<!--
+Placeholder for KEP-5936 (Add user fields to atomic write volumes), targeting alpha in v1.37.
+-->
+
+Kubernetes v1.37 introduces (as an alpha feature) the ability for users to define the
+desired file owner of `configMap`, `secret`, `downwardAPI` and `projected` volumes
+using the new `defaultUser` and `user` fields.
+
+## The problem
+
+## What's new in v1.37
+
+## How it works
+
+## How to try it out
+
+## What's next
+
+## Getting involved
+
+This work is tracked in [KEP-5936](https://github.com/kubernetes/enhancements/issues/5936)
+by [SIG Storage](https://github.com/kubernetes/community/tree/master/sig-storage).


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Placeholder PR to add a feature blog for KEP-5936 Add user fields to atomic write volumes.

KEP: https://github.com/kubernetes/enhancements/issues/5936