### PR TITLE
Update container runtime reference from Docker to containerd

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/explore/explore-intro.md
@@ -74,7 +74,7 @@ Every Kubernetes Node runs at least:
 * Kubelet, a process responsible for communication between the Kubernetes control
 plane and the Node; it manages the Pods and the containers running on a machine.
 
-* A container runtime (like Docker) responsible for pulling the container image
+* A container runtime (like containerd) responsible for pulling the container image
 from a registry, unpacking the container, and running the application.
 
 ### Nodes overview


### PR DESCRIPTION
### Description

This PR updates the Kubernetes Basics tutorial by replacing the outdated Docker container runtime reference with containerd in the Nodes section.

This change ensures that the documentation accurately reflects the current Kubernetes ecosystem and avoids confusing new learners.

### Issue

Closes: #56565