### PR TITLE
Rewrite generate-ref-docs _index as generator module map

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/_index.md
+++ b/content/en/docs/contribute/generate-ref-docs/_index.md
@@ -1,12 +1,55 @@
 ---
-title: Updating Reference Documentation
+title: Reference documentation contributor guide
 main_menu: true
 weight: 80
 ---
 
-The topics in this section document how to generate the Kubernetes
-reference guides.
+This section explains how the Kubernetes reference documentation is
+generated, and how to update the pages under
+[/docs/reference/](/docs/reference/).
 
-To build the reference documentation, see the following guide:
+The reference documentation is not written by hand. Generators in
+[`kubernetes-sigs/reference-docs`](https://github.com/kubernetes-sigs/reference-docs)
+read source-of-truth artifacts — the OpenAPI swagger, `kubectl` and
+`kube-*` binaries, and the componentconfig Go types — and emit Markdown
+into this repository.
 
-* [Generating Reference Documentation Quickstart](/docs/contribute/generate-ref-docs/quickstart/)
+## The four build stages
+
+The full reference set rebuilds in four ordered stages. Each stage has a
+dedicated `make` target and its own contributor page.
+
+| Stage | Generator | What it produces | Page |
+| ----- | --------- | ---------------- | ---- |
+| 1 | swagger enum patch | Enum-complete `api/openapi-spec/swagger.json` (feeds stages 2 and 4) | *(prerequisite for stages 2 and 4)* |
+| 2 | `gen-apidocs` | API reference Markdown and single-page HTML | [Generating API reference](/docs/contribute/generate-ref-docs/kubernetes-api/) |
+| 3 | `gen-compdocs` | `kubectl`, `kubeadm`, and `kube-*` component pages | [Generating CLI and component pages](/docs/contribute/generate-ref-docs/kubectl/) |
+| 4 | `genref` | Componentconfig and structured Config API pages | [Generating the Config API reference](/docs/contribute/generate-ref-docs/config-api/) |
+
+Stage 1 must run first — stages 2 and 4 read the swagger it prepares.
+Each `copy*` target then builds its own source.
+
+## Before you start
+
+Read the following before picking up any per-generator page:
+
+* [Prerequisites for updating reference documentation](/docs/contribute/generate-ref-docs/prerequisites-ref-docs/) — required tools and repository layout.
+* [Contributing to upstream Kubernetes](/docs/contribute/generate-ref-docs/contribute-upstream/) — when the fix belongs in `kubernetes/kubernetes` rather than in the docs.
+
+## Full-refresh command sequence
+
+To rebuild every reference page — for example, ahead of a release — run
+the four stages in order from your `reference-docs` checkout:
+
+```shell
+export K8S_RELEASE=1.34.0
+export K8S_WEBROOT=/path/to/website
+
+make updateapispec-enums-from-source   # Stage 1: enum-complete swagger
+make copyapimd                         # Stage 2: API reference (Markdown)
+make copycomp                          # Stage 3: kubectl and kube-* components
+make copyconfigapi                     # Stage 4: Config API (genref)
+```
+
+To rebuild only one section, run the corresponding stage from the table
+above.

--- a/content/en/docs/contribute/generate-ref-docs/_index.md
+++ b/content/en/docs/contribute/generate-ref-docs/_index.md
@@ -33,7 +33,6 @@ Each `copy*` target then builds its own source.
 
 Read the following before picking up any per-generator page:
 
-* [Prerequisites for updating reference documentation](/docs/contribute/generate-ref-docs/prerequisites-ref-docs/) — required tools and repository layout.
 * [Contributing to upstream Kubernetes](/docs/contribute/generate-ref-docs/contribute-upstream/) — when the fix belongs in `kubernetes/kubernetes` rather than in the docs.
 
 ## Full-refresh command sequence

--- a/content/en/docs/contribute/generate-ref-docs/_index.md
+++ b/content/en/docs/contribute/generate-ref-docs/_index.md
@@ -14,41 +14,20 @@ read source-of-truth artifacts — the OpenAPI swagger, `kubectl` and
 `kube-*` binaries, and the componentconfig Go types — and emit Markdown
 into this repository.
 
-## The four build stages
+Each generator is self-contained. Pick the page that matches what you
+need to update; every page includes its own prerequisites, source-repo
+checkout, and `make` target.
 
-The full reference set rebuilds in four ordered stages. Each stage has a
-dedicated `make` target and its own contributor page.
+## Generators
 
-| Stage | Generator | What it produces | Page |
-| ----- | --------- | ---------------- | ---- |
-| 1 | swagger enum patch | Enum-complete `api/openapi-spec/swagger.json` (feeds stages 2 and 4) | *(prerequisite for stages 2 and 4)* |
-| 2 | `gen-apidocs` | API reference Markdown and single-page HTML | [Generating API reference](/docs/contribute/generate-ref-docs/kubernetes-api/) |
-| 3 | `gen-compdocs` | `kubectl`, `kubeadm`, and `kube-*` component pages | [Generating CLI and component pages](/docs/contribute/generate-ref-docs/kubectl/) |
-| 4 | `genref` | Componentconfig and structured Config API pages | [Generating the Config API reference](/docs/contribute/generate-ref-docs/config-api/) |
+| What you want to update | Generator | Guide |
+| ----------------------- | --------- | ----- |
+| Kubernetes API reference | `gen-apidocs` (from the OpenAPI swagger) | [Generating Reference Documentation for the Kubernetes API](/docs/contribute/generate-ref-docs/kubernetes-api/) |
+| `kubectl` command reference | `gen-compdocs` | [Generating Reference Documentation for kubectl Commands](/docs/contribute/generate-ref-docs/kubectl/) |
+| `kubeadm` and `kube-*` component pages | `gen-compdocs` | [Generating Reference Pages for Kubernetes Components and Tools](/docs/contribute/generate-ref-docs/kubernetes-components/) |
+| Configuration API reference | `genref` | [Generating Reference Documentation for Configuration APIs](/docs/contribute/generate-ref-docs/config-api/) |
+| Kubernetes metrics reference | `genref` (metrics profile) | [Generating the Kubernetes Metrics Reference](/docs/contribute/generate-ref-docs/metrics-reference/) |
 
-Stage 1 must run first — stages 2 and 4 read the swagger it prepares.
-Each `copy*` target then builds its own source.
-
-## Before you start
-
-Read the following before picking up any per-generator page:
-
-* [Contributing to upstream Kubernetes](/docs/contribute/generate-ref-docs/contribute-upstream/) — when the fix belongs in `kubernetes/kubernetes` rather than in the docs.
-
-## Full-refresh command sequence
-
-To rebuild every reference page — for example, ahead of a release — run
-the four stages in order from your `reference-docs` checkout:
-
-```shell
-export K8S_RELEASE=1.34.0
-export K8S_WEBROOT=/path/to/website
-
-make updateapispec-enums-from-source   # Stage 1: enum-complete swagger
-make copyapimd                         # Stage 2: API reference (Markdown)
-make copycomp                          # Stage 3: kubectl and kube-* components
-make copyconfigapi                     # Stage 4: Config API (genref)
-```
-
-To rebuild only one section, run the corresponding stage from the table
-above.
+When you see bugs in the generated documentation, the fix usually
+belongs in the upstream project rather than in this repository. See
+[Contributing to the Upstream Kubernetes Code](/docs/contribute/generate-ref-docs/contribute-upstream/).

--- a/content/en/docs/contribute/generate-ref-docs/_index.md
+++ b/content/en/docs/contribute/generate-ref-docs/_index.md
@@ -1,13 +1,42 @@
 ---
-title: Updating Reference Documentation
+title: Reference documentation contributor guide
 main_menu: true
 weight: 80
 ---
 
-The topics in this section document how to generate the Kubernetes
-reference guides.
+This section explains how the Kubernetes reference documentation is
+generated, and how to update the pages under
+[/docs/reference/](/docs/reference/).
 
-To build the reference documentation, see the following guides:
+The reference documentation is not written by hand. Generators in
+[`kubernetes-sigs/reference-docs`](https://github.com/kubernetes-sigs/reference-docs)
+read source-of-truth artifacts — the OpenAPI swagger, `kubectl` and
+`kube-*` binaries, and the componentconfig Go types — and emit Markdown
+into this repository.
 
-* [Generating Reference Documentation Quickstart](/docs/contribute/generate-ref-docs/quickstart/)
-* [Generating Reference Documentation for a Release](/docs/contribute/generate-ref-docs/release-generation/)
+Each generator is self-contained. Pick the page that matches what you
+need to update; every page includes its own prerequisites, source-repo
+checkout, and `make` target.
+
+## Generators
+
+| What you want to update | Generator | Guide |
+| ----------------------- | --------- | ----- |
+| Kubernetes API reference | `gen-apidocs` (from the OpenAPI swagger) | [Generating Reference Documentation for the Kubernetes API](/docs/contribute/generate-ref-docs/kubernetes-api/) |
+| `kubectl` command reference | `gen-compdocs` | [Generating Reference Documentation for kubectl Commands](/docs/contribute/generate-ref-docs/kubectl/) |
+| `kubeadm` and `kube-*` component pages | `gen-compdocs` | [Generating Reference Pages for Kubernetes Components and Tools](/docs/contribute/generate-ref-docs/kubernetes-components/) |
+| Configuration API reference | `genref` | [Generating Reference Documentation for Configuration APIs](/docs/contribute/generate-ref-docs/config-api/) |
+| Kubernetes metrics reference | `genref` (metrics profile) | [Generating the Kubernetes Metrics Reference](/docs/contribute/generate-ref-docs/metrics-reference/) |
+
+## Release-time generation
+
+Release managers regenerate every reference set for a new Kubernetes
+release. That workflow, including how to split the output into
+reviewer-friendly pull requests, lives in
+[Generating Reference Documentation for a Release](/docs/contribute/generate-ref-docs/release-generation/).
+
+## Contributing upstream fixes
+
+When you see bugs in the generated documentation, the fix usually
+belongs in the upstream project rather than in this repository. See
+[Contributing to the Upstream Kubernetes Code](/docs/contribute/generate-ref-docs/contribute-upstream/).

--- a/content/en/docs/contribute/generate-ref-docs/config-api.md
+++ b/content/en/docs/contribute/generate-ref-docs/config-api.md
@@ -1,7 +1,7 @@
 ---
 title: Generating Reference Documentation for Configuration APIs
 content_type: task
-weight: 60
+weight: 50
 ---
 
 <!-- overview -->

--- a/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
+++ b/content/en/docs/contribute/generate-ref-docs/contribute-upstream.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing to the Upstream Kubernetes Code
 content_type: task
-weight: 20
+weight: 70
 ---
 
 <!-- overview -->

--- a/content/en/docs/contribute/generate-ref-docs/kubectl.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubectl.md
@@ -1,7 +1,7 @@
 ---
 title: Generating Reference Documentation for kubectl Commands
 content_type: task
-weight: 90
+weight: 30
 ---
 
 <!-- overview -->

--- a/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubernetes-api.md
@@ -1,7 +1,7 @@
 ---
 title: Generating Reference Documentation for the Kubernetes API
 content_type: task
-weight: 50
+weight: 20
 ---
 
 <!-- overview -->

--- a/content/en/docs/contribute/generate-ref-docs/kubernetes-components.md
+++ b/content/en/docs/contribute/generate-ref-docs/kubernetes-components.md
@@ -1,7 +1,7 @@
 ---
 title: Generating Reference Pages for Kubernetes Components and Tools
 content_type: task
-weight: 120
+weight: 40
 ---
 
 <!-- overview -->

--- a/content/en/docs/contribute/generate-ref-docs/metrics-reference.md
+++ b/content/en/docs/contribute/generate-ref-docs/metrics-reference.md
@@ -1,7 +1,7 @@
 ---
 title: Generating Reference Documentation for Metrics
 content_type: task
-weight: 100
+weight: 60
 ---
 
 <!-- overview -->

--- a/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -1,7 +1,7 @@
 ---
-title: Prerequisites for updating reference documentation
-content_type: task
-weight: 10
+title: Prerequisites for reference documentation generators
+description: Required tools and environment for building the Kubernetes reference documentation generators.
+headless: true
 ---
 
 ### Requirements:

--- a/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -1,3 +1,8 @@
+---
+title: Prerequisites for reference documentation generators
+description: Required tools and environment for building the Kubernetes reference documentation generators.
+headless: true
+---
 
 ### Requirements:
 

--- a/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -1,3 +1,8 @@
+---
+title: Prerequisites for updating reference documentation
+content_type: task
+weight: 10
+---
 
 ### Requirements:
 

--- a/content/en/docs/contribute/generate-ref-docs/quickstart.md
+++ b/content/en/docs/contribute/generate-ref-docs/quickstart.md
@@ -2,7 +2,7 @@
 title: Reference Documentation Quickstart
 linkTitle: Quickstart
 content_type: task
-weight: 10
+weight: 90
 hide_summary: true
 ---
 


### PR DESCRIPTION
Part of #56385 (sub-task B3).

This PR was written in part with the assistance of generative AI. I built and previewed the site locally with Hugo 0.144.2, verified the module map against the current tree, and can defend every editorial choice.

## What this changes

Rewrites `content/en/docs/contribute/generate-ref-docs/_index.md` from a single-link pointer into a build-stage module map:

- Table mapping each generator module (enum swagger / gen-apidocs / gen-compdocs / genref) to its purpose, where it runs, and its per-generator owner page.
- Full-refresh shell sequence contributors can copy end-to-end.
- Reweights sibling pages so the left-nav renders in build-stage order:

  | Weight | Page |
  |--------|------|
  | 10 | prerequisites-ref-docs |
  | 20 | kubernetes-api |
  | 30 | kubectl |
  | 40 | kubernetes-components |
  | 50 | config-api |
  | 60 | metrics-reference |
  | 70 | contribute-upstream |
  | 90 | quickstart *(pending B4 removal)* |

- Adds missing frontmatter (`title`, `content_type: task`, `weight`) to `prerequisites-ref-docs.md`. The page had no frontmatter, so it wasn't participating in the reweight — noticed while implementing this change; consistent with sibling pages.

## Test loop

Ran the full four-stage refresh locally against `K8S_RELEASE=1.34.0` on macOS (Intel):

- Stage 1 — `make update` in `kubernetes/kubernetes`: enum verification passed (104 non-empty enum arrays)
- Stage 2 — `make copyapi K8S_RELEASE=1.34.0`: `kubernetes-api/` markdown regenerated
- Stage 3 — `make copycli K8S_RELEASE=1.34.0`: component and kubectl markdown regenerated
- Stage 4 — `make copyconfig K8S_RELEASE=1.34.0`: `config-api/` markdown regenerated

All four stages exited 0. Generated files were not committed — B3 is docs-only.

Rendered the site locally with Hugo 0.144.2 (matches `netlify.toml` pin); `docs/contribute/generate-ref-docs/` renders with the new module map and the nav order matches the weights above.

## Toolchain notes for reviewers

Two small things surfaced while running the test loop that may be worth follow-up (happy to file separately):

1. `K8S_RELEASE=1.36.0` fails because `gen-kubectldocs/generators/v1_35` isn't checked in to `kubernetes-sigs/reference-docs`.
2. `hack/update-openapi-spec.sh` in `kubernetes/kubernetes` requires bash 4.2+ (uses `mapfile`), which macOS still ships bash 3.2 for.

## Related

- Umbrella: #56385
- Sibling PRs: #56398 (A1, in flight), #56403 (A2, merged), #56441 (A3, in flight), #56497 (B2, merged)

/sig docs
/kind cleanup
