### PR TITLE
[WIP] Add docs for cgroupOptions

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -285,6 +285,23 @@ fail validation.
 			</td>
 		</tr>
 		<tr>
+			<td style="white-space: nowrap">Cgroup Options</td>
+			<td>
+				<p>Setting cgroup options (such as writable cgroups) must be disallowed. {{< feature-state for_k8s_version="v1.37" state="alpha" >}}</p>
+				<p><strong>Restricted Fields</strong></p>
+				<ul>
+					<li><code>spec.containers[*].securityContext.cgroupOptions.mountMode</code></li>
+					<li><code>spec.initContainers[*].securityContext.cgroupOptions.mountMode</code></li>
+					<li><code>spec.ephemeralContainers[*].securityContext.cgroupOptions.mountMode</code></li>
+				</ul>
+				<p><strong>Allowed Values</strong></p>
+				<ul>
+					<li>Undefined/nil</li>
+					<li><code>ReadOnly</code></li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
   			<td>Seccomp</td>
   			<td>
   				<p>Seccomp profile must not be explicitly set to <code>Unconfined</code>.</p>

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/CgroupOptions.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/CgroupOptions.md
@@ -1,0 +1,18 @@
+---
+title: CgroupOptions
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.37"
+---
+
+Enables configuring cgroup options (such as setting `mountMode: Writable` for
+unprivileged containers on cgroup v2 systems) via the `cgroupOptions` field of a
+container's `securityContext`. See
+[Configure cgroupOptions for a Container](/docs/tasks/configure-pod-container/security-context/#configure-cgroupoptions-for-a-container)
+for details.

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -40,6 +40,9 @@ a Pod or Container. Security context settings include, but are not limited to:
 
 * `readOnlyRootFilesystem`: Mounts the container's root filesystem as read-only.
 
+* `cgroupOptions`: Configures cgroup options for a container, such as mounting
+  the container's cgroup subtree as writable.
+
 The above bullets are not a complete set of security context settings -- please see
 [SecurityContext](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#securitycontext-v1-core)
 for a comprehensive list.
@@ -839,6 +842,37 @@ spec to be `false`. In other words: a container that wishes to have an Unmasked
 [user namespace](/docs/concepts/workloads/pods/user-namespaces/).
 Kubernetes v1.12 to v1.29 did not enforce that requirement.
 {{< /note >}}
+
+## Configure cgroupOptions for a Container
+
+{{< feature-state feature_gate_name="CgroupOptions" >}}
+
+You can configure cgroup options for a container using the `cgroupOptions` field
+in the `securityContext` of a container. For example, setting `mountMode:
+Writable` enables unprivileged containers on cgroup v2 systems to have write
+access to their own delegated cgroup subtree.
+
+{{< note >}}
+Writable cgroups (`mountMode: Writable`) require Linux nodes running cgroup v2
+with the `nsdelegate` mount option enabled. This feature is not supported on
+cgroup v1.
+{{< /note >}}
+
+When `mountMode: Writable` is set, the kubelet automatically sets conservative
+limits on `cgroup.max.descendants` and `cgroup.max.depth` on the Pod-level
+cgroup to bound resource consumption from nested sub-cgroups.
+
+If the container runtime on a node does not support `CgroupOptions`, pod
+creation will fail and the kubelet will emit a `FailedNodeDeclaredFeaturesCheck`
+event on the pod.
+
+The `cgroupOptions` field is immutable after Pod creation.
+
+```yaml
+securityContext:
+  cgroupOptions:
+    mountMode: Writable
+```
 
 ## Discussion
 


### PR DESCRIPTION
Add feature gate entry and securityContext usage documentation for CgroupOptions (KEP-5474) targeting the v1.37 release cycle.

### Description

Adds user-facing documentation for KEP-5474 (`CgroupOptions`) targeting stage `alpha` in Kubernetes v1.37:

Includes the `CgroupOptions` feature gate reference, feature docs (configuration examples), prerequisites (cgroup v2 with `nsdelegate`), and pod security standards restrictions.

### Issue

Tracks: https://github.com/kubernetes/enhancements/issues/5474

@Divya063