### PR TITLE
Add contributor guide for Configuration API reference generation

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/config-api.md
+++ b/content/en/docs/contribute/generate-ref-docs/config-api.md
@@ -1,0 +1,108 @@
+---
+title: Generating Reference Documentation for Configuration APIs
+content_type: task
+weight: 60
+---
+
+<!-- overview -->
+
+This page shows how you can generate updated reference documentation for Kubernetes Configuration APIs. It is aimed at people who are contributing to Kubernetes.
+
+The Configuration API reference documents configuration types for Kubernetes tools and
+components - for example, `kubelet`, `kube-apiserver`, `kube-scheduler`, `kubeconfig`, and `kubeadm` formats.
+The published reference exists at [/docs/reference/config-api/](/docs/reference/config-api/).
+The [kubernetes-sigs/reference-docs](https://github.com/kubernetes-sigs/reference-docs) `genref` generator builds documentation from the Go type definitions located in 
+`genref/config.yaml`.
+
+If you find bugs in the generated content, you most likely need to
+[fix them upstream](/docs/contribute/generate-ref-docs/contribute-upstream/).
+
+## {{% heading "prerequisites" %}}
+
+{{< include "prerequisites-ref-docs.md" >}}
+
+<!-- steps -->
+
+## Set up the local repositories
+
+You need local clones of `kubernetes/website` and `kubernetes-sigs/reference-docs`.
+You do not need a local `kubernetes/kubernetes` checkout — `genref` reads configuration 
+types directly from Go modules.
+
+If you have not already forked and cloned `kubernetes/website`, see
+[Work from a local clone](/docs/contribute/new-content/open-a-pr/#fork-the-repo).
+Clone `reference-docs`:
+
+```shell
+git clone https://github.com/kubernetes-sigs/reference-docs
+```
+
+The remaining steps refer to your `kubernetes/website` clone as `<web-base>` and
+your `reference-docs` clone as `<rdocs-base>`.
+
+## Set build variables
+
+Set these in your shell. They apply to every `make` command in the steps that
+follow, whichever directory you run it from.
+
+```shell
+export K8S_WEBROOT=/path/to/your/website   # your website clone (<web-base>)
+```
+
+## Build and publish the Configuration API reference
+
+From `<rdocs-base>`:
+
+```shell
+cd <rdocs-base>
+make copyconfigapi
+```
+
+This command runs in two stages:
+1. **`configapi`** - builds and runs `genref`, which generates Markdown to `genref/output/md`
+2. **`copyconfigapi`** - which copies the generated files into your website clone at
+`<web-base>/content/en/docs/reference/config-api/`.
+
+The first run downloads the Go module dependencies and it may take several minutes.
+
+Check what changed in your website clone:
+```shell
+cd <web-base>
+git status
+```
+
+Look for updates made under `content/en/docs/reference/config-api` - for example:
+
+```text
+content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
+content/en/docs/reference/config-api/apiserver-config.v1.md
+content/en/docs/reference/config-api/client-authentication.v1.md
+```
+
+## Preview website and test locally
+
+Preview your updates:
+```shell
+cd <web-base>
+git submodule update --init --recursive --depth 1   # if not already done
+make container-serve
+```
+
+Then open a local preview through your web browser and confirm that the 
+pages you updated load properly. 
+Hugo serves that local preview at http://localhost:1313/
+So the page to check is http://localhost:1313/docs/reference/config-api/
+
+## Commit the changes
+
+If you regenerated the Configuration API reference for a release update,
+commit the changed files under `content/en/docs/reference/config-api/` in
+`<web-base>`, then open a [pull request](/docs/contribute/new-content/open-a-pr/)
+to [kubernetes/website](https://github.com/kubernetes/website).
+
+## {{% heading "whatsnext" %}}
+
+* [Generating Reference Documentation for the Kubernetes API](/docs/contribute/generate-ref-docs/kubernetes-api/)
+* [Generating Reference Documentation Quickstart](/docs/contribute/generate-ref-docs/quickstart/)
+* [Contributing to Upstream Reference Docs](/docs/contribute/generate-ref-docs/contribute-upstream/)


### PR DESCRIPTION
Document the genref workflow (make copyconfigapi) as part of the generate-ref-docs guide refresh. Part of #56385 (B2).

## Description
  Adds a new contributor guide for regenerating the Configuration API reference
  using `genref` in kubernetes-sigs/reference-docs.
  Part of #56385 — B2.

  ## Changes
  - Add `content/en/docs/contribute/generate-ref-docs/config-api.md`
  - Documents the `make copyconfigapi` workflow
  - No generated reference files included (guide-only PR)
  
  ## Verification
  The documented steps were run locally.

  ### Terminal output

  ```shell
  export K8S_WEBROOT=/path/to/website
  cd /path/to/reference-docs
  make copyconfigapi
  ```
<img width="1920" height="1080" alt="screenshot-20260715-122958" src="https://github.com/user-attachments/assets/d23f5483-694f-49be-88f7-574f78e1b7f8" />
<img width="1920" height="1080" alt="screenshot-20260715-123015" src="https://github.com/user-attachments/assets/ef8fbc2a-2abc-49ae-a98a-1f674bdd20c1" />
<img width="1920" height="1080" alt="screenshot-20260715-123126" src="https://github.com/user-attachments/assets/d1d472e5-f088-4293-9a8d-3648a413e51c" />

  ### Preview

  - Local preview: `make container-serve` → http://localhost:1313/docs/reference/config-api/
  - Contributor guide: http://localhost:1313/docs/contribute/generate-ref-docs/config-api/
 
<img width="1920" height="1080" alt="screenshot-20260715-130955" src="https://github.com/user-attachments/assets/69aa51c1-168e-4e87-a419-a61152aec01d" />
<img width="1680" height="1080" alt="screenshot-20260715-130320" src="https://github.com/user-attachments/assets/84999efe-0d29-422f-9a36-59115b6b2c6a" />
<img width="1846" height="1000" alt="screenshot-20260715-135648" src="https://github.com/user-attachments/assets/08c964f4-9e65-4380-876b-4a5f51a41083" />

### Acknowledgements
AI was used to help create this PR description and was used in testing the local previews
The format and several components of this guide were reused or inspired from #56398 