### PR TITLE
fix: prevent mode icon clipping on smaller screens by reducing navbar padding

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -25,7 +25,7 @@
     <ul class="navbar-nav mt-lg-0">
     {{ $p := . }}
     {{ range .Site.Menus.main }}
-    <li class="nav-item me-4 mb-2 mb-lg-0">
+    <li class="nav-item me-2 me-lg-4 mb-2 mb-lg-0">
         {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
         {{ with .Page }}
         {{ $active = or $active ( $.IsDescendant .)  }}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Reduces the horizontal margin between the main navbar items on smaller screens (below 992px) to prevent the dark/light mode toggle icon from being partially hidden or clipped. 
Changed the margin class on the main menu items in `layouts/partials/navbar.html` from `me-4` to `me-2 me-lg-4`.

#### Before: 
<img width="1055" height="946" alt="Screenshot 2026-07-24 104859" src="https://github.com/user-attachments/assets/eb3b8755-a991-4108-bdd4-92f65591b24c" />

#### After: 
<img width="1017" height="936" alt="image" src="https://github.com/user-attachments/assets/10c6c428-de3c-4b7f-b207-1f6303501ec0" />


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #56585 