### PR TITLE
Fix ContainerStatus section in Pod API reference

### DIFF
--- a/content/en/docs/reference/kubernetes-api/core/pod-v1.md
+++ b/content/en/docs/reference/kubernetes-api/core/pod-v1.md
@@ -341,30 +341,193 @@ PodStatus represents information about the status of a pod. Status may trail the
 
 PodList is a list of Pods.
 
+## ContainerStatus {#ContainerStatus}
+
+ContainerStatus contains details for the current status of this container.
+
 <hr>
 
-<table>
-  <thead><tr><th>Field</th><th>Description</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><code>apiVersion</code><br/><em>string</em></td>
-      <td>APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources</td>
-    </tr>
-    <tr>
-      <td><code>items</code>&nbsp;<strong>*</strong><br/><em><a href="{{< ref "pod-v1#Pod" >}}">Pod array</a></em></td>
-      <td>List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md</td>
-    </tr>
-    <tr>
-      <td><code>kind</code><br/><em>string</em></td>
-      <td>Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</td>
-    </tr>
-    <tr>
-      <td><code>metadata</code><br/><em><a href="{{< ref "../definitions/list-meta-v1-meta#ListMeta" >}}">ListMeta</a></em></td>
-      <td>Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</td>
-    </tr>
-  </tbody>
-</table>
+- **name** (string), required
 
+  This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
+
+- **image** (string), required
+
+  The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images
+
+- **imageID** (string), required
+
+  ImageID of the container's image.
+
+- **containerID** (string)
+
+  Container's ID in the format 'docker://\<container_id>'.
+
+- **state** (ContainerState)
+
+  Details about the container's current condition.
+
+  <a name="ContainerState"></a>
+  *ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.*
+
+  - **state.running** (ContainerStateRunning)
+
+    Details about a running container
+
+    <a name="ContainerStateRunning"></a>
+    *ContainerStateRunning is a running state of a container.*
+
+    - **state.running.startedAt** (Time)
+
+      Time at which the container was last (re-)started
+
+      <a name="Time"></a>
+      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **state.terminated** (ContainerStateTerminated)
+
+    Details about a terminated container
+
+    <a name="ContainerStateTerminated"></a>
+    *ContainerStateTerminated is a terminated state of a container.*
+
+    - **state.terminated.containerID** (string)
+
+      Container's ID in the format 'docker://\<container_id>'
+
+    - **state.terminated.exitCode** (int32), required
+
+      Exit status from the last termination of the container
+
+    - **state.terminated.startedAt** (Time)
+
+      Time at which previous execution of the container started
+
+      <a name="Time"></a>
+      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+    - **state.terminated.finishedAt** (Time)
+
+      Time at which the container last terminated
+
+      <a name="Time"></a>
+      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+    - **state.terminated.message** (string)
+
+      Message regarding the last termination of the container
+
+    - **state.terminated.reason** (string)
+
+      (brief) reason from the last termination of the container
+
+    - **state.terminated.signal** (int32)
+
+      Signal from the last termination of the container
+
+  - **state.waiting** (ContainerStateWaiting)
+
+    Details about a waiting container
+
+    <a name="ContainerStateWaiting"></a>
+    *ContainerStateWaiting is a waiting state of a container.*
+
+    - **state.waiting.message** (string)
+
+      Message regarding why the container is not yet running.
+
+    - **state.waiting.reason** (string)
+
+      (brief) reason the container is not yet running.
+
+- **lastState** (ContainerState)
+
+  Details about the container's last termination condition.
+
+  <a name="ContainerState"></a>
+  *ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.*
+
+  - **lastState.running** (ContainerStateRunning)
+
+    Details about a running container
+
+    <a name="ContainerStateRunning"></a>
+    *ContainerStateRunning is a running state of a container.*
+
+    - **lastState.running.startedAt** (Time)
+
+      Time at which the container was last (re-)started
+
+      <a name="Time"></a>
+      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+  - **lastState.terminated** (ContainerStateTerminated)
+
+    Details about a terminated container
+
+    <a name="ContainerStateTerminated"></a>
+    *ContainerStateTerminated is a terminated state of a container.*
+
+    - **lastState.terminated.containerID** (string)
+
+      Container's ID in the format 'docker://\<container_id>'
+
+    - **lastState.terminated.exitCode** (int32), required
+
+      Exit status from the last termination of the container
+
+    - **lastState.terminated.startedAt** (Time)
+
+      Time at which previous execution of the container started
+
+      <a name="Time"></a>
+      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+    - **lastState.terminated.finishedAt** (Time)
+
+      Time at which the container last terminated
+
+      <a name="Time"></a>
+      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+    - **lastState.terminated.message** (string)
+
+      Message regarding the last termination of the container
+
+    - **lastState.terminated.reason** (string)
+
+      (brief) reason from the last termination of the container
+
+    - **lastState.terminated.signal** (int32)
+
+      Signal from the last termination of the container
+
+  - **lastState.waiting** (ContainerStateWaiting)
+
+    Details about a waiting container
+
+    <a name="ContainerStateWaiting"></a>
+    *ContainerStateWaiting is a waiting state of a container.*
+
+    - **lastState.waiting.message** (string)
+
+      Message regarding why the container is not yet running.
+
+    - **lastState.waiting.reason** (string)
+
+      (brief) reason the container is not yet running.
+
+- **ready** (boolean), required
+
+  Specifies whether the container has passed its readiness probe.
+
+- **restartCount** (int32), required
+
+  The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.
+
+- **started** (boolean)
+
+  Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
 
 ## Affinity {#Affinity}
 

--- a/content/en/docs/reference/kubernetes-api/core/pod-v1.md
+++ b/content/en/docs/reference/kubernetes-api/core/pod-v1.md
@@ -347,187 +347,47 @@ ContainerStatus contains details for the current status of this container.
 
 <hr>
 
-- **name** (string), required
-
-  This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
-
-- **image** (string), required
-
-  The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images
-
-- **imageID** (string), required
-
-  ImageID of the container's image.
-
-- **containerID** (string)
-
-  Container's ID in the format 'docker://\<container_id>'.
-
-- **state** (ContainerState)
-
-  Details about the container's current condition.
-
-  <a name="ContainerState"></a>
-  *ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.*
-
-  - **state.running** (ContainerStateRunning)
-
-    Details about a running container
-
-    <a name="ContainerStateRunning"></a>
-    *ContainerStateRunning is a running state of a container.*
-
-    - **state.running.startedAt** (Time)
-
-      Time at which the container was last (re-)started
-
-      <a name="Time"></a>
-      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
-
-  - **state.terminated** (ContainerStateTerminated)
-
-    Details about a terminated container
-
-    <a name="ContainerStateTerminated"></a>
-    *ContainerStateTerminated is a terminated state of a container.*
-
-    - **state.terminated.containerID** (string)
-
-      Container's ID in the format 'docker://\<container_id>'
-
-    - **state.terminated.exitCode** (int32), required
-
-      Exit status from the last termination of the container
-
-    - **state.terminated.startedAt** (Time)
-
-      Time at which previous execution of the container started
-
-      <a name="Time"></a>
-      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
-
-    - **state.terminated.finishedAt** (Time)
-
-      Time at which the container last terminated
-
-      <a name="Time"></a>
-      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
-
-    - **state.terminated.message** (string)
-
-      Message regarding the last termination of the container
-
-    - **state.terminated.reason** (string)
-
-      (brief) reason from the last termination of the container
-
-    - **state.terminated.signal** (int32)
-
-      Signal from the last termination of the container
-
-  - **state.waiting** (ContainerStateWaiting)
-
-    Details about a waiting container
-
-    <a name="ContainerStateWaiting"></a>
-    *ContainerStateWaiting is a waiting state of a container.*
-
-    - **state.waiting.message** (string)
-
-      Message regarding why the container is not yet running.
-
-    - **state.waiting.reason** (string)
-
-      (brief) reason the container is not yet running.
-
-- **lastState** (ContainerState)
-
-  Details about the container's last termination condition.
-
-  <a name="ContainerState"></a>
-  *ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.*
-
-  - **lastState.running** (ContainerStateRunning)
-
-    Details about a running container
-
-    <a name="ContainerStateRunning"></a>
-    *ContainerStateRunning is a running state of a container.*
-
-    - **lastState.running.startedAt** (Time)
-
-      Time at which the container was last (re-)started
-
-      <a name="Time"></a>
-      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
-
-  - **lastState.terminated** (ContainerStateTerminated)
-
-    Details about a terminated container
-
-    <a name="ContainerStateTerminated"></a>
-    *ContainerStateTerminated is a terminated state of a container.*
-
-    - **lastState.terminated.containerID** (string)
-
-      Container's ID in the format 'docker://\<container_id>'
-
-    - **lastState.terminated.exitCode** (int32), required
-
-      Exit status from the last termination of the container
-
-    - **lastState.terminated.startedAt** (Time)
-
-      Time at which previous execution of the container started
-
-      <a name="Time"></a>
-      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
-
-    - **lastState.terminated.finishedAt** (Time)
-
-      Time at which the container last terminated
-
-      <a name="Time"></a>
-      *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
-
-    - **lastState.terminated.message** (string)
-
-      Message regarding the last termination of the container
-
-    - **lastState.terminated.reason** (string)
-
-      (brief) reason from the last termination of the container
-
-    - **lastState.terminated.signal** (int32)
-
-      Signal from the last termination of the container
-
-  - **lastState.waiting** (ContainerStateWaiting)
-
-    Details about a waiting container
-
-    <a name="ContainerStateWaiting"></a>
-    *ContainerStateWaiting is a waiting state of a container.*
-
-    - **lastState.waiting.message** (string)
-
-      Message regarding why the container is not yet running.
-
-    - **lastState.waiting.reason** (string)
-
-      (brief) reason the container is not yet running.
-
-- **ready** (boolean), required
-
-  Specifies whether the container has passed its readiness probe.
-
-- **restartCount** (int32), required
-
-  The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.
-
-- **started** (boolean)
-
-  Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
+<table>
+  <thead><tr><th>Field</th><th>Description</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>name</code> <strong>*</strong><br/><em>string</em></td>
+      <td>This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.</td>
+    </tr>
+    <tr>
+      <td><code>image</code> <strong>*</strong><br/><em>string</em></td>
+      <td>The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images</td>
+    </tr>
+    <tr>
+      <td><code>imageID</code> <strong>*</strong><br/><em>string</em></td>
+      <td>ImageID of the container's image.</td>
+    </tr>
+    <tr>
+      <td><code>containerID</code><br/><em>string</em></td>
+      <td>Container's ID in the format 'docker://&lt;container_id&gt;'.</td>
+    </tr>
+    <tr>
+      <td><code>state</code><br/><em>ContainerState</em></td>
+      <td>Details about the container's current condition.</td>
+    </tr>
+    <tr>
+      <td><code>lastState</code><br/><em>ContainerState</em></td>
+      <td>Details about the container's last termination condition.</td>
+    </tr>
+    <tr>
+      <td><code>ready</code> <strong>*</strong><br/><em>boolean</em></td>
+      <td>Specifies whether the container has passed its readiness probe.</td>
+    </tr>
+    <tr>
+      <td><code>restartCount</code> <strong>*</strong><br/><em>int32</em></td>
+      <td>The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.</td>
+    </tr>
+    <tr>
+      <td><code>started</code><br/><em>boolean</em></td>
+      <td>Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Affinity {#Affinity}
 


### PR DESCRIPTION
## What this PR does

This PR fixes the `ContainerStatus` section in the Pod API reference.

The previous content incorrectly displayed fields from `PodList`. This change replaces it with the correct `ContainerStatus` documentation generated from the API reference source.

## Issue

Fixes the incorrect `ContainerStatus` documentation in:
`content/en/docs/reference/kubernetes-api/core/pod-v1.md`

#56427
