### PR TITLE
Fix unreadable feature-state banner text in dark mode

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -12,6 +12,7 @@
 
 div.feature-state-notice {
   background-color: $feature;
+  color: #000;
   border-radius: 0.75rem;
   padding: 1rem;
   margin-bottom: 1em;


### PR DESCRIPTION


<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
The "(enabled/disabled by default)" text rendered by the feature-state shortcode is a bare text node inside .feature-state-notice. The banner background stays light ($feature) in both themes, but the bare text had no explicit color, so in dark mode it inherited the light page text color and became unreadable. Add an explicit dark text color on the container so all banner text stays readable in both light and dark modes.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
- Before
<img width="1035" height="527" alt="image" src="https://github.com/user-attachments/assets/8f56e764-a38a-46da-b90f-395adc98331f" />

- After
<img width="1035" height="527" alt="image" src="https://github.com/user-attachments/assets/5962dce5-f497-4bbc-a1bb-9eecb3156678" />

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #https://github.com/kubernetes/website/issues/56266