### PR TITLE
Add image volume type to Restricted Pod Security Standards allowed volumes

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -370,6 +370,7 @@ fail validation.
 					<li><code>spec.volumes[*].downwardAPI</code></li>
 					<li><code>spec.volumes[*].emptyDir</code></li>
 					<li><code>spec.volumes[*].ephemeral</code></li>
+					<li><code>spec.volumes[*].image</code></li>
 					<li><code>spec.volumes[*].persistentVolumeClaim</code></li>
 					<li><code>spec.volumes[*].projected</code></li>
 					<li><code>spec.volumes[*].secret</code></li>


### PR DESCRIPTION
Adds `spec.volumes[*].image` to the list of allowed volume types under the Restricted Pod Security Standards profile.

The ImageVolume type was permitted under Restricted in kubernetes/kubernetes#130394 (merged for v1.33), but the documentation's allowed-volumes list was never updated to reflect it. This adds the missing entry, keeping the list alphabetical.

Fixes #55370

/sig auth
/kind documentation

```release-note
NONE
```
