### PR TITLE
[pl] Add (automatic) hyperlinks from API reference pages to concept docs that reference them - sync with PR 55864

### DIFF
--- a/i18n/pl/pl.toml
+++ b/i18n/pl/pl.toml
@@ -6,6 +6,10 @@
 [api_reference_title]
 other = "Dokumentacja API"
 
+[api_reference_page_related_concepts]
+one = "Ogólne omówienie {{ .title }}"
+other = "Powiązane pojęcia"
+
 [auto_generated_edit_notice]
 other = "(strona wygenerowana automatycznie)"
 


### PR DESCRIPTION
sync with the PR #55864

---

nie brzmi to po polsku tak zgrabnie jak po angielsku. chatgpt zaproponowal alternatywne tlumaczenia :

[api_reference_page_related_concepts]
one = "Dokumentacja koncepcji dla {{ .title }}"
other = "Powiązane strony z koncepcjami"

[api_reference_page_related_concepts]
one = "Dokumentacja pojęcia dla {{ .title }}"
other = "Powiązane strony z pojęciami"

[api_reference_page_related_concepts]
one = "Dokumentacja pojęcia: {{ .title }}"
other = "Powiązane pojęcia"

[api_reference_page_related_concepts]
one = "Informacje koncepcyjne o {{ .title }}"
other = "Powiązane strony koncepcyjne"

[api_reference_page_related_concepts]
one = "Pojęcie: {{ .title }}"
other = "Powiązane pojęcia"

[api_reference_page_related_concepts]
one = "Omówienie koncepcji dla {{ .title }}"
other = "Powiązane omówienia koncepcyjne"

[api_reference_page_related_concepts]
one = "Dokumentacja koncepcji dla {{ .title }}"
other = "Powiązane strony z koncepcjami"
