### PR TITLE
Add YAML and CLI examples for Pod Security Admission labels

### DIFF
--- a/content/en/docs/concepts/security/pod-security-admission.md
+++ b/content/en/docs/concepts/security/pod-security-admission.md
@@ -60,6 +60,8 @@ A namespace can configure any or all modes, or even set a different level for di
 
 For each mode, there are two labels that determine the policy used:
 
+{{< tabs name="pod_security_labels" >}}
+{{% tab name="YAML" %}}
 ```yaml
 # The per-mode level label indicates which policy level to apply for the mode.
 #
@@ -74,6 +76,24 @@ pod-security.kubernetes.io/<MODE>: <LEVEL>
 # VERSION must be a valid Kubernetes minor version, or `latest`.
 pod-security.kubernetes.io/<MODE>-version: <VERSION>
 ```
+{{% /tab %}}
+{{% tab name="CLI" %}}
+```shell
+# The per-mode level label indicates which policy level to apply for the mode.
+#
+# MODE must be one of `enforce`, `audit`, or `warn`.
+# LEVEL must be one of `privileged`, `baseline`, or `restricted`.
+kubectl label --overwrite ns <NAMESPACE> pod-security.kubernetes.io/<MODE>=<LEVEL>
+ 
+# Optional: per-mode version label that can be used to pin the policy to the
+# version that shipped with a given Kubernetes minor version (for example v{{< skew currentVersion >}}).
+#
+# MODE must be one of `enforce`, `audit`, or `warn`.
+# VERSION must be a valid Kubernetes minor version, or `latest`.
+kubectl label --overwrite ns <NAMESPACE> pod-security.kubernetes.io/<MODE>-version=<VERSION>
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Check out [Enforce Pod Security Standards with Namespace Labels](/docs/tasks/configure-pod-container/enforce-standards-namespace-labels) to see example usage.
 


### PR DESCRIPTION
## Add YAML and CLI examples for Pod Security Admission labels

### Description

The Pod Security Admission page currently shows pod security labels using only YAML syntax (`pod-security.kubernetes.io/<MODE>: <LEVEL>`), which is correct for namespace manifests but not valid as a `kubectl label` argument. Readers following the page and pasting the snippet directly into `kubectl label` encounter a syntax error, since the CLI requires `key=value` rather than `key: value`.

This PR splits the existing code block into two tabs:

- **YAML** — retains the original colon syntax, unchanged, for use in `metadata.labels` when applying a namespace manifest with `kubectl apply -f`.
- **CLI** — adds the equivalent `kubectl label` command using `key=value` syntax, including the `--overwrite` flag so the command succeeds even if the namespace already carries other labels.

Both the per-mode level label and the per-mode version label examples are covered in each tab, and the inline comments explaining `MODE`, `LEVEL`, and `VERSION` placeholders are preserved.

This is a documentation-only change. No links, anchors, or surrounding prose were modified, so it should not affect any other page or translation that links into this section.

### Before / after

**Before** — a single YAML-only block, ambiguous about which command form to use:

```yaml
pod-security.kubernetes.io/<MODE>: <LEVEL>
```

**After** — explicit, runnable examples for both workflows, presented as tabs (consistent with the tabbed examples used elsewhere on kubernetes.io, e.g. the OS-specific install instructions):

```yaml
pod-security.kubernetes.io/<MODE>: <LEVEL>
```
```shell
kubectl label --overwrite ns <NAMESPACE> pod-security.kubernetes.io/<MODE>=<LEVEL>
```
<img width="782" height="410" alt="Screenshot 2026-07-01 at 12 01 21 AM" src="https://github.com/user-attachments/assets/a4ad8902-adac-4d69-90b3-fd3e0987a5b0" />

<img width="715" height="381" alt="Screenshot 2026-07-01 at 12 01 29 AM" src="https://github.com/user-attachments/assets/1b7d17ae-772a-4d15-a54b-8f091df34e5e" />

### Why not just change `:` to `=`?

The original issue proposed replacing the colon with an equals sign throughout. That would fix the CLI use case but break the YAML manifest use case, since `key=value` is not valid YAML for a labels map. Showing both forms side by side resolves the reported confusion without removing a valid, commonly used pattern (declarative namespace manifests).

### Testing

- Previewed locally with `hugo server` to confirm the `tabs`/`tab` shortcodes render correctly and both code blocks retain syntax highlighting (`yaml`, `shell`).
- Verified the `kubectl label` command syntax against `kubectl label --help` and the [[kubectl label reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_label/)](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_label/).


### Issue

Closes:  #56332
