### PR TITLE
[zh-cn]sync configure-liveness-readiness-startup-probes

### DIFF
--- a/content/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -510,7 +510,7 @@ is that you use the `readinessProbe` field instead of the `livenessProbe` field.
 readinessProbe:
   exec:
     command:
-    - cat
+    - /bin/cat
     - /tmp/healthy
   initialDelaySeconds: 5
   periodSeconds: 5


### PR DESCRIPTION
content/zh-cn/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md