### PR TITLE
docs: bootstrap token JWS is signed with the token secret, not the full token

### DIFF
--- a/content/en/docs/reference/access-authn-authz/bootstrap-tokens.md
+++ b/content/en/docs/reference/access-authn-authz/bootstrap-tokens.md
@@ -174,9 +174,10 @@ The signature is a JWS signature using the "detached" mode. To validate the
 signature, the user should encode the `kubeconfig` payload according to JWS
 rules (base64 encoded while discarding any trailing `=`). That encoded payload
 is then used to form a whole JWS by inserting it between the 2 dots. You can
-verify the JWS using the `HS256` scheme (HMAC-SHA256) with the full token (e.g.
-`07401b.f395accd246ae52d`) as the shared secret. Users _must_ verify that HS256
-is used.
+verify the JWS using the `HS256` scheme (HMAC-SHA256) with the token secret part
+(e.g. `f395accd246ae52d`) as the shared secret. Users _must_ verify that HS256
+is used. You might have to pad the secret with zeroes to the right for some
+validation tools to accept it given it is only 16 bytes.
 
 {{< warning >}}
 Any party with a bootstrapping token can create a valid signature for that


### PR DESCRIPTION
### Description

Fixes the JWS verification instructions in the bootstrap tokens reference page.

The docs currently say the HMAC-SHA256 shared secret for verifying the `cluster-info` JWS signature is the full token (`07401b.f395accd246ae52d`). The actual implementation uses only the token secret part as the key — the token ID is just the `kid` header:

https://github.com/kubernetes/kubernetes/blob/fc1c3faf47e46f9c257a17f9aae5abc6dd28c118/staging/src/k8s.io/cluster-bootstrap/token/jws/jws.go#L31

This updates the sentence to the wording suggested by @neolit123 in the issue, including the note that some external validation tools require padding the 16-byte secret with zeroes.

### Issue

Fixes #56477

<!-- oss-radar:idempotency=auto-20260713-151841.w3.kubernetes_website.56477 -->
