### PR TITLE
Modernize upstream reference docs contribution guide

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
+++ b/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
@@ -6,78 +6,88 @@ weight: 20
 
 <!-- overview -->
 
-This page shows how to contribute to the upstream `kubernetes/kubernetes` project.
-You can fix bugs found in the Kubernetes API documentation or the content of
-the Kubernetes components such as `kubeadm`, `kube-apiserver`, and `kube-controller-manager`.
+This page shows how to contribute documentation fixes to the upstream
+`kubernetes/kubernetes` project. You can fix bugs found in the Kubernetes API
+reference or in the reference pages for Kubernetes components such as `kubeadm`,
+`kube-apiserver`, and `kube-controller-manager`.
 
-If you instead want to regenerate the reference documentation for the Kubernetes
-API or the `kube-*` components from the upstream code, see the following instructions:
+If you instead want to regenerate the reference documentation from the
+upstream code, see the following instructions:
 
 - [Generating Reference Documentation for the Kubernetes API](/docs/contribute/generate-ref-docs/kubernetes-api/)
 - [Generating Reference Documentation for the Kubernetes Components and Tools](/docs/contribute/generate-ref-docs/kubernetes-components/)
 
 ## {{% heading "prerequisites" %}}
 
+- You need a machine that is running Linux or macOS.
+
 - You need to have these tools installed:
 
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [Golang](https://go.dev/doc/install) version 1.13+
-  - [Docker](https://docs.docker.com/engine/installation/)
-  - [etcd](https://github.com/coreos/etcd/)
+  - [Go](https://go.dev/doc/install), using the version required by the
+    repository you are building
   - [make](https://www.gnu.org/software/make/)
   - [gcc compiler/linker](https://gcc.gnu.org/)
+  - [Docker](https://docs.docker.com/engine/installation/), if you need to run
+    Docker-based build or preview targets
 
-- Your `GOPATH` environment variable must be set, and the location of `etcd`
-  must be in your `PATH` environment variable.
+- Your `PATH` environment variable must include the required build tools, such
+  as the `go` binary.
 
 - You need to know how to create a pull request to a GitHub repository.
   Typically, this involves creating a fork of the repository.
-  For more information, see [Creating a Pull Request](https://help.github.com/articles/creating-a-pull-request/)
-  and [GitHub Standard Fork & Pull Request Workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
+  For more information, see [Open a pull request](/docs/contribute/new-content/open-a-pr/).
+
+You do not need to set `GOPATH` or use `go get` to clone Kubernetes repositories.
+Clone the repositories with `git`.
 
 <!-- steps -->
 
 ## The big picture
 
-The reference documentation for the Kubernetes API and the `kube-*` components
-such as `kube-apiserver`, `kube-controller-manager` are automatically generated
-from the source code in the [upstream Kubernetes](https://github.com/kubernetes/kubernetes/).
+The reference documentation for the Kubernetes API and the `kube-*` components,
+such as `kube-apiserver` and `kube-controller-manager`, is generated from source
+code in the [upstream Kubernetes](https://github.com/kubernetes/kubernetes/)
+repository.
 
-When you see bugs in the generated documentation, you may want to consider
-creating a patch to fix it in the upstream project.
+When you see bugs in generated reference documentation, consider fixing the
+authoritative comments or generated inputs in the upstream project. After the
+upstream change is merged, regenerate the published reference documentation in
+the `kubernetes/website` repository.
 
-## Clone the Kubernetes repository
+## Set up the local repositories
 
-If you don't already have the kubernetes/kubernetes repository, get it now:
+Create a workspace and clone the repositories you need:
 
 ```shell
-mkdir $GOPATH/src
-cd $GOPATH/src
-go get github.com/kubernetes/kubernetes
+mkdir -p ~/src/k8s.io
+cd ~/src/k8s.io
+
+git clone https://github.com/kubernetes/kubernetes.git
+git clone https://github.com/kubernetes-sigs/reference-docs.git
+git clone https://github.com/<your-username>/website.git
 ```
 
-Determine the base directory of your clone of the
-[kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repository.
-For example, if you followed the preceding step to get the repository, your
-base directory is `$GOPATH/src/github.com/kubernetes/kubernetes`.
-The remaining steps refer to your base directory as `<k8s-base>`.
+You use the `kubernetes/kubernetes` clone to fix the upstream source comments
+and regenerate upstream generated files. You use the `reference-docs` and
+`website` clones later to verify and publish the reference documentation.
 
-Determine the base directory of your clone of the
-[kubernetes-sigs/reference-docs](https://github.com/kubernetes-sigs/reference-docs) repository.
-For example, if you followed the preceding step to get the repository, your
-base directory is `$GOPATH/src/github.com/kubernetes-sigs/reference-docs`.
-The remaining steps refer to your base directory as `<rdocs-base>`.
+The remaining steps refer to these local paths:
+
+- `<k8s-base>`: your `kubernetes/kubernetes` clone
+- `<rdocs-base>`: your `kubernetes-sigs/reference-docs` clone
+- `<web-base>`: your `kubernetes/website` fork clone
 
 ## Edit the Kubernetes source code
 
-The Kubernetes API reference documentation is automatically generated from
-an OpenAPI spec, which is generated from the Kubernetes source code. If you
-want to change the API reference documentation, the first step is to change one
-or more comments in the Kubernetes source code.
+The Kubernetes API reference documentation is generated from an OpenAPI spec,
+which is generated from the Kubernetes source code. If you want to change the
+API reference documentation, the first step is to change one or more comments in
+the Kubernetes source code.
 
-The documentation for the `kube-*` components is also generated from the upstream
-source code. You must change the code related to the component
-you want to fix in order to fix the generated documentation.
+The documentation for the `kube-*` components is also generated from upstream
+source code. You must change the code related to the component you want to fix
+in order to fix the generated documentation.
 
 ### Make changes to the upstream source code
 
@@ -88,7 +98,7 @@ will be different in your situation.
 
 Here's an example of editing a comment in the Kubernetes source code.
 
-In your local kubernetes/kubernetes repository, check out the default branch,
+In your local `kubernetes/kubernetes` repository, check out the default branch
 and make sure it is up to date:
 
 ```shell
@@ -97,11 +107,11 @@ git checkout master
 git pull https://github.com/kubernetes/kubernetes master
 ```
 
-Suppose this source file in that default branch has the typo "atmost":
+Suppose this source file in that default branch has the typo `atmost`:
 
 [kubernetes/kubernetes/staging/src/k8s.io/api/apps/v1/types.go](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/apps/v1/types.go)
 
-In your local environment, open `types.go`, and change "atmost" to "at most".
+In your local environment, open `types.go`, and change `atmost` to `at most`.
 
 Verify that you have changed the file:
 
@@ -109,10 +119,10 @@ Verify that you have changed the file:
 git status
 ```
 
-The output shows that you are on the master branch, and that the `types.go`
+The output shows that you are on the `master` branch, and that the `types.go`
 source file has been modified:
 
-```shell
+```none
 On branch master
 ...
     modified:   staging/src/k8s.io/api/apps/v1/types.go
@@ -120,8 +130,9 @@ On branch master
 
 ### Commit your edited file
 
-Run `git add` and `git commit` to commit the changes you have made so far. In the next step,
-you will do a second commit. It is important to keep your changes separated into two commits.
+Run `git add` and `git commit` to commit the changes you have made so far. In the
+next step, you will do a second commit. It is important to keep your source
+changes and generated changes separated into two commits.
 
 ### Generate the OpenAPI spec and related files
 
@@ -134,7 +145,7 @@ Go to `<k8s-base>` and run these scripts:
 
 Run `git status` to see what was generated.
 
-```shell
+```none
 On branch master
 ...
     modified:   api/openapi-spec/swagger.json
@@ -144,18 +155,22 @@ On branch master
     modified:   staging/src/k8s.io/api/apps/v1/types_swagger_doc_generated.go
 ```
 
-View the contents of `api/openapi-spec/swagger.json` to make sure the typo is fixed.
-For example, you could run `git diff -a api/openapi-spec/swagger.json`.
-This is important, because `swagger.json` is the input to the second stage of
-the doc generation process.
+View the contents of `api/openapi-spec/swagger.json` to make sure the typo is
+fixed. For example, you could run:
 
-Run `git add` and `git commit` to commit your changes. Now you have two commits:
-one that contains the edited `types.go` file, and one that contains the generated OpenAPI spec
-and related files. Keep these two commits separate. That is, do not squash your commits.
+```shell
+git diff -a api/openapi-spec/swagger.json
+```
 
-Submit your changes as a
-[pull request](https://help.github.com/articles/creating-a-pull-request/) to the
-master branch of the
+This is important because `swagger.json` is the input to the next stage of the
+reference documentation generation process.
+
+Run `git add` and `git commit` to commit your generated changes. Now you have two
+commits: one that contains the edited `types.go` file, and one that contains the
+generated OpenAPI spec and related files. Keep these two commits separate. Do not
+squash your commits.
+
+Submit your changes as a pull request to the `master` branch of the
 [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repository.
 Monitor your pull request, and respond to reviewer comments as needed. Continue
 to monitor your pull request until it is merged.
@@ -164,11 +179,11 @@ to monitor your pull request until it is merged.
 is an example of a pull request that fixes a typo in the Kubernetes source code.
 
 {{< note >}}
-It can be tricky to determine the correct source file to be changed. In the
+It can be tricky to determine the correct source file to change. In the
 preceding example, the authoritative source file is in the `staging` directory
-in the `kubernetes/kubernetes` repository. But in your situation,the `staging` directory
-might not be the place to find the authoritative source. For guidance, check the
-`README` files in
+in the `kubernetes/kubernetes` repository. In your situation, the `staging`
+directory might not be the authoritative source. For guidance, check the
+`README` files in the
 [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/tree/master/staging)
 repository and in related repositories, such as
 [kubernetes/apiserver](https://github.com/kubernetes/apiserver/blob/master/README.md).
@@ -176,52 +191,57 @@ repository and in related repositories, such as
 
 ### Cherry pick your commit into a release branch
 
-In the preceding section, you edited a file in the master branch and then ran scripts
-to generate an OpenAPI spec and related files. Then you submitted your changes in a pull request
-to the master branch of the kubernetes/kubernetes repository. Now suppose you want to backport
-your change into a release branch. For example, suppose the master branch is being used to develop
-Kubernetes version {{< skew latestVersion >}}, and you want to backport your change into the
+In the preceding section, you edited a file in the `master` branch, ran scripts
+to generate an OpenAPI spec and related files, and submitted your changes in a
+pull request to the `master` branch of the `kubernetes/kubernetes` repository.
+Now suppose you want to backport your change into a release branch. For example,
+suppose the `master` branch is being used to develop Kubernetes version
+{{< skew latestVersion >}}, and you want to backport your change into the
 release-{{< skew prevMinorVersion >}} branch.
 
-Recall that your pull request has two commits: one for editing `types.go`
-and one for the files generated by scripts. The next step is to propose a cherry pick of your first
-commit into the release-{{< skew prevMinorVersion >}} branch. The idea is to cherry pick the commit
-that edited `types.go`, but not the commit that has the results of running the scripts. For instructions, see
+Recall that your pull request has two commits: one for editing `types.go` and
+one for the files generated by scripts. The next step is to propose a cherry pick
+of your first commit into the release-{{< skew prevMinorVersion >}} branch. The
+idea is to cherry pick the commit that edited `types.go`, but not the commit
+that has the results of running the scripts. For instructions, see
 [Propose a Cherry Pick](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md).
 
 {{< note >}}
-Proposing a cherry pick requires that you have permission to set a label and a milestone in your
-pull request. If you don't have those permissions, you will need to work with someone who can set the label
-and milestone for you.
+Proposing a cherry pick requires that you have permission to set a label and a
+milestone in your pull request. If you don't have those permissions, you need to
+work with someone who can set the label and milestone for you.
 {{< /note >}}
 
-When you have a pull request in place for cherry picking your one commit into the
-release-{{< skew prevMinorVersion >}} branch, the next step is to run these scripts in the
-release-{{< skew prevMinorVersion >}} branch of your local environment.
+When you have a pull request in place for cherry picking your one commit into
+the release-{{< skew prevMinorVersion >}} branch, run these scripts in the
+release-{{< skew prevMinorVersion >}} branch of your local environment:
 
 ```shell
 ./hack/update-codegen.sh
 ./hack/update-openapi-spec.sh
 ```
 
-Now add a commit to your cherry-pick pull request that has the recently generated OpenAPI spec
-and related files. Monitor your pull request until it gets merged into the
-release-{{< skew prevMinorVersion >}} branch.
+Add a commit to your cherry-pick pull request that has the recently generated
+OpenAPI spec and related files. Monitor your pull request until it gets merged
+into the release-{{< skew prevMinorVersion >}} branch.
 
-At this point, both the master branch and the release-{{< skew prevMinorVersion >}} branch have your updated `types.go`
-file and a set of generated files that reflect the change you made to `types.go`. Note that the
-generated OpenAPI spec and other generated files in the release-{{< skew prevMinorVersion >}} branch are not necessarily
-the same as the generated files in the master branch. The generated files in the release-{{< skew prevMinorVersion >}} branch
-contain API elements only from Kubernetes {{< skew prevMinorVersion >}}. The generated files in the master branch might contain
-API elements that are not in {{< skew prevMinorVersion >}}, but are under development for {{< skew latestVersion >}}.
+At this point, both the `master` branch and the
+release-{{< skew prevMinorVersion >}} branch have your updated `types.go` file
+and a set of generated files that reflect the change you made to `types.go`.
+The generated OpenAPI spec and other generated files in the
+release-{{< skew prevMinorVersion >}} branch are not necessarily the same as the
+generated files in the `master` branch. The generated files in the release
+branch contain API elements only from Kubernetes {{< skew prevMinorVersion >}}.
+The generated files in the `master` branch might contain API elements that are
+not in {{< skew prevMinorVersion >}}, but are under development for Kubernetes
+{{< skew latestVersion >}}.
 
 ## Generate the published reference docs
 
-The preceding section showed how to edit a source file and then generate
-several files, including `api/openapi-spec/swagger.json` in the
-`kubernetes/kubernetes` repository.
-The `swagger.json` file is the OpenAPI definition file to use for generating
-the API reference documentation.
+The preceding section showed how to edit a source file and then generate several
+files, including `api/openapi-spec/swagger.json` in the
+`kubernetes/kubernetes` repository. The `swagger.json` file is the OpenAPI
+definition file to use for generating the API reference documentation.
 
 You are now ready to follow the
 [Generating Reference Documentation for the Kubernetes API](/docs/contribute/generate-ref-docs/kubernetes-api/)


### PR DESCRIPTION
Fixes kubernetes/website#56385 (A3)

## Changes

- Modernizes `contribute-upstream.md` setup instructions to use `git clone` instead of GOPATH-era `go get`.
- Removes stale prerequisites such as Go 1.13 and etcd.
- Clarifies how the `kubernetes/kubernetes`, `reference-docs`, and `website` clones are used in the upstream fix workflow.
- Keeps the existing fix-content-in-`kubernetes/kubernetes` flow, including separate source and generated-file commits.
- Refreshes wording around generated OpenAPI files, branch naming, and pull request steps.

## Validation

- `git diff --check`
- `git show --check --oneline HEAD`

I could not run the full reference-doc generator flow from this environment because `go` and `make` are not installed, and the available WSL backend failed to start. I verified the documented upstream script paths through the GitHub API:

- `hack/update-codegen.sh`
- `hack/update-openapi-spec.sh`
- `staging/src/k8s.io/api/apps/v1/types.go`
