### PR TITLE
Fix duplicate words and minor grammar typos in documentation

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -213,7 +213,7 @@ Aggregated APIs offer more advanced API features and customization of other feat
 
 | Feature | Description | CRDs | Aggregated API |
 | ------- | ----------- | ---- | -------------- |
-| Validation | Help users prevent errors and allow you to evolve your API independently of your clients. These features are most useful when there are many clients who can't all update at the same time. | Yes.  Most validation can be specified in the CRD using [OpenAPI v3.0 validation](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation). [CRDValidationRatcheting](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-ratcheting) feature gate allows failing validations specified using OpenAPI also can be ignored if the failing part of the resource was unchanged.  Any other validations supported by addition of a [Validating Webhook](/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook-alpha-in-1-8-beta-in-1-9). | Yes, arbitrary validation checks |
+| Validation | Help users prevent errors and allow you to evolve your API independently of your clients. These features are most useful when there are many clients who can't all update at the same time. | Yes.  Most validation can be specified in the CRD using [OpenAPI v3.0 validation](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation). The [CRDValidationRatcheting](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-ratcheting) feature gate allows failing validations specified using OpenAPI to be ignored if the failing part of the resource was unchanged.  Any other validations are supported by the addition of a [Validating Webhook](/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook-alpha-in-1-8-beta-in-1-9). | Yes, arbitrary validation checks |
 | Defaulting | See above | Yes, either via [OpenAPI v3.0 validation](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting) `default` keyword (GA in 1.17), or via a [Mutating Webhook](/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) (though this will not be run when reading from etcd for old objects). | Yes |
 | Multi-versioning | Allows serving the same object through two API versions. Can help ease API changes like renaming fields. Less important if you control your client versions. | [Yes](/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning) | Yes |
 | Custom Storage | If you need storage with a different performance mode (for example, a time-series database instead of key-value store) or isolation for security (for example, encryption of sensitive information, etc.) | No | Yes |
@@ -266,7 +266,7 @@ Installing an Aggregated API server always involves running a new Deployment.
 Custom resources consume storage space in the same way that ConfigMaps do. Creating too many
 custom resources may overload your API server's storage space.
 
-Custom resources are placed into storage based upon the the current storage
+Custom resources are placed into storage based upon the current storage
 version of the resource, defined in the CRD spec. Any update to a custom
 resource will use the currently defined storage version to store the resource.
 All other versions either need to have all the fields of that version or define

--- a/content/en/docs/reference/node/kubelet-files.md
+++ b/content/en/docs/reference/node/kubelet-files.md
@@ -10,8 +10,8 @@ This document outlines files that kubelet reads and writes.
 
 {{< note >}}
 
-This document is for informational purpose and not describing any guaranteed behaviors or APIs.
-It lists resources used by the kubelet, which is an implementation detail and a subject to change at any release.
+This document is for informational purposes and not describing any guaranteed behaviors or APIs.
+It lists resources used by the kubelet, which is an implementation detail and subject to change at any release.
 
 {{< /note >}}
 
@@ -104,7 +104,7 @@ Names of files:
 
 - `allocated_pods_state` records the resources allocated to each pod running on the node
 - `actuated_pods_state` records the resources that have been accepted by the runtime
-  for each pod pod running on the node
+  for each pod running on the node
 
 The files are located within the kubelet base directory
 (`/var/lib/kubelet` by default on Linux; configurable using `--root-dir`).
@@ -188,7 +188,7 @@ See the [seccomp reference](/docs/reference/node/seccomp/) for details.
 ### AppArmor
 
 The kubelet does not load or refer to AppArmor profiles by a Kubernetes-specific path.
-AppArmor profiles are loaded via the node operating system rather then referenced by their path.
+AppArmor profiles are loaded via the node operating system rather than referenced by their path.
 
 ## Locking
 
@@ -197,7 +197,7 @@ AppArmor profiles are loaded via the node operating system rather then reference
 
 A lock file for the kubelet; typically `/var/run/kubelet.lock`. The kubelet uses this to ensure
 that two different kubelets don't try to run in conflict with each other.
-You can configure the path to the lock file using the the `--lock-file` kubelet command line argument.
+You can configure the path to the lock file using the `--lock-file` kubelet command line argument.
 
 If two kubelets on the same node use a different value for the lock file path, they will not be able to
 detect a conflict when both are running.

--- a/content/en/docs/tutorials/cluster-management/admission-policies.md
+++ b/content/en/docs/tutorials/cluster-management/admission-policies.md
@@ -64,11 +64,11 @@ You can also use _parameters_, which are **optional**. To learn more, see
 [parameter resources](/docs/reference/access-authn-authz/validating-admission-policy/#parameter-resources) (ValidatingAdmissionPolicy) or
 [parameter resources](/docs/reference/access-authn-authz/mutating-admission-policy/#parameter-resources) (MutatingAdmissionPolicy).
 
-Policy objects describes the abstract logic of a policy using Common Expression Language (CEL). 
+Policy objects describe the abstract logic of a policy using Common Expression Language (CEL). 
 For example, a ValidatingAdmissionPolicy might enforce replica limits or ensure specific labels are present, 
 while a MutatingAdmissionPolicy can modify resources such as adding a default label to a namespace.
 
-Binding objects link the policy to your cluster and provides scoping. 
+Binding objects link the policy to your cluster and provide scoping. 
 A ValidatingAdmissionPolicyBinding or MutatingAdmissionPolicyBinding connects the policy to specific resources. 
 If you only want to enforce a policy for a specific subset of resources, the binding is where you narrow the
 scope of the policy (using `matchResources`).
@@ -121,7 +121,7 @@ the validation failure in both the API response body and the HTTP `Warning:` hea
 
 #### MutatingAdmissionPolicyBinding {#policy-actions-mutating}
 
-For MutatingAdmissionPolicyBinding, the the action is always to mutate the object.
+For MutatingAdmissionPolicyBinding, the action is always to mutate the object.
 
 You can use a JSON Patch or a Kubernetes _apply configuration_.
 


### PR DESCRIPTION
This PR fixes a few minor duplicate word typos (like `the the` and `pod pod`) and grammatical errors that I found in the English documentation.

Fixes #56544