### PR TITLE
Document deprecated volume node affinity annotation

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1211,6 +1211,19 @@ you should consider adding the labels manually (or adding support for `Persisten
 With `PersistentVolumeLabel`, the scheduler prevents Pods from mounting volumes in a different zone.
 If your infrastructure doesn't have this constraint, you don't need to add the zone labels to the volumes at all.
 
+### volume.alpha.kubernetes.io/node-affinity (deprecated)
+
+Type: Annotation
+
+Used on: PersistentVolume
+
+This annotation stored node affinity rules for a PersistentVolume as a JSON-serialized
+`NodeAffinity` object. The scheduler used these rules to limit which nodes could access the volume.
+
+This annotation has been deprecated since Kubernetes v1.10. Use the
+[`nodeAffinity` field](/docs/concepts/storage/persistent-volumes/#node-affinity) in the
+PersistentVolume spec instead.
+
 ### volume.beta.kubernetes.io/storage-provisioner (deprecated)
 
 Type: Annotation

--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1211,7 +1211,7 @@ you should consider adding the labels manually (or adding support for `Persisten
 With `PersistentVolumeLabel`, the scheduler prevents Pods from mounting volumes in a different zone.
 If your infrastructure doesn't have this constraint, you don't need to add the zone labels to the volumes at all.
 
-### volume.alpha.kubernetes.io/node-affinity (deprecated)
+### volume.alpha.kubernetes.io/node-affinity (deprecated) {#volume-alpha-kubernetes-io-node-affinity}
 
 Type: Annotation
 


### PR DESCRIPTION
### Description

Document the deprecated `volume.alpha.kubernetes.io/node-affinity`
annotation in the well-known labels, annotations, and taints reference.

The new entry explains that the annotation:

- was used on PersistentVolumes
- stored node affinity rules as a JSON-serialized `NodeAffinity` object
- constrained which nodes could access the volume
- was replaced by the PersistentVolume `.spec.nodeAffinity` field in Kubernetes v1.10

### Issue

Closes: #42149