### PR TITLE
fix(docs): fix broken Summary API link and add kubelet metrics endpoints

### DIFF
--- a/content/en/docs/reference/instrumentation/node-metrics.md
+++ b/content/en/docs/reference/instrumentation/node-metrics.md
@@ -10,7 +10,7 @@ description: >-
 The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
 gathers metric statistics at the node, volume, pod and container level,
 and emits this information in the
-[Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1).
+[Summary API](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go).
 
 You can send a proxied request to the stats summary API via the
 Kubernetes API server.
@@ -50,7 +50,7 @@ the kubelet [fetches Pod- and container-level metric data using CRI](/docs/refer
 As a stable feature, Kubernetes lets you configure kubelet to collect Linux kernel
 [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html)
 (PSI) for CPU, memory, and I/O usage. The information is collected at node, pod and container level.
-See [Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1) for detailed schema.
+See [Summary API](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go) for detailed schema.
 Starting with Kubernetes v.1.36, the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is locked to true and cannot be disabled. The information is also exposed in
 [Prometheus metrics](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 

--- a/content/en/docs/reference/instrumentation/node-metrics.md
+++ b/content/en/docs/reference/instrumentation/node-metrics.md
@@ -10,7 +10,7 @@ description: >-
 The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
 gathers metric statistics at the node, volume, pod and container level,
 and emits this information in the
-[Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/).
+[Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1).
 
 You can send a proxied request to the stats summary API via the
 Kubernetes API server.
@@ -50,7 +50,7 @@ the kubelet [fetches Pod- and container-level metric data using CRI](/docs/refer
 As a stable feature, Kubernetes lets you configure kubelet to collect Linux kernel
 [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html)
 (PSI) for CPU, memory, and I/O usage. The information is collected at node, pod and container level.
-See [Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/) for detailed schema.
+See [Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1) for detailed schema.
 Starting with Kubernetes v.1.36, the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is locked to true and cannot be disabled. The information is also exposed in
 [Prometheus metrics](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 
@@ -62,6 +62,21 @@ Pressure Stall Information requires:
 
 - [Linux kernel versions 4.20 or later](/docs/reference/node/kernel-version-requirements#requirements-psi).
 - [cgroup v2](/docs/concepts/architecture/cgroups)
+
+## Kubelet metrics endpoints {#kubelet-metrics}
+
+The kubelet exposes several HTTP endpoints for metrics collection:
+
+| Endpoint | Description | Format |
+|----------|-------------|--------|
+| `/stats/summary` | Summary API with node, pod, and container stats | JSON |
+| `/metrics/resource` | Resource metrics (CPU, memory) for pods and containers | Prometheus |
+| `/metrics/cadvisor` | Detailed container metrics from cAdvisor | Prometheus |
+| `/metrics` | Kubelet's own operational metrics | Prometheus |
+
+For resource metrics used by metrics-server and Horizontal Pod Autoscaler (HPA),
+use the `/metrics/resource` endpoint. For detailed container-level statistics,
+use the `/stats/summary` endpoint or `/metrics/cadvisor`.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/reference/instrumentation/understand-psi-metrics.md
+++ b/content/en/docs/reference/instrumentation/understand-psi-metrics.md
@@ -16,7 +16,7 @@ As a stable feature, Kubernetes lets you configure the kubelet to collect Linux 
 Starting with Kubernetes v.1.36, the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is locked to true and cannot be disabled.
 
 PSI metrics are exposed through two different sources:
-- The kubelet's [Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/), which provides PSI data at the node, pod, and container level.
+- The kubelet's [Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1), which provides PSI data at the node, pod, and container level.
 - The `/metrics/cadvisor` endpoint on the kubelet, which exposes PSI metrics in the [Prometheus format](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 
 ### Requirements

--- a/content/en/docs/reference/instrumentation/understand-psi-metrics.md
+++ b/content/en/docs/reference/instrumentation/understand-psi-metrics.md
@@ -16,7 +16,7 @@ As a stable feature, Kubernetes lets you configure the kubelet to collect Linux 
 Starting with Kubernetes v.1.36, the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is locked to true and cannot be disabled.
 
 PSI metrics are exposed through two different sources:
-- The kubelet's [Summary API](https://pkg.go.dev/k8s.io/kubelet/pkg/apis/stats/v1alpha1), which provides PSI data at the node, pod, and container level.
+- The kubelet's [Summary API](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go), which provides PSI data at the node, pod, and container level.
 - The `/metrics/cadvisor` endpoint on the kubelet, which exposes PSI metrics in the [Prometheus format](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 
 ### Requirements


### PR DESCRIPTION
## What this PR does

Fixes #56087 - Fixes broken Summary API link and adds kubelet metrics endpoints documentation.

## AI Disclosure

This PR was created with AI assistance for drafting parts of the documentation and code changes.

## Changes made

### 1. Fix broken Summary API link
- Updated link from `/docs/reference/config-api/kubelet-stats.v1alpha1/` (404) to wire format source code on GitHub
- Fixed in both `node-metrics.md` and `understand-psi-metrics.md`

### 2. Add kubelet metrics endpoints documentation
Added a new section documenting kubelet metrics endpoints:

| Endpoint | Description | Format |
|----------|-------------|--------|
| `/stats/summary` | Summary API with node, pod, and container stats | JSON |
| `/metrics/resource` | Resource metrics (CPU, memory) for pods and containers | Prometheus |
| `/metrics/cadvisor` | Detailed container metrics from cAdvisor | Prometheus |
| `/metrics` | Kubelet's own operational metrics | Prometheus |

## Why this change

The issue reported a broken link on the node-metrics page where the Summary API link returned a 404. Additionally, the page lacked clear documentation about available kubelet metrics endpoints, making it difficult for users to understand how to access node metrics.

## Files changed

- `content/en/docs/reference/instrumentation/node-metrics.md` - Fixed broken link, added metrics endpoints section
- `content/en/docs/reference/instrumentation/understand-psi-metrics.md` - Fixed broken link

## Verification

- All Summary API links now point to wire format source code on GitHub
- New metrics endpoints section follows Kubernetes documentation style guide
- No remaining broken links to kubelet-stats.v1alpha1