### PR TITLE
Add click-to-copy for code blocks from Docsy 0.7.0

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -47,7 +47,7 @@
 
 {{ if .Site.Params.prism_syntax_highlighting -}}
   <script src='{{ "js/prism.js" | relURL }}'></script>
-{{ else if false -}}
+{{ else if ( not .Site.Params.disable_click2copy_chroma ) -}}
   {{ $c2cJS := resources.Get "js/click-to-copy.js" -}}
   {{ if hugo.IsProduction -}}
     {{ $c2cJS = $c2cJS | minify | fingerprint -}}


### PR DESCRIPTION
### Description

Docsy v0.7 introduced the click-to-copy functionality for code blocks when using the default syntax highlighting (Chroma, not Prism). We've been missing a relevant change in `layouts/partials/scripts.html` to make it work. This PR fixes it, which results in adding the "Copy to clipboard" button to all code blocks across the documentation:

<img width="681" height="227" alt="image" src="https://github.com/user-attachments/assets/5e4da6a2-03d8-47b1-9964-d093f4de1e34" />

### Issue

Closes: #55275

/area web-development