### PR TITLE
Documentation updates for alpha release for KEP-5855 (bind mount options on volumeMounts)

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -1173,6 +1173,27 @@ OCI-level:
 - [runc](https://runc.io/), since v1.1
 - [crun](https://github.com/containers/crun), since v1.8.6
 
+## Bind mount options
+
+{{< feature-state feature_gate_name="VolumeBindMountOptions" >}}
+
+The `.spec.containers[*].volumeMounts[*].bindMountOptions` field lets you apply security-related
+Linux bind mount flags to any volume mount. The allowed values are:
+
+* `noexec` - prevents execution of binaries on the mounted volume
+* `nodev` - ignores device special files on the mounted volume
+* `nosuid` - ignores set-user-identifier or set-group-identifier bits on the mounted volume
+
+These options apply per container, so different containers in the same Pod can mount
+the same volume with different bind mount options. The field is not supported with
+[image volumes](#image).
+
+{{< note >}}
+The container runtime (such as containerd or CRI-O) must support the `mount_options`
+field in the CRI `Mount` message. If the runtime does not advertise support, the kubelet
+rejects Pods that use `bindMountOptions`. This field has no effect on Windows nodes.
+{{< /note >}}
+
 ## {{% heading "whatsnext" %}}
 
 Follow an example of [deploying WordPress and MySQL with Persistent Volumes](/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/).

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/VolumeBindMountOptions.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/VolumeBindMountOptions.md
@@ -1,0 +1,17 @@
+---
+title: VolumeBindMountOptions
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.37"
+---
+Enables setting bind mount options (`noexec`, `nodev`, `nosuid`) per container
+volume mount using the `bindMountOptions` field in `volumeMounts`. When enabled,
+the kubelet passes these options to the container runtime, which applies them as
+Linux bind mount flags. The container runtime must support the `mount_options`
+field in the CRI `Mount` message. This field has no effect on Windows nodes.

--- a/content/en/docs/tasks/configure-pod-container/configure-bind-mount-options.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-bind-mount-options.md
@@ -1,0 +1,76 @@
+---
+title: Set Bind Mount Options on Volume Mounts
+content_type: task
+weight: 216
+min-kubernetes-server-version: v1.37
+---
+
+<!-- overview -->
+
+{{< feature-state feature_gate_name="VolumeBindMountOptions" >}}
+
+This page shows how to apply security-related bind mount options (`noexec`,
+`nodev`, `nosuid`) to volume mounts in a Pod.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+You need to have the `VolumeBindMountOptions`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) enabled
+on the API server **and** the kubelet. The container runtime must also support
+the `mount_options` field in the CRI `Mount` message.
+
+<!-- steps -->
+
+## Create a Pod with bind mount options {#create-pod}
+
+The `.spec.containers[*].volumeMounts[*].bindMountOptions` field accepts a list of bind mount flags.
+The allowed values are `noexec`, `nodev`, and `nosuid`.
+
+For example, to mount an emptyDir volume at `/tmp` with `noexec` and `nosuid`
+so that binaries cannot be executed and set-user-ID bits are ignored:
+
+{{% code_sample file="pods/bind-mount-options.yaml" %}}
+
+1. Create the pod on your cluster:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/bind-mount-options.yaml
+   ```
+
+1. Verify the pod is running:
+
+   ```shell
+   kubectl get pod bind-mount-options-demo
+   ```
+
+1. Check the mount options on the volume:
+
+   ```shell
+   kubectl exec bind-mount-options-demo -- mount | grep /tmp
+   ```
+
+   The output should include `noexec` and `nosuid` in the mount options.
+
+1. Verify that executing a binary on the mount fails:
+
+   ```shell
+   kubectl exec bind-mount-options-demo -- sh -c 'cp /bin/ls /tmp/ls && /tmp/ls'
+   ```
+
+   The output is similar to:
+
+   ```none
+   sh: /tmp/ls: Permission denied
+   ```
+
+1. Delete the Pod that you created for this exercise:
+
+   ```shell
+   kubectl delete pod bind-mount-options-demo
+   ```
+
+## {{% heading "whatsnext" %}}
+
+- Learn more about [bind mount options](/docs/concepts/storage/volumes/#bind-mount-options) for volumes

--- a/content/en/examples/pods/bind-mount-options.yaml
+++ b/content/en/examples/pods/bind-mount-options.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bind-mount-options-demo
+spec:
+  containers:
+  - image: registry.k8s.io/busybox
+    name: test-container
+    command: ["sleep", "3600"]
+    volumeMounts:
+    - mountPath: /tmp
+      name: tmp-volume
+      bindMountOptions:
+      - noexec
+      - nosuid
+  volumes:
+  - name: tmp-volume
+    emptyDir: {}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
This PR adds documentation for KEP-5855: bind mount options (noexec, nodev, nosuid) on volumeMounts.
### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
https://github.com/kubernetes/enhancements/issues/5855

Closes: #