### PR TITLE
KEP-5966: etcd RangeStream (v1.37 beta)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/EtcdRangeStream.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/EtcdRangeStream.md
@@ -1,0 +1,18 @@
+---
+title: EtcdRangeStream
+content_type: feature_gate
+
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.37"
+
+---
+Enables the kube-apiserver to use etcd's `RangeStream` RPC to stream large list
+responses from etcd, instead of fetching them in a single `Range` response. This
+reduces memory spikes in both etcd and the kube-apiserver when serving large
+`LIST` requests.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/EtcdRangeStream.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/EtcdRangeStream.md
@@ -8,7 +8,7 @@ _build:
 
 stages:
   - stage: beta
-    defaultValue: false
+    defaultValue: true
     fromVersion: "1.37"
 
 ---

--- a/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
+++ b/content/en/docs/tasks/administer-cluster/configure-upgrade-etcd.md
@@ -481,6 +481,23 @@ Before you start an upgrade, back up your etcd cluster first.
 
 For details on etcd upgrade, refer to the [etcd upgrades](https://etcd.io/docs/latest/upgrades/) documentation.
 
+## Streaming reads from etcd
+
+{{< feature-state feature_gate_name="EtcdRangeStream" >}}
+
+With the `EtcdRangeStream` feature gate enabled and etcd v3.7 or later, the API server
+reads large collections from etcd as a stream instead of in pages, which lowers peak
+memory use on both sides. If the backend does not implement the `RangeStream` RPC, the
+API server detects the gRPC `Unimplemented` response and falls back to paginated reads.
+If your etcd-compatible backend or proxy does not fall back cleanly, disable the gate
+with `--feature-gates=EtcdRangeStream=false`.
+
+{{< note >}}
+Streamed reads are recorded as `operation="listStream"` in the
+`etcd_request_duration_seconds` metric. Update any dashboard or alert that matches
+`operation="list"`.
+{{< /note >}}
+
 ## Maintaining etcd clusters
 
 For more details on etcd maintenance, please refer to the [etcd maintenance](https://etcd.io/docs/latest/op-guide/maintenance/) documentation.


### PR DESCRIPTION
Updates the `EtcdRangeStream` feature gate on the website for [KEP-5966: etcd RangeStream](https://github.com/kubernetes/enhancements/issues/5966) (beta, default on in v1.37). This is an internal kube-apiserver optimization and is not user facing.

/sig etcd
/kind feature
Tracked-by: kubernetes/enhancements#5966
