### PR TITLE
Warn against rules: [] in aggregated ClusterRole manifests

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -266,6 +266,14 @@ field of this one.
 The control plane overwrites any values that you manually specify in the `rules` field of an
 aggregate ClusterRole. If you want to change or add rules, do so in the `ClusterRole` objects
 that are selected by the `aggregationRule`.
+
+Omit the `rules` field from manifests for aggregated ClusterRoles. Setting it, even to an
+empty list, claims ownership of the field when the manifest is applied with
+[server-side apply](/docs/reference/using-api/server-side-apply/). That ownership causes
+conflicts between the applier and the control plane: subsequent applies either fail with a
+field manager conflict on `.rules`, or (if conflicts are forced, as GitOps controllers
+typically do) repeatedly clear the aggregated rules, which the control plane then fills in
+again.
 {{< /caution >}}
 
 Here is an example aggregated ClusterRole:
@@ -279,7 +287,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.example.com/aggregate-to-monitoring: "true"
-rules: [] # The control plane automatically fills in the rules
+# The control plane automatically fills in the rules
 ```
 
 If you create a new ClusterRole that matches the label selector of an existing aggregated ClusterRole,


### PR DESCRIPTION
**Description**

The aggregated ClusterRole example in the RBAC reference ships `rules: [] # The control plane automatically fills in the rules`. Under server-side apply this line is a trap: an empty list is not "leave the field alone" — it claims ownership of `.rules` for the applier's field manager, while the built-in `clusterrole-aggregation-controller` manages that field itself (since v1.21 it force-applies the aggregated rules, kubernetes/kubernetes#99462). The caution box above the example already says the control plane overwrites manual `rules` values, but the example then tells readers to set the key anyway.

For anyone who copies the example into a manifest managed with `kubectl apply --server-side` or a GitOps controller, the result is a permanent field ownership fight: plain applies fail with `conflict with "clusterrole-aggregation-controller": .rules`, and appliers that force conflicts (Flux, Argo CD and similar do) wipe the aggregated rules on every apply, after which the controller fills them back in — a brief RBAC outage per sync plus perpetual spurious drift. A long-lived example of users hitting exactly this is fluxcd/flux2#2472.

This PR drops `rules: []` from the example (an aggregated ClusterRole is valid without the key — verified on v1.36: creation works and the controller fills the rules in) and extends the existing caution block to explain why the key should be omitted.
