### PR TITLE
Use https for Slack link

### DIFF
--- a/layouts/partials/blog-meta-links.html
+++ b/layouts/partials/blog-meta-links.html
@@ -7,7 +7,7 @@
   <a class="widget-link" href="https://bsky.app/profile/kubernetes.io" target="_blank"><div> <i class="fa-brands fa-bluesky"> </i> <span class="widget-link-text"> @kubernetes.io</span></div></a>
   <a class="widget-link" href="https://x.com/kubernetesio" target="_blank"><div> <i class="fa-brands fa-twitter-square"> </i> <span class="widget-link-text"> @Kubernetesio</span></div></a>
   <a class="widget-link" href="https://github.com/kubernetes/kubernetes" target="_blank"><div> <i class="fa-brands fa-square-github"></i> <span class="widget-link-text"> on GitHub </span></div></a>
-  <a class="widget-link" href="http://slack.k8s.io" target="_blank"><div><i class="fa-brands fa-slack"> </i> <span class="widget-link-text">#kubernetes-users </span></div></a>
+  <a class="widget-link" href="https://slack.k8s.io" target="_blank"><div><i class="fa-brands fa-slack"> </i> <span class="widget-link-text">#kubernetes-users </span></div></a>
   <a class="widget-link" href="https://stackoverflow.com/questions/tagged/kubernetes" target="_blank"><div><i class="fa-brands fa-stack-overflow"></i> <span class="widget-link-text"> Stack Overflow</span></div></a>
   <a class="widget-link" href="https://discuss.kubernetes.io" target="_blank"><div> <i class="fa-brands fa-discourse"></i><span class="widget-link-text"> Forum </span></div></a>
   <a class="widget-link" href="https://kubernetes.io/docs/setup"><div><i class="fa-solid fa-download"></i> <span class="widget-link-text"> Kubernetes</span></div></a>


### PR DESCRIPTION
### Description

Using https instead of http for the Slack link on the blog.