### PR TITLE
Fix broken link in JSONSchemaProps description

### DIFF
--- a/content/en/docs/reference/kubernetes-api/apiextensions/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/apiextensions/custom-resource-definition-v1.md
@@ -437,7 +437,7 @@ JSON represents any valid JSON value. These types are supported: bool, int64, fl
 
 ## JSONSchemaProps {#JSONSchemaProps}
 
-JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+JSONSchemaProps is a JSON-Schema following Specification Draft 4 (<https://json-schema.org/>).
 
 <hr>
 


### PR DESCRIPTION
This PR was created with the assistance of generative AI.

Fixes #53971

The JSONSchemaProps description had a broken link http://json-schema.org/) where the trailing ) was included in the URL. Fixed by wrapping the URL in angle brackets and upgrading to HTTPS.