### PR TITLE
Document the stable-<major>.<minor>.txt marker for older kubectl versions

### DIFF
--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -51,7 +51,20 @@ The following methods exist for installing kubectl on Linux:
    curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/linux/arm64/kubectl
    ```
 
-   {{< /note >}}
+  To download the latest patch of an **older minor version**, replace `stable.txt` with
+  `stable-<major>.<minor>.txt`. For example, to download the latest {{< skew prevMinorVersion >}}
+  release on Linux x86-64:
+
+  ```bash
+  curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable-{{< skew prevMinorVersion>}}.txt)/bin/linux/amd64/kubectl"
+  ```
+
+  And for Linux ARM64:
+
+  ```bash
+  curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable-{{< skew prevMinorVersion>}}.txt)/bin/linux/arm64/kubectl"
+  ```
+  {{< /note >}}
 
 1. Validate the binary (optional)
 


### PR DESCRIPTION
### Description

This adds an example showing how to substitute `stable-<major>.<minor>.txt` for `stable.txt` to download the latest patched kubectl for any supported older minor version.

Kubernetes maintains a canonical `stable-<major>.<minor>.txt` marker for every supported minor release (until EOL), which resolves to the latest patched version for that minor-- e.g. `stable-1.30.txt` returns `v1.30.14`.

The existing docs only show downloading `stable.txt` (the current latest release). Users who need an older minor — for example, to stay within the version skew policy against an older control plane — have no documented way to get the latest patch of that minor, and are left guessing a specific patch version by hand.

This adds an example showing how to substitute `stable-<major>.<minor>.txt` for `stable.txt` to download the latest patched kubectl for any supported older minor version.

The convention is implemented at https://github.com/kubernetes/kubernetes/blob/release-1.36/cmd/kubeadm/app/util/version.go#L60-L70 and has remained stable for 4-10 years.

```
// In case of labels, it tries to fetch from release
// servers and then return actual semantic version.
//
// Available names on release servers:
//
//	stable      (latest stable release)
//	stable-1    (latest stable release in 1.x)
//	stable-1.0  (and similarly 1.1, 1.2, 1.3, ...)
//	latest      (latest release, including alpha/beta)
//	latest-1    (latest release in 1.x, including alpha/beta)
//	latest-1.0  (and similarly 1.1, 1.2, 1.3, ...)
```


Closes: #56498