### PR TITLE
Clarify what setting .spec.os.name does in the Pod OS section

### DIFF
--- a/content/en/docs/concepts/workloads/pods/_index.md
+++ b/content/en/docs/concepts/workloads/pods/_index.md
@@ -126,11 +126,13 @@ the name should follow the more restrictive rules for a
 
 {{< feature-state state="stable" for_k8s_version="v1.25" >}}
 
-You should set the `.spec.os.name` field to either `windows` or `linux` to indicate the OS on
-which you want the pod to run. These two are the only operating systems supported for now by
-Kubernetes. In the future, this list may be expanded.
+You should set the `.spec.os.name` field to either `windows` or `linux` to indicate the
+operating system that the containers in that Pod require. These two are the only operating
+systems supported for now by Kubernetes. In the future, this list may be expanded.
 
-In Kubernetes v{{< skew currentVersion >}}, the value of `.spec.os.name` does not affect
+The kubelet refuses to run a Pod if the value of `.spec.os.name` does not match the
+operating system of the node. However, in Kubernetes
+v{{< skew currentVersion >}}, the value of `.spec.os.name` does not affect
 how the {{< glossary_tooltip text="kube-scheduler" term_id="kube-scheduler" >}}
 picks a node for the Pod to run on. In any cluster where there is more than one operating system for
 running nodes, you should set the


### PR DESCRIPTION
### Description

The Pod OS section tells you to set `.spec.os.name`, then says the value does not
affect how the scheduler picks a node — without saying what setting it does do.
Read together, those two statements look like a contradiction, which is what
#55112 reports.

This adds the missing half: the kubelet refuses to run a Pod if `.spec.os.name`
does not match the operating system of the node. The scheduling sentence then reads
as a caveat rather than a contradiction, and the recommendation to set the field
stays as it is.

That kubelet behaviour is already documented under the
[`kubernetes.io/os`](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os)
label, which links to this section for more detail — so this page was the one place
not stating it.

The opening sentence now describes the operating system that the containers require,
matching how `content/en/docs/concepts/windows/user-guide.md` already describes the
field. Checked `windows/intro.md` as well; no change needed there. Built locally with
Hugo 0.144.2 and checked the rendered section.

#55454 proposes a different fix for the same issue and has been inactive since April.
Its review feedback was that the recommendation to set `.spec.os.name` should be kept,
so this change keeps it — happy to close this one if its author picks that back up.

This PR was assisted by AI but human reviewed along the way.

### Issue

Closes: #55112