### PR TITLE
[WIP][placeholder] KEP-5366: Graceful Leader Transition (v1.37 beta)

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ControllerManagerReleaseLeaderElectionLockOnExit.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ControllerManagerReleaseLeaderElectionLockOnExit.md
@@ -9,6 +9,10 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.36"
+    toVersion: "1.36"
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.37"
 ---
 Enables the `kube-controller-manager` to actively release its leader election lock
 during leader transitions, rather than waiting for the lock's TTL to expire.


### PR DESCRIPTION
Placeholder docs PR for [KEP-5366: Graceful Leader Transition](https://github.com/kubernetes/enhancements/issues/5366), graduating to beta on by default in v1.37.

Updates the `ControllerManagerReleaseLeaderElectionLockOnExit` feature gate reference to add the v1.37 beta default-on stage. WIP, will flesh out any additional docs before the deadline.

/sig api-machinery
/kind feature
Tracked-by: kubernetes/enhancements#5366