### PR TITLE
docs: clarify Scoop prerequisite for Windows installation

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-windows.md
+++ b/content/en/docs/tasks/tools/install-kubectl-windows.md
@@ -102,9 +102,19 @@ installer or remove the Docker Desktop's `kubectl`.
    ```
    {{% /tab %}}
    {{% tab name="scoop" %}}
+
+   If you don't already have Scoop installed:
+
    ```powershell
-   scoop install kubectl
+   irm get.scoop.sh | iex
    ```
+
+   Then install kubectl:
+
+   ```powershell
+     scoop install kubectl
+   ```
+
    {{% /tab %}}
    {{% tab name="winget" %}}
    ```powershell


### PR DESCRIPTION
## What this PR does

Adds a note in the Scoop installation section clarifying that Scoop must already be installed and links users to the official Scoop installation instructions.

The existing `scoop install kubectl` command remains unchanged because it correctly installs `kubectl` once Scoop is available.

Fixes #56338