### PR TITLE
Localize network-policy-provider pages (cilium, kube-router, romana, …

### DIFF
--- a/content/hi/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
+++ b/content/hi/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy.md
@@ -1,0 +1,112 @@
+---
+title: नेटवर्कपॉलिसी के लिए Cilium का उपयोग करें
+content_type: task
+weight: 30
+---
+
+<!-- overview -->
+
+यह पेज दिखाता है कि नेटवर्कपॉलिसी के लिए Cilium का उपयोग कैसे करें।
+
+Cilium की पृष्ठभूमि जानने के लिए, [Cilium का परिचय](https://docs.cilium.io/en/stable/overview/intro) पढ़ें।
+
+## {{% heading "prerequisites" %}}
+
+{{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
+
+<!-- steps -->
+
+## बुनियादी परीक्षण के लिए Minikube पर Cilium डिप्लॉय करना {#deploying-cilium-on-minikube-for-basic-testing}
+
+Cilium से आसानी से परिचित होने के लिए, आप minikube में Cilium की एक बुनियादी DaemonSet इंस्टॉलेशन करने हेतु
+[Cilium कुबेरनेट्स गेटिंग स्टार्टेड गाइड](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/)
+का पालन कर सकते हैं।
+
+minikube शुरू करने के लिए, जिसके लिए संस्करण v1.5.2 या उससे उच्चतर आवश्यक है, इसे निम्नलिखित
+आर्गुमेंट्स के साथ चलाएँ:
+
+```shell
+minikube version
+```
+
+```
+minikube version: v1.5.2
+```
+
+```shell
+minikube start --network-plugin=cni
+```
+
+minikube के लिए आप इसके CLI टूल का उपयोग करके Cilium इंस्टॉल कर सकते हैं। ऐसा करने के लिए, पहले
+निम्नलिखित कमांड के साथ CLI का नवीनतम संस्करण डाउनलोड करें:
+
+```shell
+curl -LO https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-amd64.tar.gz
+```
+
+फिर निम्नलिखित कमांड के साथ डाउनलोड की गई फ़ाइल को अपनी `/usr/local/bin` डायरेक्टरी में एक्सट्रैक्ट करें:
+
+```shell
+sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
+rm cilium-linux-amd64.tar.gz
+```
+
+उपरोक्त कमांड चलाने के बाद, अब आप निम्नलिखित कमांड के साथ Cilium इंस्टॉल कर सकते हैं:
+
+```shell
+cilium install
+```
+
+इसके बाद Cilium स्वचालित रूप से क्लस्टर कॉन्फ़िगरेशन का पता लगाएगा और सफल इंस्टॉलेशन के लिए उपयुक्त
+घटकों को बनाकर इंस्टॉल करेगा। ये घटक हैं:
+
+- Secret `cilium-ca` में सर्टिफ़िकेट अथॉरिटी (CA) और Hubble (Cilium की ऑब्ज़र्वेबिलिटी लेयर) के लिए सर्टिफ़िकेट।
+- सर्विस अकाउंट्स।
+- क्लस्टर रोल्स।
+- ConfigMap।
+- एजेंट DaemonSet और एक ऑपरेटर Deployment।
+
+इंस्टॉलेशन के बाद, आप `cilium status` कमांड से Cilium डिप्लॉयमेंट की समग्र स्थिति देख सकते हैं।
+`status` कमांड का अपेक्षित आउटपुट
+[यहाँ](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#validate-the-installation) देखें।
+
+शेष गेटिंग स्टार्टेड गाइड यह समझाती है कि किसी उदाहरण एप्लिकेशन का उपयोग करके L3/L4
+(अर्थात् IP पता + पोर्ट) सुरक्षा पॉलिसीज़ के साथ-साथ L7 (जैसे, HTTP) सुरक्षा
+पॉलिसीज़ को कैसे लागू किया जाए।
+
+## उत्पादन उपयोग के लिए Cilium डिप्लॉय करना {#deploying-cilium-for-production-use}
+
+उत्पादन के लिए Cilium डिप्लॉय करने से संबंधित विस्तृत निर्देशों हेतु, देखें:
+[Cilium कुबेरनेट्स इंस्टॉलेशन गाइड](https://docs.cilium.io/en/stable/network/kubernetes/concepts/)।
+इस दस्तावेज़ में विस्तृत आवश्यकताएँ, निर्देश और उदाहरण
+उत्पादन DaemonSet फ़ाइलें शामिल हैं।
+
+<!-- discussion -->
+
+## Cilium घटकों को समझना {#understanding-cilium-components}
+
+Cilium के साथ एक क्लस्टर डिप्लॉय करने से `kube-system` नेमस्पेस में पॉड्स जुड़ जाते हैं। पॉड्स की यह
+सूची देखने के लिए चलाएँ:
+
+```shell
+kubectl get pods --namespace=kube-system -l k8s-app=cilium
+```
+
+आपको इसके समान पॉड्स की एक सूची दिखाई देगी:
+
+```console
+NAME           READY   STATUS    RESTARTS   AGE
+cilium-kkdhz   1/1     Running   0          3m23s
+...
+```
+
+एक `cilium` पॉड आपके क्लस्टर के प्रत्येक नोड पर चलता है और Linux BPF का उपयोग करके उस नोड पर
+पॉड्स से आने-जाने वाले ट्रैफ़िक पर नेटवर्क पॉलिसी लागू करता है।
+
+## {{% heading "whatsnext" %}}
+
+एक बार जब आपका क्लस्टर चल रहा हो, तो आप Cilium के साथ कुबेरनेट्स नेटवर्कपॉलिसी आज़माने के लिए
+[नेटवर्क पॉलिसी घोषित करें](/docs/tasks/administer-cluster/declare-network-policy/)
+का पालन कर सकते हैं।
+आनंद लें, और यदि आपके कोई प्रश्न हों, तो
+[Cilium Slack चैनल](https://slack.cilium.io/) का उपयोग करके हमसे संपर्क करें।

--- a/content/hi/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy.md
+++ b/content/hi/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy.md
@@ -1,0 +1,23 @@
+---
+title: नेटवर्कपॉलिसी के लिए Kube-router का उपयोग करें
+content_type: task
+weight: 40
+---
+
+<!-- overview -->
+यह पेज दिखाता है कि नेटवर्कपॉलिसी के लिए [Kube-router](https://github.com/cloudnativelabs/kube-router) का उपयोग कैसे करें।
+
+
+## {{% heading "prerequisites" %}}
+
+आपके पास एक चालू कुबेरनेट्स क्लस्टर होना चाहिए। यदि आपके पास पहले से कोई क्लस्टर नहीं है, तो आप Kops, Bootkube, Kubeadm आदि जैसे किसी भी क्लस्टर इंस्टॉलर का उपयोग करके एक बना सकते हैं।
+
+
+<!-- steps -->
+## Kube-router ऐडऑन इंस्टॉल करना {#installing-kube-router-addon}
+Kube-router ऐडऑन एक नेटवर्क पॉलिसी कंट्रोलर के साथ आता है जो किसी भी नेटवर्कपॉलिसी और अपडेट किए गए पॉड्स के लिए कुबेरनेट्स API सर्वर पर नज़र रखता है, और पॉलिसीज़ के निर्देशानुसार ट्रैफ़िक को अनुमति देने या ब्लॉक करने के लिए iptables नियमों तथा ipsets को कॉन्फ़िगर करता है। Kube-router ऐडऑन इंस्टॉल करने के लिए कृपया [क्लस्टर इंस्टॉलर के साथ Kube-router आज़माना](https://www.kube-router.io/docs/user-guide/#try-kube-router-with-cluster-installers) गाइड का पालन करें।
+
+
+## {{% heading "whatsnext" %}}
+
+एक बार जब आप Kube-router ऐडऑन इंस्टॉल कर लेते हैं, तो आप कुबेरनेट्स नेटवर्कपॉलिसी आज़माने के लिए [नेटवर्क पॉलिसी घोषित करें](/docs/tasks/administer-cluster/declare-network-policy/) का पालन कर सकते हैं।

--- a/content/hi/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy.md
+++ b/content/hi/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy.md
@@ -1,0 +1,33 @@
+---
+title: नेटवर्कपॉलिसी के लिए Romana
+content_type: task
+weight: 50
+---
+
+<!-- overview -->
+
+यह पेज दिखाता है कि नेटवर्कपॉलिसी के लिए Romana का उपयोग कैसे करें।
+
+## {{% heading "prerequisites" %}}
+
+[kubeadm गेटिंग स्टार्टेड गाइड](/docs/reference/setup-tools/kubeadm/) के चरण 1, 2 और 3 पूरे करें।
+
+<!-- steps -->
+
+## kubeadm के साथ Romana इंस्टॉल करना {#installing-romana-with-kubeadm}
+
+kubeadm के लिए [कंटेनरीकृत इंस्टॉलेशन गाइड](https://github.com/romana/romana/tree/master/containerize) का पालन करें।
+
+## नेटवर्क पॉलिसीज़ लागू करना {#applying-network-policies}
+
+नेटवर्क पॉलिसीज़ लागू करने के लिए निम्नलिखित में से किसी एक का उपयोग करें:
+
+* [Romana नेटवर्क पॉलिसीज़](https://github.com/romana/romana/wiki/Romana-policies)।
+    * [Romana नेटवर्क पॉलिसी का उदाहरण](https://github.com/romana/core/blob/master/doc/policy.md)।
+* NetworkPolicy API।
+
+## {{% heading "whatsnext" %}}
+
+एक बार जब आप Romana इंस्टॉल कर लेते हैं, तो आप कुबेरनेट्स नेटवर्कपॉलिसी आज़माने के लिए
+[नेटवर्क पॉलिसी घोषित करें](/docs/tasks/administer-cluster/declare-network-policy/)
+का पालन कर सकते हैं।

--- a/content/hi/docs/tasks/administer-cluster/network-policy-provider/weave-network-policy.md
+++ b/content/hi/docs/tasks/administer-cluster/network-policy-provider/weave-network-policy.md
@@ -1,0 +1,53 @@
+---
+title: नेटवर्कपॉलिसी के लिए Weave Net
+content_type: task
+weight: 60
+---
+
+<!-- overview -->
+
+यह पेज दिखाता है कि नेटवर्कपॉलिसी के लिए Weave Net का उपयोग कैसे करें।
+
+## {{% heading "prerequisites" %}}
+
+आपके पास एक कुबेरनेट्स क्लस्टर होना चाहिए। एक क्लस्टर बूटस्ट्रैप करने के लिए
+[kubeadm गेटिंग स्टार्टेड गाइड](/docs/reference/setup-tools/kubeadm/) का पालन करें।
+
+<!-- steps -->
+
+## Weave Net ऐडऑन इंस्टॉल करें {#install-the-weave-net-addon}
+
+[ऐडऑन के माध्यम से कुबेरनेट्स को इंटीग्रेट करना](https://github.com/weaveworks/weave/blob/master/site/kubernetes/kube-addon.md#-installation) गाइड का पालन करें।
+
+कुबेरनेट्स के लिए Weave Net ऐडऑन एक
+[नेटवर्क पॉलिसी कंट्रोलर](https://github.com/weaveworks/weave/blob/master/site/kubernetes/kube-addon.md#network-policy)
+के साथ आता है, जो सभी नेमस्पेस पर किसी भी नेटवर्कपॉलिसी एनोटेशन के लिए कुबेरनेट्स की स्वचालित रूप से निगरानी करता है और पॉलिसीज़ के निर्देशानुसार ट्रैफ़िक को अनुमति देने या ब्लॉक करने के लिए `iptables` नियमों को कॉन्फ़िगर करता है।
+
+## इंस्टॉलेशन का परीक्षण करें {#test-the-installation}
+
+सत्यापित करें कि weave काम करता है।
+
+निम्नलिखित कमांड दर्ज करें:
+
+```shell
+kubectl get pods -n kube-system -o wide
+```
+
+आउटपुट इसके समान है:
+
+```
+NAME                                    READY     STATUS    RESTARTS   AGE       IP              NODE
+weave-net-1t1qg                         2/2       Running   0          9d        192.168.2.10    worknode3
+weave-net-231d7                         2/2       Running   1          7d        10.2.0.17       worknodegpu
+weave-net-7nmwt                         2/2       Running   3          9d        192.168.2.131   masternode
+weave-net-pmw8w                         2/2       Running   0          9d        192.168.2.216   worknode2
+```
+
+प्रत्येक नोड में एक weave पॉड है, और सभी पॉड्स `Running` तथा `2/2 READY` हैं। (`2/2` का अर्थ है कि प्रत्येक पॉड में `weave` और `weave-npc` हैं।)
+
+## {{% heading "whatsnext" %}}
+
+एक बार जब आप Weave Net ऐडऑन इंस्टॉल कर लेते हैं, तो आप कुबेरनेट्स नेटवर्कपॉलिसी आज़माने के लिए
+[नेटवर्क पॉलिसी घोषित करें](/docs/tasks/administer-cluster/declare-network-policy/)
+का पालन कर सकते हैं। यदि आपका कोई प्रश्न है, तो हमसे
+[Slack पर #weave-community या Weave यूज़र ग्रुप](https://github.com/weaveworks/weave#getting-help) पर संपर्क करें।


### PR DESCRIPTION
### Description

Localizes the remaining Network Policy Provider pages to Hindi (part of #47439):

- cilium-network-policy.md
- kube-router-network-policy.md
- romana-network-policy.md
- weave-network-policy.md

These complete the Hindi localization of the `network-policy-provider` section
(`_index`, `antrea`, and `calico` were already localized). Translations follow the
existing `hi` convention: titles and prose are translated, while code blocks,
shortcodes, links, and product names (Cilium, Kube-router, Romana, Weave Net,
kubeadm, etc.) are preserved, and the original heading anchors are retained.

/language hi
/kind localization