### PR TITLE
Clarify ServiceAccount use case for private registry image pulls

### DIFF
--- a/content/en/docs/concepts/security/service-accounts.md
+++ b/content/en/docs/concepts/security/service-accounts.md
@@ -88,7 +88,7 @@ the following scenarios:
 * Your Pods need to communicate with an external service. For example, a
   workload Pod requires an identity for a commercially available cloud API,
   and the commercial provider allows configuring a suitable trust relationship.
-* [Authenticating to a private image registry using an `imagePullSecret`](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account).
+* [Providing `imagePullSecrets` for Pods that pull images from private registries](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account).
 * An external service needs to communicate with the Kubernetes API server. For
   example, authenticating to the cluster as part of a CI/CD pipeline.
 * You use third-party security software in your cluster that relies on the


### PR DESCRIPTION
This PR clarifies the ServiceAccount use case related to private container registries.

The previous wording stated that ServiceAccounts are used for "authenticating to a private image registry using an imagePullSecret." While `imagePullSecrets` contain the credentials used for registry authentication, the ServiceAccount itself does not authenticate to the registry. Instead, it provides a way to associate `imagePullSecrets` with Pods.

This change updates the wording to more accurately describe the responsibility of a ServiceAccount and helps avoid confusion between:

- ServiceAccount identity for Kubernetes API authentication.
- `imagePullSecrets` used for container registry authentication.

