### PR TITLE
Add reference to Gateway API TLS guide

### DIFF
--- a/content/en/docs/concepts/services-networking/gateway.md
+++ b/content/en/docs/concepts/services-networking/gateway.md
@@ -121,7 +121,8 @@ to the Gateway by the implementation's controller. This address is used as a net
 processing traffic of backend network endpoints defined in routes.
 
 See the [Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.Gateway)
-reference for a full definition of this API kind.
+reference for a full definition of this API kind. For guidance on configuring HTTPS/TLS listeners, see the
+[Gateway API TLS Guide](https://gateway-api.sigs.k8s.io/guides/tls/).
 
 {{< note >}}
 By default, a Gateway only accepts Routes from the same namespace. Cross-namespace Routes require configuring `allowedRoutes`.


### PR DESCRIPTION

Added a "See also" reference to the official Gateway API TLS Guide to signpost readers to the Gateway API documentation for configuring HTTPS/TLS listeners.  


#56402