### PR TITLE
Improve generate-ref-docs prerequisites (Go version, drop GOPATH/go get)

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -5,16 +5,16 @@
 
 - You need to have these tools installed:
 
-  - [Python](https://www.python.org/downloads/) v3.7.x+
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [Golang](https://go.dev/dl/) version 1.13+
-  - [Pip](https://pypi.org/project/pip/) used to install PyYAML
-  - [PyYAML](https://pyyaml.org/) v5.1.2
+  - [Golang](https://go.dev/dl/), matching the version required by the `go.mod` file of the `reference-docs` module you're building (`gen-apidocs`, `gen-compdocs`, or `genref`)
   - [make](https://www.gnu.org/software/make/)
   - [gcc compiler/linker](https://gcc.gnu.org/)
-  - [Docker](https://docs.docker.com/engine/installation/) (Required only for `kubectl` command reference)
+  - [Docker](https://docs.docker.com/engine/installation/) (only required for the deprecated `gen-kubectldocs` generator)
+  - [Python](https://www.python.org/downloads/) v3.7.x+, [Pip](https://pypi.org/project/pip/), and [PyYAML](https://pyyaml.org/) v5.1.2 (only required to run the deprecated `update-imported-docs.py` script)
 
-- Your `PATH` environment variable must include the required build tools, such as the `Go` binary and `python`.
+  The `reference-docs` generators are Go modules, so you don't need to set a `GOPATH` or use `go get`.
+
+- Your `PATH` environment variable must include the required build tools, such as the `Go` binary.
 
 - You need to know how to create a pull request to a GitHub repository.
   This involves creating your own fork of the repository. For more

--- a/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -11,7 +11,7 @@
   - [Go](https://go.dev/dl/), any recent release (Go downloads the exact toolchain a generator needs automatically)
   - [make](https://www.gnu.org/software/make/)
   - [gcc compiler/linker](https://gcc.gnu.org/)
-  - [Docker](https://docs.docker.com/engine/installation/) (only required by the deprecated `gen-kubectldocs` generator, or if you want to preview your changes locally with `make container-serve`)
+  - [Docker](https://docs.docker.com/engine/installation/) (required only for the local website preview with `make container-serve`)
 
 - You need to know how to create a pull request to a GitHub repository.
   This involves creating your own fork of the repository. For more

--- a/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -1,20 +1,17 @@
 
 ### Requirements:
 
-- You need a machine that is running Linux or macOS.
+- You need a machine that is running Linux or macOS. On Windows, use
+  [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install),
+  since the build tooling relies on `make` and Bash scripts.
 
 - You need to have these tools installed:
 
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [Golang](https://go.dev/dl/), matching the version required by the `go.mod` file of the `reference-docs` module you're building (`gen-apidocs`, `gen-compdocs`, or `genref`)
+  - [Go](https://go.dev/dl/), any recent release (Go downloads the exact toolchain a generator needs automatically)
   - [make](https://www.gnu.org/software/make/)
   - [gcc compiler/linker](https://gcc.gnu.org/)
-  - [Docker](https://docs.docker.com/engine/installation/) (only required for the deprecated `gen-kubectldocs` generator)
-  - [Python](https://www.python.org/downloads/) v3.7.x+, [Pip](https://pypi.org/project/pip/), and [PyYAML](https://pyyaml.org/) v5.1.2 (only required to run the deprecated `update-imported-docs.py` script)
-
-  The `reference-docs` generators are Go modules, so you don't need to set a `GOPATH` or use `go get`.
-
-- Your `PATH` environment variable must include the required build tools, such as the `Go` binary.
+  - [Docker](https://docs.docker.com/engine/installation/) (only required by the deprecated `gen-kubectldocs` generator, or if you want to preview your changes locally with `make container-serve`)
 
 - You need to know how to create a pull request to a GitHub repository.
   This involves creating your own fork of the repository. For more


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Improve generate-ref-docs prerequisites:

- Bumps the stale \`Golang ... version 1.13+\` floor to point at reference-docs' go.mod instead of a hardcoded number.
- States explicitly that reference-docs is Go-modules based (no GOPATH/go get needed).
- Reclassifies Docker as only needed for the deprecated gen-kubectldocs path (current kubectl reference uses gen-compdocs, pure Go).
- Reclassifies Python/Pip/PyYAML as only needed for the deprecated update-imported-docs.py script (slated for retirement in B4).
- Drops python from the required PATH line.

Verified Go/Docker/Python facts directly against kubernetes-sigs/reference-docs' current go.mod files and Makefile.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

Part of #56385 (sub-task A2).

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
