### PR TITLE
Align storage class and pvc docs on retroactice sc assignment

### DIFF
--- a/content/en/docs/concepts/storage/persistent-volumes.md
+++ b/content/en/docs/concepts/storage/persistent-volumes.md
@@ -917,7 +917,7 @@ it won't be supported in a future Kubernetes release.
 
 You can create a PersistentVolumeClaim without specifying a `storageClassName`
 for the new PVC, and you can do so even when no default StorageClass exists
-in your cluster. In this case, the new PVC creates as you defined it, and the
+in your cluster. In this case, the new PVC is created as you defined it, and the
 `storageClassName` of that PVC remains unset until default becomes available.
 
 When a default StorageClass becomes available, the control plane identifies any
@@ -931,11 +931,11 @@ In order to keep binding to PVs with `storageClassName` set to `""`
 (while a default StorageClass is present), you need to set the `storageClassName`
 of the associated PVC to `""`.
 
-This behavior helps administrators change default StorageClass by removing the
-old one first and then creating or setting another one. This brief window while
-there is no default causes PVCs without `storageClassName` created at that time
-to not have any default, but due to the retroactive default StorageClass
-assignment this way of changing defaults is safe.
+This behavior helps administrators change the default StorageClass by removing the
+old one first and then creating the new one. This brief window while
+there is no default StorageClass causes PVCs without `storageClassName` created 
+during that time frame to not have a default StorageClass. But due to the 
+retroactive default StorageClass assignment, this way of changing defaults is safe.
 
 ### Unused PVC tracking
 

--- a/content/en/docs/concepts/storage/storage-classes.md
+++ b/content/en/docs/concepts/storage/storage-classes.md
@@ -68,26 +68,15 @@ marked as the default. The reason that Kubernetes allows you to have
 multiple default StorageClasses is to allow for seamless migration.
 {{< /note >}}
 
-You can create a PersistentVolumeClaim without specifying a `storageClassName`
-for the new PVC, and you can do so even when no default StorageClass exists
-in your cluster. In this case, the new PVC creates as you defined it, and the
-`storageClassName` of that PVC remains unset until a default becomes available.
-
 You can have a cluster without any default StorageClass. If you don't mark any
 StorageClass as default (and one hasn't been set for you by, for example, a cloud provider),
 then Kubernetes cannot apply that defaulting for PersistentVolumeClaims that need
 it.
 
-If or when a default StorageClass becomes available, the control plane identifies any
-existing PVCs without `storageClassName`. For the PVCs that either have an empty
-value for `storageClassName` or do not have this key, the control plane then
-updates those PVCs to set `storageClassName` to match the new default StorageClass.
-If you have an existing PVC where the `storageClassName` is `""`, and you configure
-a default StorageClass, then this PVC will not get updated.
-
-In order to keep binding to PVs with `storageClassName` set to `""`
-(while a default StorageClass is present), you need to set the `storageClassName`
-of the associated PVC to `""`.
+It is possible to create PersistentVolumeClaims without specifying a
+`storageClassName` or when no default StorageClass exists in your cluster.
+In these cases, the new PVC is created as you defined it, and the `storageClassName`
+is [retroactively set](/docs/concepts/storage/persistent-volumes/#retroactive-default-storageclass-assignment) once a default StorageClass becomes available.
 
 ## Provisioner
 


### PR DESCRIPTION
### Description
Align the documentation on storage class and pvc on the topic of retroactive storage class assignment. Some of the
content seems to be redundant. The changes would remove that redundancy.

### Issue
#56589

Closes: #56589