### PR TITLE
[fr] Add StatefulSet debugging task

### DIFF
--- a/content/fr/docs/tasks/debug/debug-application/debug-statefulset.md
+++ b/content/fr/docs/tasks/debug/debug-application/debug-statefulset.md
@@ -1,0 +1,40 @@
+---
+reviewers:
+- bprashanth
+- enisoc
+- erictune
+- foxish
+- janetkuo
+- kow3ns
+- smarterclayton
+title: Déboguer un StatefulSet
+content_type: task
+weight: 30
+---
+
+<!-- overview -->
+Cette tâche explique comment déboguer un StatefulSet.
+
+## {{% heading "prerequisites" %}}
+
+* Vous devez disposer d'un cluster Kubernetes, et l'outil de ligne de commande kubectl doit être configuré pour communiquer avec votre cluster.
+* Vous devez avoir un StatefulSet en cours d'exécution que vous souhaitez examiner.
+
+<!-- steps -->
+
+## Déboguer un StatefulSet
+
+Pour lister tous les Pods appartenant à un StatefulSet et portant l'étiquette `app.kubernetes.io/name=MyApp`, vous pouvez utiliser la commande suivante :
+
+```shell
+kubectl get pods -l app.kubernetes.io/name=MyApp
+```
+
+Si l'un des Pods listés reste longtemps dans l'état `Unknown` ou `Terminating`, consultez la tâche
+[Supprimer des Pods d'un StatefulSet](/docs/tasks/run-application/delete-stateful-set/) pour savoir comment y remédier.
+Vous pouvez déboguer les Pods individuels d'un StatefulSet à l'aide du guide
+[Déboguer des Pods](/docs/tasks/debug/debug-application/debug-pods/).
+
+## {{% heading "whatsnext" %}}
+
+Apprenez-en davantage sur le [débogage d'un conteneur d'initialisation](/docs/tasks/debug/debug-application/debug-init-containers/).


### PR DESCRIPTION
### Description

Adds a French translation of the Debug a StatefulSet task.

- Preserves the source structure, front matter, command, and links.
- Uses terminology consistent with the existing French Kubernetes documentation.
- Adds only the missing French page; no existing content is removed or moved.
- The translation was prepared with AI assistance and manually reviewed against the current English source and French terminology.

### Validation

- Hugo build completed successfully (533 French pages generated).
- Control-character check and `git diff --check` passed.

### Issue

Relates to #17598