### PR TITLE
[WAS] KEP-5547: Add docs for job integration alpha2

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -319,10 +319,10 @@ or completed for the same index will be deleted by the Job controller once they 
 
 When the [`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/) 
 feature gate is enabled, the Job controller compiles a Job's `.spec.scheduling`
-configuration into [Workload](/docs/concepts/workloads/workload-api/) and PodGroup
-objects (`scheduling.k8s.io/v1beta1`) before it creates any Pods. This lets you
-express explicit scheduling intent for a Job, such as
-[gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/) (all Pods
+configuration into [Workload](/docs/concepts/workloads/workload-api/) and 
+[PodGroup](/docs/concepts/workloads/podgroup-api/) objects (`scheduling.k8s.io/v1beta1`) 
+before it creates any Pods. This lets you express explicit scheduling intent for a Job, 
+such as [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/) (all Pods
 scheduled together or none), topology co-location, and disruption behavior.
 
 When you omit `.spec.scheduling`, the Job defaults to the `Basic` scheduling
@@ -335,9 +335,9 @@ regardless of the policy.
 
 The `.spec.scheduling` field accepts the following fields:
 
-- `schedulingPolicy`: exactly one of `basic` or `gang`. With `gang`, all Pods must
-  be schedulable together before any of them are bound. An omitted `gang.minCount`
-  defaults to the Job's `.spec.parallelism`. See
+- `schedulingPolicy`: exactly one of `basic` or `gang` must be specified. With `gang`, 
+  all Pods must be schedulable together before any of them are bound. An omitted 
+  `gang.minCount` defaults to the Job's `.spec.parallelism`. See
   [PodGroup scheduling policies](/docs/concepts/workloads/workload-api/policies/).
 - `schedulingConstraints`:
   [topology](/docs/concepts/workloads/workload-api/topology-aware-scheduling/)
@@ -347,7 +347,7 @@ The `.spec.scheduling` field accepts the following fields:
   [disruption and priority](/docs/concepts/workloads/workload-api/disruption-and-priority/).
 - `resourceClaims`: dynamic resource claims shared across the Job's Pods.
 
-All `.spec.scheduling` fields are immutable after the Job is created, except
+All `.spec.scheduling` fields are immutable after the Job is created, except for 
 `schedulingPolicy.gang.minCount`, which you can change to
 [scale a gang elastically](#elastic-indexed-jobs).
 
@@ -404,7 +404,7 @@ the Job, so they are garbage collected when the Job is deleted.
 ### Default (Basic) scheduling
 
 A Job that omits `.spec.scheduling` defaults to `Basic`, which acts as an implicit
-opt-out from gang scheduling. Its Pods schedule the same way as an ordinary Job,
+opt-out of gang scheduling. Its Pods schedule the same way as an ordinary Job,
 while a `Basic` `Workload` and `PodGroup` are still created:
 
 ```yaml

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -317,32 +317,44 @@ or completed for the same index will be deleted by the Job controller once they 
 
 {{< feature-state feature_gate_name="WorkloadWithJob" >}}
 
-When the [`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/) feature gate is enabled,
-the Job controller automatically creates
-[Workload](/docs/concepts/workloads/workload-api/) and
-[PodGroup](/docs/concepts/workloads/podgroup-api/) objects
-for [qualifying parallel Jobs](#qualifying-criteria) before creating any Pods.
-This enables native [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)
-where all Pods in a Job are scheduled together or none are scheduled.
+When the [`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/) 
+feature gate is enabled, the Job controller compiles a Job's `.spec.scheduling`
+configuration into [Workload](/docs/concepts/workloads/workload-api/) and PodGroup
+objects (`scheduling.k8s.io/v1beta1`) before it creates any Pods. This lets you
+express explicit scheduling intent for a Job, such as
+[gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/) (all Pods
+scheduled together or none), topology co-location, and disruption behavior.
 
-### Qualifying criteria
+When you omit `.spec.scheduling`, the Job defaults to the `Basic` scheduling
+policy, which preserves the standard pod-by-pod scheduling outcome of an ordinary
+Job. The controller still creates a `Workload` and `PodGroup` for every
+eligible Job (including `Basic` ones), so the observable objects are consistent
+regardless of the policy.
 
-The Job controller creates a Workload with a
-[gang scheduling policy](/docs/concepts/workloads/workload-api/policies/#gang-policy)
-when the Job meets all of the following conditions:
+### Scheduling configuration
 
-- `.spec.parallelism` is greater than 1
-- `.spec.completionMode` is `Indexed`
-- `.spec.parallelism` equals `.spec.completions`
-- `.spec.template.spec.schedulingGroup` is not set
+The `.spec.scheduling` field accepts the following fields:
 
-Jobs that do not match these criteria continue to schedule Pods independently,
-with no `Workload` or `PodGroup` created.
+- `schedulingPolicy`: exactly one of `basic` or `gang`. With `gang`, all Pods must
+  be schedulable together before any of them are bound. An omitted `gang.minCount`
+  defaults to the Job's `.spec.parallelism`. See
+  [PodGroup scheduling policies](/docs/concepts/workloads/workload-api/policies/).
+- `schedulingConstraints`:
+  [topology](/docs/concepts/workloads/workload-api/topology-aware-scheduling/)
+  co-location constraints for the Job's Pods.
+- `disruptionMode`: whether the Pods are disrupted individually (`single`) or as a
+  group (`all`). See
+  [disruption and priority](/docs/concepts/workloads/workload-api/disruption-and-priority/).
+- `resourceClaims`: dynamic resource claims shared across the Job's Pods.
 
-For example, the following Job runs 8 parallel indexed workers. When the feature
-is enabled, the Job controller creates a `Workload` and `PodGroup` with
-`minCount: 8` before creating any Pods, ensuring all 8 workers are
-scheduled together:
+All `.spec.scheduling` fields are immutable after the Job is created, except
+`schedulingPolicy.gang.minCount`, which you can change to
+[scale a gang elastically](#elastic-indexed-jobs).
+
+### Gang scheduling
+
+The following Job requests gang scheduling for its 8 Pods, co-located within a
+single zone, and disrupted together:
 
 ```yaml
 apiVersion: batch/v1
@@ -354,6 +366,14 @@ spec:
   parallelism: 8
   completions: 8
   completionMode: Indexed
+  scheduling:
+    schedulingPolicy:
+      gang: {}                # minCount omitted -> defaults to parallelism (8)
+    schedulingConstraints:
+      key:
+      - level: topology.kubernetes.io/zone
+    disruptionMode:
+      all: {}                 # the entire group is disrupted together
   template:
     spec:
       restartPolicy: Never
@@ -365,44 +385,78 @@ spec:
             nvidia.com/gpu: 1
 ```
 
-When the Job controller processes this Job, it automatically:
+When the Job controller processes this Job, it:
 
-1. Creates a [Workload](/docs/concepts/workloads/workload-api/) object in the same namespace. The Workload contains a
-   `podGroupTemplate` with a
-   [gang scheduling policy](/docs/concepts/workloads/workload-api/policies/#gang-policy)
-   where `minCount` equals the Job's parallelism.
-1. Creates a [PodGroup](/docs/concepts/workloads/podgroup-api/)
-   object based on that template.
-   The PodGroup is a standalone runtime scheduling unit that carries an inline copy
-   of the gang policy.
-1. Creates Pods with `spec.schedulingGroup.podGroupName` set to the PodGroup name,
-   linking each Pod to its scheduling group.
+1. Creates a [Workload](/docs/concepts/workloads/workload-api/) object in the same
+   namespace, containing a `podGroupTemplate` compiled from `.spec.scheduling`
+   (here, a [gang policy](/docs/concepts/workloads/workload-api/policies/) with
+   `minCount: 8`).
+1. Creates a PodGroup object from that template. The PodGroup is the runtime
+   scheduling unit and carries an inline copy of the policy.
+1. Creates Pods with `.spec.schedulingGroup.podGroupName` set to the PodGroup's
+   name, linking each Pod to its scheduling group.
 
-Discovery of these objects is based on spec references (`controllerRef` and
-`podGroupTemplateRef`).
+The controller discovers these objects through spec references
+(`Workload.spec.controllerRef` and `PodGroup.spec.workloadRef`), not by
+name. Objects the controller creates carry an `ownerReferences` entry pointing to
+the Job, so they are garbage collected when the Job is deleted.
 
-The Workload and PodGroup are owned by the Job (via `ownerReferences`) and are
-automatically garbage collected when the Job is deleted.
+### Default (Basic) scheduling
 
-### Opt-out for higher-level controllers
+A Job that omits `.spec.scheduling` defaults to `Basic`, which acts as an implicit
+opt-out from gang scheduling. Its Pods schedule the same way as an ordinary Job,
+while a `Basic` `Workload` and `PodGroup` are still created:
 
-If a Job's Pod template already has `spec.schedulingGroup` set, the Job controller
-does not create `Workload` or `PodGroup` objects. This allows higher-level controllers
-such as `JobSet` to manage the `Workload` and `PodGroup` lifecycle themselves.
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: batch-processor
+  namespace: batch
+spec:
+  parallelism: 10
+  completions: 10
+  # .spec.scheduling omitted -> defaults to Basic scheduling.
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: processor
+        image: processor-image:v1
+```
 
-### CronJob behavior 
+### Higher-level controllers
 
-Jobs created by a `CronJob` do not have `schedulingGroup` set in the `PodTemplate`.
-If a CronJob-created `Job` matches the gang scheduling criteria, the Job controller
-creates a separate `Workload` and `PodGroup` for each Job instance.
+For a standalone Job, the Job controller owns both the `Workload` and the
+`PodGroup`. When a Job instead carries an `ownerReference` to a parent controller
+that compiles the `Workload` (for example, `JobSet`), the Job controller defers
+`Workload` ownership to that parent. Whether the Job controller still creates the
+runtime `PodGroup` depends on what the parent delegates:
+
+- If the parent sets the `scheduling.k8s.io/group-template-name` annotation on the
+  Job, the Job controller creates and owns the `PodGroup`, mapped to the parent's
+  named `PodGroupTemplate`.
+- Otherwise, the parent owns both objects and the Job controller creates neither;
+  it discovers the existing objects and uses them when creating Pods.
+
+If a Job's Pod template already has `.spec.template.spec.schedulingGroup` set, the
+Job controller creates neither object, letting you (or a higher-level controller)
+manage the `Workload`/`PodGroup` lifecycle yourself.
+
+### CronJob behavior
+
+Jobs created by a `CronJob` are standalone; the `CronJob` does not create or manage
+`Workload` objects. If a `CronJob`'s `jobTemplate` sets `.spec.scheduling`, the Job
+controller creates a separate `Workload` and `PodGroup` for each Job instance,
+compiled from that Job's `.spec.scheduling` (defaulting to `Basic` when omitted).
+These objects are garbage collected when each Job completes or is deleted.
 
 ### Limitations for Alpha release {#workload-integration-limitations}
 
-- Each Job maps to exactly one `PodGroup`. All Pods in the Job belong to the same
-  scheduling group.
-- The `minCount` in the gang policy is immutable. Updates to `.spec.parallelism`
-  are rejected for Jobs that use gang scheduling. See
-  [Elastic Indexed Jobs](#elastic-indexed-jobs) for details on this restriction.
+- Each Job maps to exactly one `PodGroup`; all Pods in the Job share a single
+  scheduling policy.
+- Only `schedulingPolicy.gang.minCount` is mutable; all other `.spec.scheduling`
+  fields are immutable after creation.
 - Suspended Jobs retain their `Workload` and `PodGroup` objects; they are not deleted
   on suspend or recreated on resume.
 
@@ -1174,7 +1228,7 @@ See [My pod stays terminating](/docs/tasks/debug/debug-application/debug-pods/) 
 observe that pods from a Job are stuck with the tracking finalizer.
 {{< /note >}}
 
-### Elastic Indexed Jobs
+### Elastic Indexed Jobs {#elastic-indexed-jobs}
 
 {{< feature-state feature_gate_name="ElasticIndexedJob" >}}
 
@@ -1187,11 +1241,19 @@ scaling an indexed Job, such as MPI, Horovod, Ray, and PyTorch training jobs.
 
 {{< note >}}
 When the [`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/)
-feature gate is enabled and a Job matches the
-[gang scheduling criteria](#integrate-with-workload-apis),
-updates to `.spec.parallelism` are rejected because the `Workload`'s `minCount` field
-is immutable. To scale a gang-scheduled Job, delete and recreate it with the
-new parallelism value.
+feature gate is enabled and a Job uses [gang scheduling](#integrate-with-workload-apis), 
+the gang size follows the mutable `schedulingPolicy.gang.minCount` (or 
+`.spec.parallelism` when `minCount` is unset).
+You can scale the gang in one of two ways:
+
+- set `.spec.scheduling.schedulingPolicy.gang.minCount` directly, or
+- change `.spec.parallelism` when `minCount` is unset.
+
+On either change, the controller recompiles the `Workload` and re-syncs the
+`PodGroup` size, rescaling the gang in place without recreating the Job. Updates
+apply only to Pods evaluated in future scheduling cycles and do not affect
+already-scheduled Pods. A `gang.minCount` greater than `.spec.parallelism` is
+rejected, since such a gang can never be satisfied.
 {{< /note >}}
 
 ### Delayed creation of replacement pods {#pod-replacement-policy}

--- a/content/en/docs/concepts/workloads/workload-api/_index.md
+++ b/content/en/docs/concepts/workloads/workload-api/_index.md
@@ -86,16 +86,21 @@ This data is not used to schedule or manage the Workload.
 When the
 [`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/)
 feature gate is enabled, the
-[Job](/docs/concepts/workloads/controllers/job/) controller automatically
-creates Workload and PodGroup objects for parallel indexed Jobs where
-`.spec.parallelism` equals `.spec.completions`. The gang policy's `minCount`
-is set to the Job's parallelism, so all Pods must be schedulable together
+[Job](/docs/concepts/workloads/controllers/job/) controller compiles a Job's
+`.spec.scheduling` configuration into `Workload` and `PodGroup` objects before it
+creates any Pods. You opt into gang scheduling by setting
+`.spec.scheduling.schedulingPolicy.gang` on the Job; an omitted `gang.minCount`
+defaults to the Job's `.spec.parallelism`, so all Pods must be schedulable together
 before any of them are bound to nodes.
 
-This is the built-in path for using gang scheduling with Jobs.
-You do not need to create Workload or PodGroup objects yourself as the Job
-controller handles it automatically. Other workload controllers (such as
-JobSet) may manage their own Workload and PodGroup objects independently.
+When `.spec.scheduling` is omitted, the Job defaults to the `basic` policy, which
+preserves standard pod-by-pod scheduling. Either way the Job controller creates the
+`Workload` and `PodGroup` for you, so you do not need to create them yourself.
+Other workload controllers (such as JobSet) may manage their own `Workload` and
+`PodGroup` objects independently.
+
+For the full set of scheduling fields and examples, see
+[Integrate with Workload APIs](/docs/concepts/workloads/controllers/job/#integrate-with-workload-apis).
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/WorkloadWithJob.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/WorkloadWithJob.md
@@ -11,6 +11,9 @@ stages:
     fromVersion: "1.36"
 ---
 
-Enables the Job controller to automatically create [Workload](/docs/concepts/workloads/workload-api/) and [PodGroup](/docs/concepts/workloads/podgroup-api/) objects
-for [qualifying Jobs](/docs/concepts/workloads/controllers/job#qualifying-criteria). See [Integrate with Workload APIs](/docs/concepts/workloads/controllers/job#integrate-with-workload-apis)
+Enables the Job controller to compile a Job's `.spec.scheduling` configuration into
+[Workload](/docs/concepts/workloads/workload-api/) and [PodGroup](/docs/concepts/workloads/podgroup-api/) 
+objects before it creates any Pods.
+When `.spec.scheduling` is omitted, the Job defaults to the `Basic` scheduling policy. See
+[Integrate with Workload APIs](/docs/concepts/workloads/controllers/job#integrate-with-workload-apis)
 for details.


### PR DESCRIPTION
Updates the user-facing docs for the Job integration to reflect the v1.37 alpha2 with the explicit `.spec.scheduling` API.

KEP Issue: https://github.com/kubernetes/enhancements/issues/5547