### PR TITLE
Add note about single-node cluster behavior in hello-minikube

### DIFF
--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -39,6 +39,11 @@ See [Install tools](/docs/tasks/tools/#kubectl) for installation instructions.
 minikube start
 ```
 
+{{< alert color="info" title="Note" >}}
+`minikube start` creates a single-node cluster. That node acts as both the control plane and a worker node. This differs from many production Kubernetes clusters, where control plane nodes are typically isolated from worker node using
+[taints](/docs/concepts/scheduling-eviction/taint-and-toleration/).
+{{< /alert >}}
+
 ## Check the status of the minikube cluster
 
 Verify the status of the minikube cluster to ensure all the components are in a running state.

--- a/content/en/docs/tutorials/hello-minikube.md
+++ b/content/en/docs/tutorials/hello-minikube.md
@@ -40,8 +40,8 @@ minikube start
 ```
 
 {{< alert color="info" title="Note" >}}
-`minikube start` creates a single-node cluster. That node acts as both the control plane and a worker node. This differs from many production Kubernetes clusters, where control plane nodes are typically isolated from worker node using
-[taints](/docs/concepts/scheduling-eviction/taint-and-toleration/).
+The command `minikube start` creates a single-Node cluster. That Node acts as both the control plane and a worker Node. This differs from many production Kubernetes clusters, where control plane Nodes are typically isolated from worker Node using
+[taints](/docs/concepts/scheduling-eviction/taint-and-toleration/) or completely invisible to the user.
 {{< /alert >}}
 
 ## Check the status of the minikube cluster


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
This PR adds a note about minikube's single-node cluster behavior right after `minikube start` in the **Hello Minikube** tutorial.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #56550