### PR TITLE
Documentation updates for alpha release for KEP-5502 (emptyDir volume permission mode)

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -197,6 +197,22 @@ Please check [here](/docs/concepts/configuration/manage-resources-containers/#me
 for points to note in terms of resource management when using memory-backed `emptyDir`.
 {{< /caution >}}
 
+{{< feature-state feature_gate_name="EmptyDirVolumeMode" >}}
+
+The `emptyDir.mode` field lets you set Unix permission bits on the emptyDir directory,
+specifying a value between `0000` and `01777` (octal). This follows the same pattern as the
+`defaultMode` field on Secret and ConfigMap volumes. If `mode` is not specified, the
+directory is created with the default `0777` permissions.
+
+Setting a custom mode is useful when you want to restrict access to owner and group only
+(for example, `0750`), or set the sticky bit on a shared directory so that only file owners
+can delete their own files (for example, `01777`).
+
+{{< note >}}
+If `fsGroup` is set in the Pod's security context, the group permissions applied by
+`fsGroup` override the `mode` specified here. The `mode` field has no effect on Windows.
+{{< /note >}}
+
 #### emptyDir configuration example
 
 ```yaml
@@ -236,6 +252,26 @@ spec:
     emptyDir:
       sizeLimit: 500Mi
       medium: Memory
+```
+
+#### emptyDir permissions configuration example
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pd
+spec:
+  containers:
+  - image: registry.k8s.io/test-webserver
+    name: test-container
+    volumeMounts:
+    - mountPath: /cache
+      name: cache-volume
+  volumes:
+  - name: cache-volume
+    emptyDir:
+      mode: 01777
 ```
 
 ### fc (fibre channel) {#fc}

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/EmptyDirVolumeMode.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/EmptyDirVolumeMode.md
@@ -1,0 +1,16 @@
+---
+title: EmptyDirVolumeMode
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.37"
+---
+Enables setting Unix permission bits on `emptyDir` volume directories using the
+`mode` field in `emptyDir` volume sources. When enabled, users can specify a value
+between `0000` and `01777` (octal) to control the directory permissions at creation
+time. If `mode` is not specified, the default `0777` behavior is preserved.

--- a/content/en/docs/tasks/configure-pod-container/configure-emptydir-volume-mode.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-emptydir-volume-mode.md
@@ -1,0 +1,70 @@
+---
+title: Set Permissions on an emptyDir Volume
+content_type: task
+weight: 215
+min-kubernetes-server-version: v1.37
+---
+
+<!-- overview -->
+
+{{< feature-state feature_gate_name="EmptyDirVolumeMode" >}}
+
+This page shows how to set Unix permission bits on an `emptyDir` volume directory
+using the `mode` field.
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+You need to have the `EmptyDirVolumeMode`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/) enabled
+on the API server **and** the kubelet.
+
+<!-- steps -->
+
+## Create a Pod that uses an emptyDir volume with custom permissions {#create-pod}
+
+The `emptyDir.mode` field lets you set Unix permission bits (from `0000` to `01777` in octal)
+on the volume directory. If not specified, the directory is created with the default `0777`
+permissions.
+
+For example, to create a shared `/tmp` directory with the sticky bit set so that only file
+owners can delete their own files:
+
+{{% code_sample file="pods/emptydir-volume-mode.yaml" %}}
+
+1. Create the pod on your cluster:
+
+   ```shell
+   kubectl apply -f https://k8s.io/examples/pods/emptydir-volume-mode.yaml
+   ```
+
+1. Verify the pod is running:
+
+   ```shell
+   kubectl get pod emptydir-mode-demo
+   ```
+
+1. Check the permissions on the mounted volume:
+
+   ```shell
+   kubectl exec emptydir-mode-demo -- ls -ld /tmp
+   ```
+
+   The output is similar to:
+
+   ```none
+   drwxrwxrwt 2 root root 4096 Jul 28 00:00 /tmp
+   ```
+
+   The `t` at the end confirms the sticky bit is set.
+
+1. Delete the Pod that you created for this exercise:
+
+   ```shell
+   kubectl delete pod emptydir-mode-demo
+   ```
+
+## {{% heading "whatsnext" %}}
+
+- Learn more about [`emptyDir` volumes](/docs/concepts/storage/volumes/#emptydir)

--- a/content/en/examples/pods/emptydir-volume-mode.yaml
+++ b/content/en/examples/pods/emptydir-volume-mode.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: emptydir-mode-demo
+spec:
+  containers:
+  - image: registry.k8s.io/busybox
+    name: test-container
+    command: ["sleep", "3600"]
+    volumeMounts:
+    - mountPath: /tmp
+      name: tmp-volume
+  volumes:
+  - name: tmp-volume
+    emptyDir:
+      mode: 01777


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
This PR adds documentation for KEP-5502: emptyDir volume permission mode

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
https://github.com/kubernetes/enhancements/issues/5502

Closes: #