### PR TITLE
KEP-6178: ConcurrentWatchObjectDecode beta on by default in v1.37

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ConcurrentWatchObjectDecode.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ConcurrentWatchObjectDecode.md
@@ -10,6 +10,10 @@ stages:
   - stage: beta
     defaultValue: false
     fromVersion: "1.31"
+    toVersion: "1.36"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.37"
 
 ---
 Enable concurrent watch object decoding. This is to avoid starving the API server's


### PR DESCRIPTION
Adds the v1.37 beta default-on stage to the `ConcurrentWatchObjectDecode` feature gate reference for [KEP-6178: Concurrent Watch Object Decode](https://github.com/kubernetes/enhancements/issues/6178).

The feature is an internal API server watch-decode optimization with no user-facing surface beyond the gate, so the feature gate reference is the complete docs footprint.

/sig api-machinery
/kind feature
Tracked-by: kubernetes/enhancements#6178