### PR TITLE
Fix confusing kube-proxy reference in front-proxy certificates note

### DIFF
--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -58,7 +58,7 @@ In this scenario, there are two approaches for certificate usage:
 
 {{< note >}}
 ront-proxy certificates are required only when using the API server aggregation layer
-[an extension API server](/docs/tasks/extend-kubernetes/setup-extension-api-server/).
+to support [an extension API server](/docs/tasks/extend-kubernetes/setup-extension-api-server/).
 {{< /note >}}
 
 etcd also implements mutual TLS to authenticate clients and peers.

--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -57,7 +57,7 @@ In this scenario, there are two approaches for certificate usage:
   `kubelet-client.key` are created.
 
 {{< note >}}
-`front-proxy` certificates are required only if you run kube-proxy to support
+ront-proxy certificates are required only when using the API server aggregation layer
 [an extension API server](/docs/tasks/extend-kubernetes/setup-extension-api-server/).
 {{< /note >}}
 

--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -57,7 +57,7 @@ In this scenario, there are two approaches for certificate usage:
   `kubelet-client.key` are created.
 
 {{< note >}}
-ront-proxy certificates are required only when using the API server aggregation layer
+`front-proxy` certificates are required only when using the API server aggregation layer
 to support [an extension API server](/docs/tasks/extend-kubernetes/setup-extension-api-server/).
 {{< /note >}}
 


### PR DESCRIPTION
Fixes #55622

The note in the certificates page states that "front-proxy certificates are required only if you run kube-proxy to support an extension API server". This wording is confusing because kube-proxy usually refers to the node-level networking component, not the API server aggregation layer proxy.

Updated to clarify that front-proxy certificates are for the API server aggregation layer, which is a distinct feature from the kube-proxy DaemonSet.