### PR TITLE
Add net.ipv4.tcp_slow_start_after_idle and net.ipv4.tcp_notsent_lowat to safe sysctls

### DIFF
--- a/content/en/docs/reference/node/kernel-version-requirements.md
+++ b/content/en/docs/reference/node/kernel-version-requirements.md
@@ -34,6 +34,8 @@ Code: https://github.com/kubernetes/kubernetes/blob/00236ae0d73d2455a2470469ed10
 - `net.ipv4.tcp_syncookies` (namespaced since kernel 4.6+).
 - `net.ipv4.tcp_rmem` (since Kubernetes 1.32, needs kernel 4.15+).
 - `net.ipv4.tcp_wmem` (since Kubernetes 1.32, needs kernel 4.15+).
+- `net.ipv4.tcp_slow_start_after_idle` (since Kubernetes 1.37, needs kernel 4.15+).
+- `net.ipv4.tcp_notsent_lowat` (since Kubernetes 1.37, needs kernel 4.6+).
 - `net.ipv4.vs.conn_reuse_mode` (used in `ipvs` proxy mode, needs kernel 4.1+);
 
 ### kube proxy `nftables` proxy mode

--- a/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
+++ b/content/en/docs/tasks/administer-cluster/sysctl-cluster.md
@@ -83,6 +83,8 @@ The following sysctls are supported in the _safe_ set:
 - `net.ipv4.tcp_keepalive_probes` (since Kubernetes 1.29, needs kernel 4.5+).
 - `net.ipv4.tcp_rmem` (since Kubernetes 1.32, needs kernel 4.15+).
 - `net.ipv4.tcp_wmem` (since Kubernetes 1.32, needs kernel 4.15+).
+- `net.ipv4.tcp_slow_start_after_idle` (since Kubernetes 1.37, needs kernel 4.15+).
+- `net.ipv4.tcp_notsent_lowat` (since Kubernetes 1.37, needs kernel 4.6+).
 
 {{< note >}}
 There are some exceptions to the set of safe sysctls:


### PR DESCRIPTION
 This PR updates the Kubernetes documentation to include `net.ipv4.tcp_slow_start_after_idle`
  and `net.ipv4.tcp_notsent_lowat` in the list of allowed safe sysctls starting in Kubernetes v1. 37.

Specifically, it updates:
    1. **sysctl-cluster.md:** Adds the sysctls to the safe set list along with their kernel version requirements.
    2. **kernel-version-requirements.md:** Documents the minimum kernel version requirements for these sysctls:
       - `net.ipv4.tcp_slow_start_after_idle` (needs kernel 4.15+)
       - `net.ipv4.tcp_notsent_lowat` (needs kernel 4.6+)

These changes correspond to the core Kubernetes code changes introduced in v1.37.

### Issue
Accompanying documentation for kubernetes/kubernetes#138389