### PR TITLE
Remerge documentation for Kubelet feature gate HugepageAwareEviction.

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -98,6 +98,18 @@ reproduces the same set of steps that the kubelet performs to calculate
 file-backed memory on the inactive LRU list) from its calculation, as it assumes that
 memory is reclaimable under pressure.
 
+{{<note>}}
+{{< feature-state feature_gate_name="HugepageAwareEviction" >}}
+On nodes with [hugepages](/docs/tasks/manage-hugepages/scheduling-hugepages/)
+configured, the kubelet subtracts the node's total hugepage capacity from
+`memory.available` used by eviction manager.
+Without this adjustment, hugepage-reserved RAM inflates
+`AvailableBytes` because the memory cgroup controller does not track hugetlb
+allocations in its working set. This can delay eviction and lead to OOM kills.
+To restore the previous behavior, disable the `HugepageAwareEviction`
+[feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
+{{</note>}}
+
 On Windows nodes, the value for `memory.available` is derived from the node's global
 memory commit levels (queried through the [`GetPerformanceInfo()`](https://learn.microsoft.com/windows/win32/api/psapi/nf-psapi-getperformanceinfo)
 system call) by subtracting the node's global [`CommitTotal`](https://learn.microsoft.com/windows/win32/api/psapi/ns-psapi-performance_information) from the node's [`CommitLimit`](https://learn.microsoft.com/windows/win32/api/psapi/ns-psapi-performance_information). Please note that `CommitLimit` can change if the node's page-file size changes!

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/HugepageAwareEviction.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/HugepageAwareEviction.md
@@ -1,0 +1,16 @@
+---
+title: HugepageAwareEviction
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: beta
+    defaultValue: true
+    fromVersion: "1.37"
+---
+Subtracts hugepage capacity from `memory.available` so the kubelet's eviction
+signal reflects actual regular-memory availability. Without this gate, hugepage
+reservations inflate `AvailableBytes`, delaying eviction and causing OOM kills
+on nodes with hugepages configured.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

Remerge PR 56329 to dev-1.37 branch.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

PR 56329 documents feature gate HugepageAwareEviction for v1.37 and wrongly merged in main branch.
https://github.com/kubernetes/website/pull/56329

Closes: #https://github.com/kubernetes/website/issues/56558