### PR TITLE
Document KYAML graduation to stable in v1.37

### DIFF
--- a/content/en/docs/reference/encodings/kyaml.md
+++ b/content/en/docs/reference/encodings/kyaml.md
@@ -5,7 +5,7 @@ weight: 40
 ---
 
 <!-- overview -->
-**KYAML** is a safer and less ambiguous subset of YAML, initially introduced in Kubernetes v1.34 (alpha) and enabled by default in v1.35 (beta). Designed specifically for Kubernetes, KYAML addresses common YAML pitfalls such as whitespace sensitivity and implicit type coercion while maintaining full compatibility with existing YAML parsers and tooling. 
+**KYAML** is a safer and less ambiguous subset of YAML, initially introduced in Kubernetes v1.34 (alpha), enabled by default in v1.35 (beta), and promoted to stable in v1.37. Designed specifically for Kubernetes, KYAML addresses common YAML pitfalls such as whitespace sensitivity and implicit type coercion while maintaining full compatibility with existing YAML parsers and tooling. 
 
 <!-- body -->
 This reference describes KYAML syntax.

--- a/content/en/docs/reference/encodings/kyaml.md
+++ b/content/en/docs/reference/encodings/kyaml.md
@@ -5,7 +5,7 @@ weight: 40
 ---
 
 <!-- overview -->
-**KYAML** is a safer and less ambiguous subset of YAML, initially introduced in Kubernetes v1.34 (alpha), enabled by default in v1.35 (beta), and promoted to stable in v1.37. Designed specifically for Kubernetes, KYAML addresses common YAML pitfalls such as whitespace sensitivity and implicit type coercion while maintaining full compatibility with existing YAML parsers and tooling. 
+**KYAML** is a safer and less ambiguous subset of YAML. Designed specifically for Kubernetes, KYAML addresses common YAML pitfalls such as whitespace sensitivity and implicit type coercion while maintaining full compatibility with existing YAML parsers and tooling. 
 
 <!-- body -->
 This reference describes KYAML syntax.

--- a/content/en/docs/reference/kubectl/_index.md
+++ b/content/en/docs/reference/kubectl/_index.md
@@ -271,10 +271,10 @@ Output format | Description
 `-o json`     | Output a JSON formatted API object.
 `-o jsonpath=<template>` | Print the fields defined in a [jsonpath](/docs/reference/kubectl/jsonpath/) expression.
 `-o jsonpath-file=<filename>` | Print the fields defined by the [jsonpath](/docs/reference/kubectl/jsonpath/) expression in the `<filename>` file.
-`-o kyaml`    | Output a [KYAML](/docs/reference/encodings/kyaml/) formatted API object (beta).
+`-o kyaml`    | Output a [KYAML](/docs/reference/encodings/kyaml/) formatted API object.
 `-o name`     | Print only the resource name and nothing else.
 `-o wide`     | Output in the plain-text format with any additional information. For pods, the node name is included.
-`-o yaml`     | Output a YAML formatted API object. KYAML is an experimental Kubernetes-specific dialect of YAML, and can be parsed as YAML.
+`-o yaml`     | Output a YAML formatted API object. KYAML is a Kubernetes-specific dialect of YAML, and can be parsed as YAML.
 
 ##### Example
 

--- a/content/en/docs/reference/kubectl/kubectl.md
+++ b/content/en/docs/reference/kubectl/kubectl.md
@@ -383,14 +383,6 @@ kubectl [flags]
 </td>
 </tr>
 
-<tr>
-<td colspan="2">KUBECTL_KYAML</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">When set to true, kubectl is capable of producing Kubernetes-specific dialect of YAML output format.
-</td>
-</tr>
-
 </tbody>
 </table>
 

--- a/content/en/docs/reference/kubectl/quick-reference.md
+++ b/content/en/docs/reference/kubectl/quick-reference.md
@@ -461,7 +461,7 @@ Output format | Description
 `-o=json`     | Output a JSON formatted API object
 `-o=jsonpath=<template>` | Print the fields defined in a [jsonpath](/docs/reference/kubectl/jsonpath) expression
 `-o=jsonpath-file=<filename>` | Print the fields defined by the [jsonpath](/docs/reference/kubectl/jsonpath) expression in the `<filename>` file
-`-o=kyaml` (beta) | Output a [KYAML](/docs/reference/encodings/kyaml) formatted API object. KYAML is an Kubernetes-specific dialect of YAML, and can be parsed as YAML.
+`-o=kyaml`    | Output a [KYAML](/docs/reference/encodings/kyaml) formatted API object. KYAML is a Kubernetes-specific dialect of YAML, and can be parsed as YAML.
 `-o=name`     | Print only the resource name and nothing else
 `-o=wide`     | Output in the plain-text format with any additional information, and for pods, the node name is included
 `-o=yaml`     | Output a YAML formatted API object


### PR DESCRIPTION
### Description

Documentation for KYAML output for kubectl graduating to **stable** in v1.37.

  **Tracking issue (kubernetes/enhancements):**
  - KEP-5295: https://github.com/kubernetes/enhancements/issues/5295

  **Code (kubernetes/kubernetes):**
  - Promote KYAML printer to stable: https://github.com/kubernetes/kubernetes/pull/140076

  **Changes in this PR:**
  - `reference/encodings/kyaml.md` note GA in v1.37
  - `reference/kubectl/_index.md` drop "(beta)" / "experimental" from `-o kyaml`
  - `reference/kubectl/quick-reference.md` drop "(beta)" from `-o=kyaml`

  **Out of scope (separate PR):**
  - "Kubernetes v1.37: KYAML graduates to stable" blog #56297

  **Still to confirm:**
  - At GA the `KUBECTL_KYAML` env var is removed; the entry in the generated
    `reference/kubectl/kubectl.md` may need to drop via the k/k docs regen sync.

### Issue

Closes: https://github.com/kubernetes/enhancements/issues/5295#issuecomment-4702613326