### PR TITLE
[id] Replace codenew with code_sample shortcode

### DIFF
--- a/content/id/docs/concepts/cluster-administration/logging.md
+++ b/content/id/docs/concepts/cluster-administration/logging.md
@@ -21,7 +21,7 @@ Arsitektur _logging_ pada level klaster yang akan dijelaskan berikut mengasumsik
 
 Pada bagian ini, kamu dapat melihat contoh tentang dasar _logging_ pada Kubernetes yang mengeluarkan data pada _standard output_. Demonstrasi berikut ini menggunakan sebuah [spesifikasi pod](/examples/debug/counter-pod.yaml) dengan kontainer yang akan menuliskan beberapa teks ke _standard output_ tiap detik.
 
-{{% codenew file="debug/counter-pod.yaml" %}}
+{{% code_sample file="debug/counter-pod.yaml" %}}
 
 Untuk menjalankan pod ini, gunakan perintah berikut:
 
@@ -126,13 +126,13 @@ Dengan menggunakan cara ini kamu dapat memisahkan aliran log dari bagian-bagian 
 
 Sebagai contoh, sebuah pod berjalan pada satu kontainer tunggal, dan kontainer menuliskan ke dua berkas log yang berbeda, dengan dua format yang berbeda pula. Berikut ini _file_ konfigurasi untuk Pod:
 
-{{% codenew file="admin/logging/two-files-counter-pod.yaml" %}}
+{{% code_sample file="admin/logging/two-files-counter-pod.yaml" %}}
 
 Hal ini akan menyulitkan untuk mengeluarkan log dalam format yang berbeda pada aliran log yang sama, meskipun kamu dapat me-_redirect_ keduanya ke `stdout` dari kontainer.  Sebagai gantinya, kamu dapat menggunakan dua buah kontainer _sidecar_. Tiap kontainer _sidecar_ dapat membaca suatu berkas log tertentu dari _shared volume_ kemudian mengarahkan log ke `stdout`-nya sendiri.
 
 Berikut _file_ konfigurasi untuk pod yang memiliki dua buah kontainer _sidecard_:
 
-{{% codenew file="admin/logging/two-files-counter-pod-streaming-sidecar.yaml" %}}
+{{% code_sample file="admin/logging/two-files-counter-pod-streaming-sidecar.yaml" %}}
 
 Saat kamu menjalankan pod ini, kamu dapat mengakses tiap aliran log secara terpisah dengan menjalankan perintah berikut:
 
@@ -175,7 +175,7 @@ Menggunakan agen _logging_ di dalam kontainer _sidecar_ dapat berakibat pengguna
 Sebagai contoh, kamu dapat menggunakan [Stackdriver](/docs/tasks/debug-application-cluster/logging-stackdriver/),
 yang menggunakan fluentd sebagai agen _logging_. Berikut ini dua _file_ konfigurasi yang dapat kamu pakai untuk mengimplementasikan cara ini. _File_ yang pertama berisi sebuah [ConfigMap](/id/docs/tasks/configure-pod-container/configure-pod-configmap/) untuk mengonfigurasi fluentd.
 
-{{% codenew file="admin/logging/fluentd-sidecar-config.yaml" %}}
+{{% code_sample file="admin/logging/fluentd-sidecar-config.yaml" %}}
 
 {{< note >}}
 Konfigurasi fluentd berada diluar cakupan artikel ini. Untuk informasi lebih lanjut tentang cara mengonfigurasi fluentd, silakan lihat [dokumentasi resmi fluentd ](http://docs.fluentd.org/).
@@ -183,7 +183,7 @@ Konfigurasi fluentd berada diluar cakupan artikel ini. Untuk informasi lebih lan
 
 _File_ yang kedua mendeskripsikan sebuah pod yang memiliki kontainer _sidecar_ yang menjalankan fluentd. Pod ini melakukan _mount_ sebuah volume yang akan digunakan fluentd untuk mengambil data konfigurasinya.
 
-{{% codenew file="admin/logging/two-files-counter-pod-agent-sidecar.yaml" %}}
+{{% code_sample file="admin/logging/two-files-counter-pod-agent-sidecar.yaml" %}}
 
 Setelah beberapa saat, kamu akan mendapati pesan log pada _interface_ Stackdriver.
 

--- a/content/id/docs/concepts/cluster-administration/manage-deployment.md
+++ b/content/id/docs/concepts/cluster-administration/manage-deployment.md
@@ -17,7 +17,7 @@ Kamu telah melakukan _deploy_ pada aplikasimu dan mengeksposnya melalui sebuah _
 
 Banyak aplikasi memerlukan beberapa _resource_, seperti Deployment dan Service. Pengelolaan beberapa _resource_ dapat disederhanakan dengan mengelompokkannya dalam berkas yang sama (dengan pemisah `---` pada YAML). Contohnya:
 
-{{% codenew file="application/nginx-app.yaml" %}}
+{{% code_sample file="application/nginx-app.yaml" %}}
 
 Beberapa _resource_ dapat dibuat seolah-olah satu _resource_:
 

--- a/content/id/docs/concepts/overview/working-with-objects/kubernetes-objects.md
+++ b/content/id/docs/concepts/overview/working-with-objects/kubernetes-objects.md
@@ -64,7 +64,7 @@ akan mengubah informasi yang kamu berikan ke dalam format JSON ketika melakukan 
 
 Berikut merupakan contoh _file_ `.yaml` yang menunjukkan _field_ dan _spec_ objek untuk _Deployment_:
 
-{{% codenew file="application/deployment.yaml" %}}
+{{% code_sample file="application/deployment.yaml" %}}
 
 Salah satu cara untuk membuat _Deployment_ menggunakan _file_ `.yaml`
 seperti yang dijabarkan di atas adalah dengan menggunakan perintah

--- a/content/id/docs/concepts/policy/pod-security-policy.md
+++ b/content/id/docs/concepts/policy/pod-security-policy.md
@@ -146,7 +146,7 @@ alias kubectl-user='kubectl --as=system:serviceaccount:psp-example:fake-user -n 
 
 Beri definisi objek contoh PodSecurityPolicy dalam sebuah berkas. Ini adalah kebijakan yang mencegah pembuatan Pod-Pod yang _privileged_.
 
-{{% codenew file="policy/example-psp.yaml" %}}
+{{% code_sample file="policy/example-psp.yaml" %}}
 
 Dan buatlah PodSecurityPolicy tersebut dengan `kubectl`:
 
@@ -297,11 +297,11 @@ podsecuritypolicy "example" deleted
 
 Berikut adalah kebijakan dengan batasan paling sedikit yang dapat kamu buat, ekuivalen dengan tidak menggunakan _admission controller_ Pod Security Policy:
 
-{{% codenew file="policy/privileged-psp.yaml" %}}
+{{% code_sample file="policy/privileged-psp.yaml" %}}
 
 Berikut adalah sebuah contoh kebijakan yang restriktif yang mengharuskan pengguna-pengguna untuk berjalan sebagai pengguna yang _unprivileged_, memblokir kemungkinan eskalasi menjadi _root_, dan mengharuskan penggunaan beberapa mekanisme keamanan.
 
-{{% codenew file="policy/restricted-psp.yaml" %}}
+{{% code_sample file="policy/restricted-psp.yaml" %}}
 
 ## Referensi Kebijakan
 

--- a/content/id/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/id/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -52,7 +52,7 @@ spec:
 
 Kemudian tambahkan sebuah `nodeSelector` seperti berikut:
 
-{{% codenew file="pods/pod-nginx.yaml" %}}
+{{% code_sample file="pods/pod-nginx.yaml" %}}
 
 Ketika kamu menjalankan perintah `kubectl apply -f https://k8s.io/examples/pods/pod-nginx.yaml`, pod tersebut akan dijadwalkan pada node yang memiliki label yang dirinci. Kamu dapat memastikan penambahan nodeSelector berhasil dengan menjalankan `kubectl get pods -o wide` dan melihat "NODE" tempat Pod ditugaskan.
 
@@ -110,7 +110,7 @@ Afinitas node dinyatakan sebagai _field_ `nodeAffinity` dari _field_ `affinity` 
 
 Berikut ini contoh dari pod yang menggunakan afinitas node:
 
-{{% codenew file="pods/pod-with-node-affinity.yaml" %}}
+{{% code_sample file="pods/pod-with-node-affinity.yaml" %}}
 
 Aturan afinitas node tersebut menyatakan pod hanya bisa ditugaskan pada node dengan label yang memiliki kunci `kubernetes.io/e2e-az-name` dan bernilai `e2e-az1` atau `e2e-az2`. Selain itu, dari semua node yang memenuhi kriteria tersebut, mode dengan label dengan kunci `another-node-label-key` and bernilai `another-node-label-value` harus lebih diutamakan.
 
@@ -151,7 +151,7 @@ Afinitas antar pod dinyatakan sebagai _field_ `podAffinity` dari _field_ `affini
 
 #### Contoh pod yang menggunakan pod affinity:
 
-{{% codenew file="pods/pod-with-pod-affinity.yaml" %}}
+{{% code_sample file="pods/pod-with-pod-affinity.yaml" %}}
 
 Afinitas pada pod tersebut menetapkan sebuah aturan afinitas pod dan aturan anti-afinitas pod. Pada contoh ini, `podAffinity` adalah `requiredDuringSchedulingIgnoredDuringExecution`
 sementara `podAntiAffinity` adalah `preferredDuringSchedulingIgnoredDuringExecution`. Aturan afinitas pod menyatakan bahwa pod dapat dijadwalkan pada node hanya jika node tersebut berada pada zona yang sama dengan minimal satu pod yang sudah berjalan yang memiliki label dengan kunci "security" dan bernilai "S1". (Lebih detail, pod dapat berjalan pada node N jika node N memiliki label dengan kunci `failure-domain.beta.kubernetes.io/zone`dan nilai V sehingga ada minimal satu node dalam klaster dengan kunci `failure-domain.beta.kubernetes.io/zone` dan bernilai V yang menjalankan pod yang memiliki label dengan kunci "security" dan bernilai "S1".) Aturan anti-afinitas pod menyatakan bahwa pod memilih untuk tidak dijadwalkan pada sebuah node jika node tersebut sudah menjalankan pod yang memiliki label dengan kunci "security" dan bernilai "S2". (Jika `topologyKey` adalah `failure-domain.beta.kubernetes.io/zone` maka dapat diartikan bahwa pod tidak dapat dijadwalkan pada node jika node berada pada zona yang sama dengan pod yang memiliki label dengan kunci "security" dan bernilai "S2".) Lihat [design doc](https://git.k8s.io/community/contributors/design-proposals/scheduling/podaffinity.md) untuk lebih banyak contoh afinitas dan anti-afinitas pod, baik `requiredDuringSchedulingIgnoredDuringExecution`

--- a/content/id/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
+++ b/content/id/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases.md
@@ -68,7 +68,7 @@ Selain _boilerplate default_, kita dapat menambahkan entri pada berkas
 `bar.remote` pada `10.1.2.3`, kita dapat melakukannya dengan cara menambahkan
 HostAliases pada Pod di bawah _field_ `.spec.hostAliases`:
 
-{{% codenew file="service/networking/hostaliases-pod.yaml" %}}
+{{% code_sample file="service/networking/hostaliases-pod.yaml" %}}
 
 Pod ini kemudian dapat dihidupkan dengan perintah berikut:
 

--- a/content/id/docs/concepts/services-networking/connect-applications-service.md
+++ b/content/id/docs/concepts/services-networking/connect-applications-service.md
@@ -25,7 +25,7 @@ Panduan ini menggunakan server *nginx* sederhana untuk mendemonstrasikan konsepn
 
 Kita melakukan ini di beberapa contoh sebelumnya, tetapi mari kita lakukan sekali lagi dan berfokus pada prespektif jaringannya. Buat sebuah *nginx Pod*, dan perhatikan bahwa templat tersebut mempunyai spesifikasi *port* kontainer:
 
-{{% codenew file="service/networking/run-my-nginx.yaml" %}}
+{{% code_sample file="service/networking/run-my-nginx.yaml" %}}
 
 Ini membuat aplikasi tersebut dapat diakses dari *node* manapun di dalam klaster kamu. Cek lokasi *node* dimana *Pod* tersebut berjalan:
 ```shell
@@ -66,7 +66,7 @@ service/my-nginx exposed
 
 Perintah di atas sama dengan `kubectl apply -f` dengan *yaml* sebagai berikut:
 
-{{% codenew file="service/networking/nginx-svc.yaml" %}}
+{{% code_sample file="service/networking/nginx-svc.yaml" %}}
 
 Spesifikasi ini akan membuat *Service* yang membuka *TCP port 80* di setiap *Pod* dengan label `run: my-nginx` dan mengeksposnya ke dalam *port Service* (`targetPort`: adalah port kontainer yang menerima trafik, `port` adalah *service port* yang dapat berupa *port* apapun yang digunakan *Pod* lain untuk mengakses *Service*).
 
@@ -254,7 +254,7 @@ nginxsecret           Opaque                                2         1m
 
 Sekarang modifikasi replika *nginx* untuk menjalankan server *https* menggunakan *certificate* di dalam *secret* dan *Service* untuk mengekspos semua *port* (80 dan 443):
 
-{{% codenew file="service/networking/nginx-secure-app.yaml" %}}
+{{% code_sample file="service/networking/nginx-secure-app.yaml" %}}
 
 Berikut catatan penting tentang manifes *nginx-secure-app*:
 
@@ -282,7 +282,7 @@ node $ curl -k https://10.244.3.5
 
 Perlu dicatat bahwa kita menggunakan parameter `-k` saat menggunakan *curl*, ini karena kita tidak tau apapun tentang *Pod* yang menjalankan *nginx* saat pembuatan seritifikat, jadi kita harus memberitahu *curl* untuk mengabaikan ketidakcocokan *CName*. Dengan membuat *Service*, kita menghubungkan *CName* yang digunakan pada *certificate* dengan nama pada *DNS* yang digunakan *Pod*. Lakukan pengujian dari sebuah *Pod* (*secret* yang sama digunakan untuk agar mudah, *Pod* tersebut hanya membutuhkan *nginx.crt* untuk mengakses *Service*)
 
-{{% codenew file="service/networking/curlpod.yaml" %}}
+{{% code_sample file="service/networking/curlpod.yaml" %}}
 
 ```shell
 kubectl apply -f ./curlpod.yaml

--- a/content/id/docs/concepts/services-networking/dns-pod-service.md
+++ b/content/id/docs/concepts/services-networking/dns-pod-service.md
@@ -225,7 +225,7 @@ pada _field_ `dnsConfig`:
 
 Di bawah ini merupakan contoh sebuah Pod dengan pengaturan DNS kustom:
 
-{{% codenew file="service/networking/custom-dns.yaml" %}}
+{{% code_sample file="service/networking/custom-dns.yaml" %}}
 
 Ketika Pod diatas dibuat, maka Container `test`
 memiliki isi berkas `/etc/resolv.conf` sebagai berikut:

--- a/content/id/docs/concepts/services-networking/dual-stack.md
+++ b/content/id/docs/concepts/services-networking/dual-stack.md
@@ -96,19 +96,19 @@ Kubernetes akan mengalokasikan alamat IP (atau yang dikenal juga sebagai
 "_cluster IP_") dari `service-cluster-ip-range` yang dikonfigurasi pertama kali
 untuk Service ini.
 
-{{% codenew file="service/networking/dual-stack-default-svc.yaml" %}}
+{{% code_sample file="service/networking/dual-stack-default-svc.yaml" %}}
 
 Spesifikasi Service berikut memasukkan bagian `ipFamily`. Sehingga Kubernetes
 akan mengalokasikan alamat IPv6 (atau yang dikenal juga sebagai "_cluster IP_") 
 dari `service-cluster-ip-range` yang dikonfigurasi untuk Service ini.
 
-{{% codenew file="service/networking/dual-stack-ipv6-svc.yaml" %}}
+{{% code_sample file="service/networking/dual-stack-ipv6-svc.yaml" %}}
 
 Sebagai perbandingan, spesifikasi Service berikut ini akan dialokasikan sebuah alamat
 IPv4 (atau yang dikenal juga sebagai "_cluster IP_") dari `service-cluster-ip-range` 
 yang dikonfigurasi untuk Service ini.
 
-{{% codenew file="service/networking/dual-stack-ipv4-svc.yaml" %}}
+{{% code_sample file="service/networking/dual-stack-ipv4-svc.yaml" %}}
 
 ### Tipe _LoadBalancer_
 

--- a/content/id/docs/concepts/services-networking/ingress.md
+++ b/content/id/docs/concepts/services-networking/ingress.md
@@ -132,7 +132,7 @@ akan diarahkan pada *backend default*.
 Terdapat konsep Kubernetes yang memungkinkan kamu untuk mengekspos sebuah Service, lihat [alternatif lain](#alternatif-lain).
 Kamu juga bisa membuat spesifikasi Ingress dengan  *backend default* yang tidak memiliki *rules*.
 
-{{% codenew file="service/networking/ingress.yaml" %}}
+{{% code_sample file="service/networking/ingress.yaml" %}}
 
 Jika kamu menggunakan `kubectl apply -f` kamu dapat melihat:
 

--- a/content/id/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/id/docs/concepts/workloads/controllers/daemonset.md
@@ -37,7 +37,7 @@ Kamu bisa definisikan DaemonSet dalam berkas YAML. Contohnya, berkas
 `daemonset.yaml` di bawah mendefinisikan DaemonSet yang menjalankan _image_ Docker
 fluentd-elasticsearch:
 
-{{% codenew file="controllers/daemonset.yaml" %}}
+{{% code_sample file="controllers/daemonset.yaml" %}}
 
 * Buat DaemonSet berdasarkan berkas YAML:
 ```

--- a/content/id/docs/concepts/workloads/controllers/deployment.md
+++ b/content/id/docs/concepts/workloads/controllers/deployment.md
@@ -41,7 +41,7 @@ Berikut adalah penggunaan yang umum pada Deployment:
 
 Berikut adalah contoh Deployment. Dia membuat ReplicaSet untuk membangkitkan tiga Pod `nginx`:
 
-{{% codenew file="controllers/nginx-deployment.yaml" %}}
+{{% code_sample file="controllers/nginx-deployment.yaml" %}}
 
 Dalam contoh ini:
 

--- a/content/id/docs/concepts/workloads/controllers/garbage-collection.md
+++ b/content/id/docs/concepts/workloads/controllers/garbage-collection.md
@@ -22,7 +22,7 @@ Kamu juga bisa menspesifikasikan hubungan antara pemilik dan dependen dengan car
 
 Berikut adalah berkas untuk sebuah ReplicaSet yang memiliki tiga Pod:
 
-{{% codenew file="controllers/replicaset.yaml" %}}
+{{% code_sample file="controllers/replicaset.yaml" %}}
 
 
 Jika kamu membuat ReplicaSet tersebut dan kemudian melihat metadata Pod, kamu akan melihat kolom OwnerReferences:

--- a/content/id/docs/concepts/workloads/controllers/job.md
+++ b/content/id/docs/concepts/workloads/controllers/job.md
@@ -33,7 +33,7 @@ Berikut merupakan contoh konfigurasi Job. Job ini melakukan komputasi π hingga
 digit ke 2000 kemudian memberikan hasilnya sebagai keluaran. Job tersebut memerlukan 
 waktu 10 detik untuk dapat diselesaikan.
 
-{{% codenew file="controllers/job.yaml" %}}
+{{% code_sample file="controllers/job.yaml" %}}
 
 Kamu dapat menjalankan contoh tersebut dengan menjalankan perintah berikut:
 

--- a/content/id/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/id/docs/concepts/workloads/controllers/replicaset.md
@@ -29,7 +29,7 @@ Hal ini berarti kamu boleh jadi tidak akan membutuhkan manipulasi objek ReplicaS
 
 ## Contoh
 
-{{% codenew file="controllers/frontend.yaml" %}}
+{{% code_sample file="controllers/frontend.yaml" %}}
 
 Menyimpan _manifest_ ini dalam `frontend.yaml` dan mengirimkannya ke klaster Kubernetes akan membuat ReplicaSet yang telah didefinisikan beserta dengan Pod yang dikelola.
 
@@ -131,7 +131,7 @@ Walaupun kamu bisa membuat Pod biasa tanpa masalah, sangat direkomendasikan untu
 
 Mengambil contoh ReplicaSet _frontend_ sebelumnya, dan Pod yang ditentukan pada _manifest_ berikut: 
 
-{{% codenew file="pods/pod-rs.yaml" %}}
+{{% code_sample file="pods/pod-rs.yaml" %}}
 
 Karena Pod tersebut tidak memiliki Controller (atau objek lain) sebagai referensi pemilik yang sesuai dengan selektor dari ReplicaSet _frontend_, Pod tersebut akan langsung diakuisisi oleh ReplicaSet.
 
@@ -257,7 +257,7 @@ Jumlah Pod pada ReplicaSet dapat diatur dengan mengubah nilai dari _field_ `.spe
 
 Pengaturan jumlah Pod pada ReplicaSet juga dapat dilakukan mengunakan [Horizontal Pod Autoscalers (HPA)](/docs/tasks/run-application/horizontal-pod-autoscale/). Berikut adalah contoh HPA terhadap ReplicaSet yang telah dibuat pada contoh sebelumnya.
 
-{{% codenew file="controllers/hpa-rs.yaml" %}}
+{{% code_sample file="controllers/hpa-rs.yaml" %}}
 
 Menyimpan _manifest_ ini dalam `hpa-rs.yaml` dan mengirimkannya ke klaster Kubernetes akan membuat HPA tersebut yang akan mengatur jumlah Pod pada ReplicaSet yang telah didefinisikan bergantung terhadap penggunaan CPU dari Pod yang direplikasi.
 

--- a/content/id/docs/concepts/workloads/controllers/replicationcontroller.md
+++ b/content/id/docs/concepts/workloads/controllers/replicationcontroller.md
@@ -36,7 +36,7 @@ Sebuah contoh sederhana adalah membuat sebuah objek ReplicationController untuk 
 
 Contoh ReplicationController ini mengonfigurasi tiga salinan dari peladen web nginx.
 
-{{% codenew file="controllers/replication.yaml" %}}
+{{% code_sample file="controllers/replication.yaml" %}}
 
 Jalankan contoh di atas dengan mengunduh berkas contoh dan menjalankan perintah ini:
 

--- a/content/id/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
+++ b/content/id/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
@@ -114,7 +114,7 @@ node2 dan node3 (`P` merepresentasikan Pod):
 Jika kita ingin Pod baru akan disebar secara merata berdasarkan Pod yang telah ada pada semua zona,
 maka _spec_ bernilai sebagai berikut:
 
-{{% codenew file="pods/topology-spread-constraints/one-constraint.yaml" %}}
+{{% code_sample file="pods/topology-spread-constraints/one-constraint.yaml" %}}
 
 `topologyKey: zone` berarti persebaran merata hanya akan digunakan pada Node dengan pasangan label 
 "zone: <nilai apapun>". `whenUnsatisfiable: DoNotSchedule` memberitahukan penjadwal untuk membiarkan
@@ -161,7 +161,7 @@ Ini dibuat berdasarkan contoh sebelumnya. Misalkan kamu memiliki klaster dengan 
 
 Kamu dapat menggunakan 2 TopologySpreadConstraint untuk mengatur persebaran Pod pada zona dan Node:
 
-{{% codenew file="pods/topology-spread-constraints/two-constraints.yaml" %}}
+{{% code_sample file="pods/topology-spread-constraints/two-constraints.yaml" %}}
 
 Dalam contoh ini, untuk memenuhi batasan pertama, Pod yang baru hanya akan ditempatkan pada "zoneB",
 sedangkan untuk batasan kedua, Pod yang baru hanya akan ditempatkan pada "node4". Maka hasil dari 
@@ -224,7 +224,7 @@ sesuai dengan nilai tersebut akan dilewatkan.
     berkas yaml seperti di bawah, jadi "mypod" akan ditempatkan pada "zoneB", bukan "zoneC".
     Demikian juga `spec.nodeSelector` akan digunakan.
 
-    {{% codenew file="pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml" %}}
+    {{% code_sample file="pods/topology-spread-constraints/one-constraint-with-nodeaffinity.yaml" %}}
     
 ### Batasan _default_ pada tingkat klaster
 

--- a/content/id/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/id/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -21,7 +21,7 @@ kube-dns.
 
 ### Membuat Pod sederhana yang digunakan sebagai lingkungan pengujian
 
-{{% codenew file="admin/dns/dnsutils.yaml" %}}
+{{% code_sample file="admin/dns/dnsutils.yaml" %}}
 
 Gunakan manifes berikut untuk membuat sebuah Pod:
 

--- a/content/id/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
+++ b/content/id/docs/tasks/administer-cluster/manage-resources/memory-constraint-namespace.md
@@ -40,7 +40,7 @@ kubectl create namespace constraints-mem-example
 
 Berikut berkas konfigurasi untuk sebuah LimitRange:
 
-{{% codenew file="admin/resource/memory-constraints.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints.yaml" %}}
 
 Membuat LimitRange:
 
@@ -85,7 +85,7 @@ Berikut berkas konfigurasi Pod yang memiliki satu Container. Manifes Container
 menentukan permintaan memori 600 MiB dan limit memori 800 MiB. Nilai tersebut memenuhi
 batasan minimum dan maksimum memori yang ditentukan oleh LimitRange.
 
-{{% codenew file="admin/resource/memory-constraints-pod.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints-pod.yaml" %}}
 
 Membuat Pod:
 
@@ -127,7 +127,7 @@ kubectl delete pod constraints-mem-demo --namespace=constraints-mem-example
 Berikut berkas konfigurasi untuk sebuah Pod yang memiliki satu Container. Container tersebut menentukan
 permintaan memori 800 MiB dan batas memori 1.5 GiB.
 
-{{% codenew file="admin/resource/memory-constraints-pod-2.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints-pod-2.yaml" %}}
 
 Mencoba membuat Pod:
 
@@ -148,7 +148,7 @@ pods "constraints-mem-demo-2" is forbidden: maximum memory usage per Container i
 Berikut berkas konfigurasi untuk sebuah Pod yang memiliki satu Container. Container tersebut menentukan
 permintaan memori 100 MiB dan limit memori 800 MiB.
 
-{{% codenew file="admin/resource/memory-constraints-pod-3.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints-pod-3.yaml" %}}
 
 Mencoba membuat Pod:
 
@@ -171,7 +171,7 @@ pods "constraints-mem-demo-3" is forbidden: minimum memory usage per Container i
 Berikut berkas konfigurasi untuk sebuah Pod yang memiliki satu Container. Container tersebut tidak menentukan
 permintaan memori dan juga limit memori.
 
-{{% codenew file="admin/resource/memory-constraints-pod-4.yaml" %}}
+{{% code_sample file="admin/resource/memory-constraints-pod-4.yaml" %}}
 
 Mencoba membuat Pod:
 

--- a/content/id/docs/tasks/configure-pod-container/assign-memory-resource.md
+++ b/content/id/docs/tasks/configure-pod-container/assign-memory-resource.md
@@ -69,7 +69,7 @@ Dalam latihan ini, kamu akan membuat Pod yang memiliki satu Container. Container
 sebesar 100 MiB dan batasan memori sebesar 200 MiB. Berikut berkas konfigurasi
 untuk Pod:
 
-{{% codenew file="pods/resource/memory-request-limit.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit.yaml" %}}
 
 Bagian `args` dalam berkas konfigurasi memberikan argumen untuk Container pada saat dimulai.
 Argumen`"--vm-bytes", "150M"` memberi tahu Container agar mencoba mengalokasikan memori sebesar 150 MiB.
@@ -139,7 +139,7 @@ Dalam latihan ini, kamu membuat Pod yang mencoba mengalokasikan lebih banyak mem
 Berikut adalah berkas konfigurasi untuk Pod yang memiliki satu Container dengan berkas
 permintaan memori sebesar 50 MiB dan batasan memori sebesar 100 MiB:
 
-{{% codenew file="pods/resource/memory-request-limit-2.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit-2.yaml" %}}
 
 Dalam bagian `args` dari berkas konfigurasi, kamu dapat melihat bahwa Container tersebut
 akan mencoba mengalokasikan memori sebesar 250 MiB, yang jauh di atas batas yaitu 100 MiB.
@@ -250,7 +250,7 @@ kapasitas dari Node mana pun dalam klaster kamu. Berikut adalah berkas konfigura
 Container dengan permintaan memori 1000 GiB, yang kemungkinan besar melebihi kapasitas
 dari setiap Node dalam klaster kamu.
 
-{{% codenew file="pods/resource/memory-request-limit-3.yaml" %}}
+{{% code_sample file="pods/resource/memory-request-limit-3.yaml" %}}
 
 Buatlah Pod:
 

--- a/content/id/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity.md
+++ b/content/id/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity.md
@@ -64,7 +64,7 @@ Afinitas Node di dalam klaster Kubernetes.
 Konfigurasi ini menunjukkan sebuah Pod yang memiliki afinitas node `requiredDuringSchedulingIgnoredDuringExecution`, `disktype: ssd`.
 Dengan kata lain, Pod hanya akan dijadwalkan hanya pada Node yang memiliki label `disktype=ssd`.
 
-{{% codenew file="pods/pod-nginx-required-affinity.yaml" %}}
+{{% code_sample file="pods/pod-nginx-required-affinity.yaml" %}}
 
 1. Terapkan konfigurasi berikut untuk membuat sebuah Pod yang akan dijadwalkan pada Node yang kamu pilih:
 
@@ -90,7 +90,7 @@ Dengan kata lain, Pod hanya akan dijadwalkan hanya pada Node yang memiliki label
 Konfigurasi ini memberikan deskripsi sebuah Pod yang memiliki afinitas Node `preferredDuringSchedulingIgnoredDuringExecution`,`disktype: ssd`.
 Artinya Pod akan diutamakan dijalankan pada Node yang memiliki label `disktype=ssd`.
 
-{{% codenew file="pods/pod-nginx-preferred-affinity.yaml" %}}
+{{% code_sample file="pods/pod-nginx-preferred-affinity.yaml" %}}
 
 1. Terapkan konfigurasi berikut untuk membuat sebuah Pod yang akan dijadwalkan pada Node yang kamu pilih:
 

--- a/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -46,7 +46,7 @@ Kubernetes menyediakan _probe liveness_ untuk mendeteksi dan memperbaiki situasi
 Pada latihan ini, kamu akan membuat Pod yang menjalankan Container dari image
 `registry.k8s.io/busybox`. Berikut ini adalah berkas konfigurasi untuk Pod tersebut:
 
-{{% codenew file="pods/probe/exec-liveness.yaml" %}}
+{{% code_sample file="pods/probe/exec-liveness.yaml" %}}
 
 Pada berkas konfigurasi di atas, kamu dapat melihat bahwa Pod memiliki satu `Container`.
 _Field_ `periodSeconds` menentukan bahwa kubelet harus melakukan _probe liveness_ setiap 5 detik.
@@ -128,7 +128,7 @@ liveness-exec   1/1       Running   1          1m
 Jenis kedua dari _probe liveness_ menggunakan sebuah permintaan GET HTTP. Berikut ini
 berkas konfigurasi untuk Pod yang menjalankan Container dari image `registry.k8s.io/e2e-test-images/agnhost`.
 
-{{% codenew file="pods/probe/http-liveness.yaml" %}}
+{{% code_sample file="pods/probe/http-liveness.yaml" %}}
 
 Pada berkas konfigurasi tersebut, kamu dapat melihat Pod memiliki sebuah Container.
 _Field_ `periodSeconds` menentukan bahwa kubelet harus mengerjakan _probe liveness_ setiap 3 detik.
@@ -190,7 +190,7 @@ kubelet akan mencoba untuk membuka soket pada Container kamu dengan porta terten
 Jika koneksi dapat terbentuk dengan sukses, maka Container dianggap dalam kondisi sehat.
 Namun jika tidak berhasil terbentuk, maka Container dianggap gagal.
 
-{{% codenew file="pods/probe/tcp-liveness-readiness.yaml" %}}
+{{% code_sample file="pods/probe/tcp-liveness-readiness.yaml" %}}
 
 Seperti yang terlihat, konfigurasi untuk pemeriksaan TCP cukup mirip dengan
 pemeriksaan HTTP. Contoh ini menggunakan _probe readiness_ dan _liveness_.

--- a/content/id/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-persistent-volume-storage.md
@@ -93,7 +93,7 @@ untuk mengatur
 
 Berikut berkas konfigurasi untuk hostPath PersistentVolume:
 
-{{% codenew file="pods/storage/pv-volume.yaml" %}}
+{{% code_sample file="pods/storage/pv-volume.yaml" %}}
 
 Berkas konfigurasi tersebut menentukan bahwa volume berada di `/mnt/data` pada 
 klaster Node. Konfigurasi tersebut juga menentukan ukuran dari 10 gibibytes dan 
@@ -129,7 +129,7 @@ setidaknya untuk satu Node.
 
 Berikut berkas konfigurasi untuk PersistentVolumeClaim:
 
-{{% codenew file="pods/storage/pv-claim.yaml" %}}
+{{% code_sample file="pods/storage/pv-claim.yaml" %}}
 
 Membuat sebuah PersistentVolumeClaim:
 
@@ -169,7 +169,7 @@ Langkah selanjutnya adalah membuat sebuah Pod yang akan menggunakan PersistentVo
 
 Berikut berkas konfigurasi untuk Pod:
 
-{{% codenew file="pods/storage/pv-pod.yaml" %}}
+{{% code_sample file="pods/storage/pv-pod.yaml" %}}
 
 Perhatikan bahwa berkas konfigurasi Pod menentukan sebuah PersistentVolumeClaim, tetapi
 tidak menentukan PeristentVolume. Dari sudut pandang Pod, _claim_ adalah volume.

--- a/content/id/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -467,7 +467,7 @@ configmap/special-config-2-c92b5mmcf2 created
 
 2.  Memberikan nilai `special.how` yang sudah terdapat pada ConfigMap pada variabel _environment_ `SPECIAL_LEVEL_KEY` di spesifikasi Pod.
 
-   {{% codenew file="pods/pod-single-configmap-env-variable.yaml" %}}
+   {{% code_sample file="pods/pod-single-configmap-env-variable.yaml" %}}
 
    Buat Pod:
 
@@ -481,7 +481,7 @@ configmap/special-config-2-c92b5mmcf2 created
 
  * Seperti pada contoh sebelumnya, buat ConfigMap terlebih dahulu.
 
-   {{% codenew file="configmap/configmaps.yaml" %}}
+   {{% code_sample file="configmap/configmaps.yaml" %}}
 
    Buat ConfigMap:
 
@@ -491,7 +491,7 @@ configmap/special-config-2-c92b5mmcf2 created
 
 * Tentukan variabel _environment_ pada spesifikasi Pod.
 
-  {{% codenew file="pods/pod-multiple-configmap-env-variable.yaml" %}}
+  {{% code_sample file="pods/pod-multiple-configmap-env-variable.yaml" %}}
 
   Buat Pod:
 
@@ -509,7 +509,7 @@ Fungsi ini tersedia pada Kubernetes v1.6 dan selanjutnya.
 
 * Buat ConfigMap yang berisi beberapa pasangan kunci-nilai.
 
-  {{% codenew file="configmap/configmap-multikeys.yaml" %}}
+  {{% code_sample file="configmap/configmap-multikeys.yaml" %}}
 
   Buat ConfigMap:
 
@@ -519,7 +519,7 @@ Fungsi ini tersedia pada Kubernetes v1.6 dan selanjutnya.
 
 * Gunakan `envFrom` untuk menentukan seluruh data pada ConfigMap sebagai variabel _environment_ kontainer. Kunci dari ConfigMap akan menjadi nama variabel _environment_ di dalam Pod.
 
- {{% codenew file="pods/pod-configmap-envFrom.yaml" %}}
+ {{% code_sample file="pods/pod-configmap-envFrom.yaml" %}}
 
  Buat Pod:
 
@@ -536,7 +536,7 @@ Kamu dapat menggunakan variabel _environment_ yang ditentukan ConfigMap pada bag
 
 Sebagai contoh, spesifikasi Pod berikut
 
-{{% codenew file="pods/pod-configmap-env-var-valueFrom.yaml" %}}
+{{% code_sample file="pods/pod-configmap-env-var-valueFrom.yaml" %}}
 
 dibuat dengan menjalankan
 
@@ -559,7 +559,7 @@ Seperti yang sudah dijelaskan pada [Membuat ConfigMap dari berkas](#membuat-conf
 
 Contoh pada bagian ini merujuk pada ConfigMap bernama `special-config`, Seperti berikut.
 
-{{% codenew file="configmap/configmap-multikeys.yaml" %}}
+{{% code_sample file="configmap/configmap-multikeys.yaml" %}}
 
 Buat ConfigMap:
 
@@ -573,7 +573,7 @@ Tambahkan nama ConfigMap di bawah bagian `volumes` pada spesifikasi Pod.
 Hal ini akan menambahkan data ConfigMap pada direktori yang ditentukan oleh `volumeMounts.mountPath` (pada kasus ini, `/etc/config`).
 Bagian `command` berisi daftar berkas pada direktori dengan nama-nama yang sesuai dengan kunci-kunci pada ConfigMap.
 
-{{% codenew file="pods/pod-configmap-volume.yaml" %}}
+{{% code_sample file="pods/pod-configmap-volume.yaml" %}}
 
 Buat Pod:
 
@@ -597,7 +597,7 @@ Jika ada beberapa berkas pada direktori `/etc/config/`, berkas-berkas tersebut a
 Gunakan kolom `path` untuk menentukan jalur berkas yang diinginkan untuk butir tertentu pada ConfigMap (butir ConfigMap tertentu).
 Pada kasus ini, butir `SPECIAL_LEVEL` akan akan dipasangkan sebagai `config-volume` pada `/etc/config/keys`.
 
-{{% codenew file="pods/pod-configmap-volume-specific-key.yaml" %}}
+{{% code_sample file="pods/pod-configmap-volume-specific-key.yaml" %}}
 
 Buat Pod:
 

--- a/content/id/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-service-account.md
@@ -282,7 +282,7 @@ Kubelet juga dapat memproyeksikan _token_ ServiceAccount ke Pod. Kamu dapat mene
 
 Perilaku ini diatur pada PodSpec menggunakan tipe ProjectedVolume yaitu [ServiceAccountToken](/id/docs/concepts/storage/volumes/#projected). Untuk memungkinkan Pod dengan _token_ dengan pengguna bertipe _"vault"_ dan durasi validitas selama dua jam, kamu harus mengubah bagian ini pada PodSpec:
 
-{{% codenew file="pods/pod-projected-svc-token.yaml" %}}
+{{% code_sample file="pods/pod-projected-svc-token.yaml" %}}
 
 Buat Pod:
 

--- a/content/id/docs/tasks/configure-pod-container/configure-volume-storage.md
+++ b/content/id/docs/tasks/configure-pod-container/configure-volume-storage.md
@@ -25,7 +25,7 @@ _Filesystem_ dari sebuah Container hanya hidup selama Container itu juga hidup. 
 Pada latihan ini, kamu membuat sebuah Pod yang menjalankan sebuah Container. Pod ini memiliki sebuah Volume dengan tipe [emptyDir](/id/docs/concepts/storage/volumes/#emptydir)
 yang tetap bertahan, meski Container berakhir dan dimulai ulang. Berikut berkas konfigurasi untuk Pod:
 
-{{% codenew file="pods/storage/redis.yaml" %}}
+{{% code_sample file="pods/storage/redis.yaml" %}}
 
 1. Membuat Pod:
 

--- a/content/id/docs/tasks/configure-pod-container/pull-image-private-registry.md
+++ b/content/id/docs/tasks/configure-pod-container/pull-image-private-registry.md
@@ -176,7 +176,7 @@ Kamu telah berhasil menetapkan kredensial Docker kamu sebagai sebuah Secret yang
 
 Berikut ini adalah berkas konfigurasi untuk Pod yang memerlukan akses ke kredensial Docker kamu pada `regcred`:
 
-{{% codenew file="pods/private-reg-pod.yaml" %}}
+{{% code_sample file="pods/private-reg-pod.yaml" %}}
 
 Unduh berkas diatas:
 

--- a/content/id/docs/tasks/configure-pod-container/quality-service-pod.md
+++ b/content/id/docs/tasks/configure-pod-container/quality-service-pod.md
@@ -41,7 +41,7 @@ Agar sebuah Pod memiliki kelas QoS Guaranteed:
 Berikut adalah berkas konfigurasi untuk sebuah Pod dengan satu Container. Container tersebut memiliki sebuah batasan memori dan sebuah
 permintaan memori, keduanya sama dengan 200MiB. Container itu juga mempunyai batasan CPU dan permintaan CPU yang sama sebesar 700 milliCPU:
 
-{{% codenew file="pods/qos/qos-pod.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod.yaml" %}}
 
 
 Buatlah Pod：
@@ -100,7 +100,7 @@ Sebuah Pod akan mendapatkan kelas QoS Burstable apabila:
 Berikut adalah berkas konfigurasi untuk Pod dengan satu Container. Container yang dimaksud memiliki batasan memori sebesar 200MiB
 dan permintaan memori sebesar 100MiB.
 
-{{% codenew file="pods/qos/qos-pod-2.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod-2.yaml" %}}
 
 
 Buatlah Pod:
@@ -147,7 +147,7 @@ Agar Pod mendapatkan kelas QoS BestEffort, Container dalam pod tidak boleh
 memiliki batasan atau permintaan memori atau CPU.
 
 Berikut adalah berkas konfigurasi untuk Pod dengan satu Container. Container yang dimaksud tidak memiliki batasan atau permintaan memori atau CPU apapun.
-{{% codenew file="pods/qos/qos-pod-3.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod-3.yaml" %}}
 
 Buatlah Pod:
 
@@ -183,7 +183,7 @@ kubectl delete pod qos-demo-3 --namespace=qos-example
 
 Berikut adalah konfigurasi berkas untuk Pod yang memiliki dua Container. Satu Container menentukan permintaan memori sebesar 200MiB. Container yang lain tidak menentukan permintaan atau batasan apapun.
 
-{{% codenew file="pods/qos/qos-pod-4.yaml" %}}
+{{% code_sample file="pods/qos/qos-pod-4.yaml" %}}
 
 Perhatikan bahwa Pod ini memenuhi kriteria untuk kelas QoS Burstable. Maksudnya, Container tersebut tidak memenuhi 
 kriteria untuk kelas QoS Guaranteed, dan satu dari Container tersebut memiliki permintaan memori.

--- a/content/id/docs/tasks/configure-pod-container/security-context.md
+++ b/content/id/docs/tasks/configure-pod-container/security-context.md
@@ -50,7 +50,7 @@ dalam spesifikasi Pod. Bagian `securityContext` adalah sebuah objek
 Aturan keamanan yang kamu tetapkan untuk Pod akan berlaku untuk semua Container dalam Pod tersebut.
 Berikut sebuah berkas konfigurasi untuk Pod yang memiliki volume `securityContext` dan `emptyDir`:
 
-{{% codenew file="pods/security/security-context.yaml" %}}
+{{% code_sample file="pods/security/security-context.yaml" %}}
 
 Dalam berkas konfigurasi ini, bagian `runAsUser` menentukan bahwa dalam setiap Container pada
 Pod, semua proses dijalankan oleh ID pengguna 1000. Bagian `runAsGroup` menentukan grup utama dengan ID 3000 untuk
@@ -191,7 +191,7 @@ ada aturan yang tumpang tindih. Aturan pada Container mempengaruhi volume pada P
 Berikut berkas konfigurasi untuk Pod yang hanya memiliki satu Container. Keduanya, baik Pod
 dan Container memiliki bagian `securityContext` sebagai berikut:
 
-{{% codenew file="pods/security/security-context-2.yaml" %}}
+{{% code_sample file="pods/security/security-context-2.yaml" %}}
 
 Buatlah Pod tersebut:
 
@@ -244,7 +244,7 @@ bagian `capabilities` pada `securityContext` di manifes Container-nya.
 Pertama-tama, mari melihat apa yang terjadi ketika kamu tidak menyertakan bagian `capabilities`.
 Berikut ini adalah berkas konfigurasi yang tidak menambah atau mengurangi kemampuan apa pun dari Container:
 
-{{% codenew file="pods/security/security-context-3.yaml" %}}
+{{% code_sample file="pods/security/security-context-3.yaml" %}}
 
 Buatlah Pod tersebut:
 
@@ -306,7 +306,7 @@ Container ini memiliki kapabilitas tambahan yang sudah ditentukan.
 Berikut ini adalah berkas konfigurasi untuk Pod yang hanya menjalankan satu Container. Konfigurasi
 ini menambahkan kapabilitas `CAP_NET_ADMIN` dan `CAP_SYS_TIME`:
 
-{{% codenew file="pods/security/security-context-4.yaml" %}}
+{{% code_sample file="pods/security/security-context-4.yaml" %}}
 
 Buatlah Pod tersebut:
 

--- a/content/id/docs/tasks/configure-pod-container/share-process-namespace.md
+++ b/content/id/docs/tasks/configure-pod-container/share-process-namespace.md
@@ -34,7 +34,7 @@ proses pemecahan masalah (_troubleshoot_) image kontainer yang tidak memiliki ut
 Pembagian _namespace_ proses (_Process Namespace Sharing_) diaktifkan menggunakan _field_ `shareProcessNamespace`
 `v1.PodSpec`. Sebagai contoh:
 
-{{% codenew file="pods/share-process-namespace.yaml" %}}
+{{% code_sample file="pods/share-process-namespace.yaml" %}}
 
 1. Buatlah sebuah Pod `nginx` di dalam klaster kamu:
 

--- a/content/id/docs/tasks/debug-application-cluster/debug-application-introspection.md
+++ b/content/id/docs/tasks/debug-application-cluster/debug-application-introspection.md
@@ -18,7 +18,7 @@ Pod kamu. Namun ada sejumlah cara untuk mendapatkan lebih banyak informasi tenta
 
 Dalam contoh ini, kamu menggunakan Deployment untuk membuat dua buah Pod, yang hampir sama dengan contoh sebelumnya.
 
-{{% codenew file="application/nginx-with-request.yaml" %}}
+{{% code_sample file="application/nginx-with-request.yaml" %}}
 
 Buat Deployment dengan menjalankan perintah ini:
 

--- a/content/id/docs/tasks/debug-application-cluster/get-shell-running-container.md
+++ b/content/id/docs/tasks/debug-application-cluster/get-shell-running-container.md
@@ -26,7 +26,7 @@ mendapatkan _shell_ untuk masuk ke dalam Container yang sedang berjalan.
 Dalam latihan ini, kamu perlu membuat Pod yang hanya memiliki satu Container saja. Container
 tersebut menjalankan _image_ nginx. Berikut ini adalah berkas konfigurasi untuk Pod tersebut:
 
-{{% codenew file="application/shell-demo.yaml" %}}
+{{% code_sample file="application/shell-demo.yaml" %}}
 
 Buatlah Pod tersebut:
 

--- a/content/id/docs/tasks/inject-data-application/define-command-argument-container.md
+++ b/content/id/docs/tasks/inject-data-application/define-command-argument-container.md
@@ -44,7 +44,7 @@ Merujuk pada [catatan](#catatan) di bawah.
 Pada latihan ini, kamu akan membuat sebuah Pod baru yang menjalankan sebuah Container. Berkas konfigurasi
 untuk Pod mendefinisikan sebuah perintah dan dua argumen:
 
-{{% codenew file="pods/commands.yaml" %}}
+{{% code_sample file="pods/commands.yaml" %}}
 
 1. Buat sebuah Pod dengan berkas konfigurasi YAML:
 

--- a/content/id/docs/tasks/inject-data-application/define-environment-variable-container.md
+++ b/content/id/docs/tasks/inject-data-application/define-environment-variable-container.md
@@ -30,7 +30,7 @@ Dalam latihan ini, kamu membuat sebuah Pod yang menjalankan satu buah Container.
 Berkas konfigurasi untuk Pod tersebut mendefinisikan sebuah variabel lingkungan dengan nama `DEMO_GREETING` yang bernilai `"Hello from the environment"`.
 Berikut berkas konfigurasi untuk Pod tersebut:
 
-{{% codenew file="pods/inject/envars.yaml" %}}
+{{% code_sample file="pods/inject/envars.yaml" %}}
 
 1. Buatlah sebuah Pod berdasarkan berkas konfigurasi YAML tersebut:
 

--- a/content/id/docs/tasks/inject-data-application/distribute-credentials-secure.md
+++ b/content/id/docs/tasks/inject-data-application/distribute-credentials-secure.md
@@ -37,7 +37,7 @@ Gunakan alat yang telah dipercayai oleh OS kamu untuk menghindari risiko dari pe
 
 Berikut ini adalah berkas konfigurasi yang dapat kamu gunakan untuk membuat Secret yang akan menampung nama pengguna dan kata sandi kamu:
 
-{{% codenew file="pods/inject/secret.yaml" %}}
+{{% code_sample file="pods/inject/secret.yaml" %}}
 
 1. Membuat Secret
 
@@ -95,7 +95,7 @@ Tentu saja ini lebih mudah. Pendekatan yang mendetil setiap langkah di atas bert
 
 Berikut ini adalah berkas konfigurasi yang dapat kamu gunakan untuk membuat Pod:
 
-{{% codenew file="pods/inject/secret-pod.yaml" %}}
+{{% code_sample file="pods/inject/secret-pod.yaml" %}}
 
 1. Membuat Pod:
 
@@ -157,7 +157,7 @@ Berikut ini adalah berkas konfigurasi yang dapat kamu gunakan untuk membuat Pod:
 
 *  Tentukan nilai `backend-username` yang didefinisikan di Secret ke variabel lingkungan `SECRET_USERNAME` di dalam spesifikasi Pod.
 
-   {{% codenew file="pods/inject/pod-single-secret-env-variable.yaml" %}}
+   {{% code_sample file="pods/inject/pod-single-secret-env-variable.yaml" %}}
 
 *  Membuat Pod:
 
@@ -187,7 +187,7 @@ Berikut ini adalah berkas konfigurasi yang dapat kamu gunakan untuk membuat Pod:
 
 *  Definisikan variabel lingkungan di dalam spesifikasi Pod.
 
-   {{% codenew file="pods/inject/pod-multiple-secret-env-variable.yaml" %}}
+   {{% code_sample file="pods/inject/pod-multiple-secret-env-variable.yaml" %}}
 
 *  Membuat Pod:
 
@@ -221,7 +221,7 @@ Fitur ini tersedia mulai dari Kubernetes v1.6 dan yang lebih baru.
 
 *  Gunakan envFrom untuk mendefinisikan semua data Secret sebagai variabel lingkungan Container. _Key_ dari Secret akan mennjadi nama variabel lingkungan di dalam Pod.
 
-    {{% codenew file="pods/inject/pod-secret-envFrom.yaml" %}}
+    {{% code_sample file="pods/inject/pod-secret-envFrom.yaml" %}}
 
 *  Membuat Pod:
 

--- a/content/id/docs/tasks/job/automated-tasks-with-cron-jobs.md
+++ b/content/id/docs/tasks/job/automated-tasks-with-cron-jobs.md
@@ -34,7 +34,7 @@ Untuk informasi lanjut mengenai keterbatasan, lihat [CronJob](/id/docs/concepts/
 CronJob  membutuhkan sebuah berkas konfigurasi.
 Ini adalah contoh dari berkas konfigurasi CronJob `.spec` yang akan mencetak waktu sekarang dan pesan "hello" setiap menit:
 
-{{% codenew file="application/job/cronjob.yaml" %}}
+{{% code_sample file="application/job/cronjob.yaml" %}}
 
 Jalankan contoh CronJob menggunakan perintah berikut:
 

--- a/content/id/docs/tasks/manage-kubernetes-objects/declarative-config.md
+++ b/content/id/docs/tasks/manage-kubernetes-objects/declarative-config.md
@@ -52,7 +52,7 @@ Tambahkan parameter `-R` untuk memproses seluruh direktori secara rekursif.
 
 Berikut sebuah contoh *file* konfigurasi objek:
 
-{{% codenew file="application/simple_deployment.yaml" %}}
+{{% code_sample file="application/simple_deployment.yaml" %}}
 
 Jalankan perintah `kubectl diff` untuk menampilkan objek yang akan dibuat:
 
@@ -135,7 +135,7 @@ Tambahkan argumen `-R` untuk memproses seluruh direktori secara rekursif.
 
 Berikut sebuah contoh *file* konfigurasi:
 
-{{% codenew file="application/simple_deployment.yaml" %}}
+{{% code_sample file="application/simple_deployment.yaml" %}}
 
 Buat objek dengan perintah `kubectl apply`::
 
@@ -248,7 +248,7 @@ spec:
 
 Perbarui *file* konfigurasi `simple_deployment.yaml`, ubah *image* dari `nginx:1.7.9` ke `nginx:1.11.9`, dan hapus *field* `minReadySeconds`:
 
-{{% codenew file="application/update_deployment.yaml" %}}
+{{% code_sample file="application/update_deployment.yaml" %}}
 
 Terapkan perubahan yang telah dibuat di *file* konfigurasi:
 
@@ -379,7 +379,7 @@ Perintah `kubectl apply` menulis konten dari berkas konfigurasi ke anotasi `kube
 
 Agar lebih jelas, simak contoh berikut. Misalkan, berikut adalah *file* konfigurasi untuk sebuah objek Deployment:
 
-{{% codenew file="application/update_deployment.yaml" %}}
+{{% code_sample file="application/update_deployment.yaml" %}}
 
 Juga, misalkan, berikut adalah konfigurasi *live* dari objek Deployment yang sama:
 
@@ -627,7 +627,7 @@ TODO(pwittrock): *Uncomment* ini untuk versi 1.6
 
 Berikut adalah sebuah *file* konfigurasi untuk sebuah Deployment. Berkas berikut tidak menspesifikasikan `strategy`:
 
-{{% codenew file="application/simple_deployment.yaml" %}}
+{{% code_sample file="application/simple_deployment.yaml" %}}
 
 Buat objek dengan perintah `kubectl apply`:
 

--- a/content/id/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
+++ b/content/id/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough.md
@@ -57,7 +57,7 @@ Bagian ini mendefinisikan laman index.php yang melakukan beberapa komputasi inte
 Pertama, kita akan memulai Deployment yang menjalankan _image_ dan mengeksposnya sebagai Service
 menggunakan konfigurasi berikut:
 
-{{% codenew file="application/php-apache.yaml" %}}
+{{% code_sample file="application/php-apache.yaml" %}}
 
 
 Jalankan perintah berikut:
@@ -434,7 +434,7 @@ Semua metrik di HorizontalPodAutoscaler dan metrik API ditentukan menggunakan no
 
 Daripada menggunakan perintah `kubectl autoscale` untuk membuat HorizontalPodAutoscaler secara imperatif, kita dapat menggunakan berkas berikut untuk membuatnya secara deklaratif:
 
-{{% codenew file="application/hpa/php-apache.yaml" %}}
+{{% code_sample file="application/hpa/php-apache.yaml" %}}
 
 Kita akan membuat _autoscaler_ dengan menjalankan perintah berikut:
 

--- a/content/id/docs/tasks/run-application/run-stateless-application-deployment.md
+++ b/content/id/docs/tasks/run-application/run-stateless-application-deployment.md
@@ -38,7 +38,7 @@ Kamu dapat menjalankan aplikasi dengan membuat sebuah objek Deployment Kubernete
 dapat mendeskripsikan sebuah Deployment di dalam berkas YAML. Sebagai contohnya, berkas
 YAML berikut mendeskripsikan sebuah Deployment yang menjalankan _image_ Docker nginx:1.14.2:
 
-{{% codenew file="application/deployment.yaml" %}}
+{{% code_sample file="application/deployment.yaml" %}}
 
 
 1. Buatlah sebuah Deployment berdasarkan berkas YAML:
@@ -100,7 +100,7 @@ YAML berikut mendeskripsikan sebuah Deployment yang menjalankan _image_ Docker n
 Kamu dapat mengubah Deployment dengan cara mengaplikasikan berkas YAML yang baru.
 Berkas YAML ini memberikan spesifikasi Deployment untuk menggunakan Nginx versi 1.16.1.
 
-{{% codenew file="application/deployment-update.yaml" %}}
+{{% code_sample file="application/deployment-update.yaml" %}}
 
 1. Terapkan berkas YAML yang baru:
 
@@ -116,7 +116,7 @@ Kamu dapat meningkatkan jumlah Pod di dalam Deployment dengan menerapkan
 berkas YAML baru. Berkas YAML ini akan meningkatkan jumlah replika menjadi 4,
 yang nantinya memberikan spesifikasi agar Deployment memiliki 4 buah Pod.
 
-{{% codenew file="application/deployment-scale.yaml" %}}
+{{% code_sample file="application/deployment-scale.yaml" %}}
 
 1. Terapkan berkas YAML:
 

--- a/content/id/docs/tutorials/hello-minikube.md
+++ b/content/id/docs/tutorials/hello-minikube.md
@@ -32,9 +32,9 @@ Kamupun bisa mengikuti tutorial ini kalau sudah instalasi minikube di lokal. Sil
 
 Tutorial ini menyediakan image Kontainer yang dibuat melalui barisan kode berikut:
 
-{{% codenew language="js" file="minikube/server.js" %}}
+{{% code_sample language="js" file="minikube/server.js" %}}
 
-{{% codenew language="conf" file="minikube/Dockerfile" %}}
+{{% code_sample language="conf" file="minikube/Dockerfile" %}}
 
 Untuk info lebih lanjut tentang perintah `docker build`, baca [dokumentasi Docker](https://docs.docker.com/engine/reference/commandline/build/).
 

--- a/content/id/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/id/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -59,7 +59,7 @@ Contoh ini menciptakan sebuah
 [Service _headless_](/id/docs/concepts/services-networking/service/#service-headless), 
 `nginx`, untuk mempublikasikan alamat IP Pod di dalam StatefulSet, `web`.
 
-{{% codenew file="application/web/web.yaml" %}}
+{{% code_sample file="application/web/web.yaml" %}}
 
 Unduh contoh di atas, dan simpan ke dalam berkas dengan nama `web.yaml`.
 
@@ -1075,7 +1075,7 @@ menjalankan atau mengakhiri semua Pod secara bersamaan (paralel), dan tidak menu
 suatu Pod menjadi Running dan Ready atau benar-benar berakhir sebelum menjalankan atau 
 mengakhiri Pod yang lain.
 
-{{% codenew file="application/web/web-parallel.yaml" %}}
+{{% code_sample file="application/web/web-parallel.yaml" %}}
 
 Unduh contoh di atas, dan simpan ke sebuah berkas dengan nama `web-parallel.yaml`.
 

--- a/content/id/docs/tutorials/stateless-application/expose-external-ip-address.md
+++ b/content/id/docs/tutorials/stateless-application/expose-external-ip-address.md
@@ -42,7 +42,7 @@ yang mengekspos alamat IP eksternal.
 
 1. Jalankan sebuah aplikasi Hello World pada klaster kamu:
 
-{{% codenew file="service/load-balancer-example.yaml" %}}
+{{% code_sample file="service/load-balancer-example.yaml" %}}
 
 ```shell
 kubectl apply -f https://k8s.io/examples/service/load-balancer-example.yaml


### PR DESCRIPTION
### Description

In #56580, we want to remove the outdated `code` and `codenew` shortcodes in favour of the newer `code_sample`. These shortcodes are compatible, so a simple replacement works.

Here's a similar, recently merged PR for English docs: #56581