### PR TITLE
DRA: GA graduation of DRA device taints

### DIFF
--- a/content/en/docs/concepts/resource-management/dynamic-resource-allocation/device-taints.md
+++ b/content/en/docs/concepts/resource-management/dynamic-resource-allocation/device-taints.md
@@ -10,6 +10,8 @@ api_metadata:
   kind: "DeviceTaintRule"
 - apiVersion: "resource.k8s.io/v1beta2"
   kind: "DeviceTaintRule"
+- apiVersion: "resource.k8s.io/v1"
+  kind: "DeviceTaintRule"
 ---
 
 <!-- overview -->
@@ -53,14 +55,6 @@ All devices must be untainted or all of their taints must be tolerated.
 Allocating a device with admin access (described [above](#admin-access))
 is not exempt either. An admin using that mode must explicitly tolerate all taints
 to access tainted devices.
-
-Device taints and tolerations is controlled by the
-[`DRADeviceTaints` feature gate](/docs/reference/command-line-tools-reference/feature-gates/#DRADeviceTaints)
-in the `kube-apiserver`, `kube-controller-manager`, and `kube-scheduler`.
-To use DeviceTaintRules, the `resource.k8s.io/v1beta2` API version must be
-enabled together with the [`DRADeviceTaintRules` feature gate](/docs/reference/command-line-tools-reference/feature-gates/#DRADeviceTaintRules).
-In contrast to `DRADeviceTaints`, `DRADeviceTaintRules` is off by default because of this dependency
-on the beta API group, which has to be off by default.
 
 You can add taints to devices in the following ways, by using the DeviceTaintRule API kind.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DRADeviceTaintRules.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DRADeviceTaintRules.md
@@ -13,6 +13,11 @@ stages:
   - stage: beta
     defaultValue: false
     fromVersion: "1.36"
+    toVersion: "1.37"
+  - stage: stable
+    defaultValue: true
+    locked: true
+    fromVersion: "1.37"
 ---
 Enables support for
 [tainting devices through DeviceTaintRule objects](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations)

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DRADeviceTaints.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DRADeviceTaints.md
@@ -13,6 +13,11 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.36"
+    toVersion: "1.37"
+  - stage: stable
+    defaultValue: true
+    locked: true
+    fromVersion: "1.37"
 ---
 Enables support for
 [tainting devices and selectively tolerating those taints](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations)


### PR DESCRIPTION
### Description

DRA device taints and eviction is graduating to GA in 1.37.

### Issue

https://github.com/kubernetes/enhancements/issues/5055
