### PR TITLE
Fix secret key names by removing .txt extension in kustomize secret guide

### DIFF
--- a/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
+++ b/content/en/docs/tasks/configmap-secret/managing-secret-using-kustomize.md
@@ -42,8 +42,8 @@ secretGenerator:
 1.  Store the credentials in files. The filenames are the keys of the secret:
 
     ```shell
-    echo -n 'admin' > ./username.txt
-    echo -n '1f2d1e2e67df' > ./password.txt
+    echo -n 'admin' > ./username
+    echo -n '1f2d1e2e67df' > ./password
     ```
     The `-n` flag ensures that there's no newline character at the end of your
     files.
@@ -54,8 +54,8 @@ secretGenerator:
     secretGenerator:
     - name: database-creds
       files:
-      - username.txt
-      - password.txt
+      - username
+      - password
     ```
 {{% /tab %}}
 {{% tab name=".env files" %}}


### PR DESCRIPTION
### Description
When using `files:` in `secretGenerator`, Kustomize uses the filename 
as the key in the secret. The previous example used `username.txt` and 
`password.txt` as filenames, which would result in secret keys named 
`username.txt` and `password.txt` instead of the intended `username` 
and `password`.

This fix renames the files to `username` and `password` (without 
extensions) so that the resulting secret keys are clean and usable 
without requiring apps to reference keys with `.txt` extension.