### PR TITLE
docs: fix grammar in topology-aware scheduling concept page

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-aware-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-aware-scheduling.md
@@ -8,8 +8,8 @@ weight: 10
 {{< feature-state feature_gate_name="TopologyAwareWorkloadScheduling" >}}
 
 *Topology-Aware Scheduling* (TAS) is a [placement scheduling algorithm](/docs/concepts/scheduling-eviction/podgroup-scheduling/#placement-scheduling-algorithm)
-that allows to find the optimal placement for the considered PodGroup, guaranteeing that all pods
-will be collocated within the same topology domain. Users can accomodate TAS to their specific
+that allows finding the optimal placement for the considered PodGroup, guaranteeing that all pods
+will be collocated within the same topology domain. Users can adapt TAS to their specific
 needs by changing TAS plugins configuration.
 
 ## Scheduling framework: TAS plugins configuration


### PR DESCRIPTION
Fixes minor grammar issues in the English topology-aware scheduling documentation:

- `allows to find` → `allows finding`
- `accomodate` → `adapt` (correct word for customizing TAS)

Signed-off-by: almightymoon <almightymoon@users.noreply.github.com>

---

This pull request was prepared with assistance from an AI tool. The commit author is solely responsible for the changes; no co-authorship metadata is included on the commit.