### PR TITLE
[de] Replace codenew with code_sample shortcode

### DIFF
--- a/content/de/docs/tutorials/hello-minikube.md
+++ b/content/de/docs/tutorials/hello-minikube.md
@@ -32,9 +32,9 @@ Sie können dieses Tutorial auch verwenden, wenn Sie [Minikube lokal](/docs/task
 
 Dieses Lernprogramm enthält ein aus den folgenden Dateien erstelltes Container-Image:
 
-{{% codenew language="js" file="minikube/server.js" %}}
+{{% code_sample language="js" file="minikube/server.js" %}}
 
-{{% codenew language="conf" file="minikube/Dockerfile" %}}
+{{% code_sample language="conf" file="minikube/Dockerfile" %}}
 
 Weitere Informationen zum `docker build` Befehl, lesen Sie die [Docker Dokumentation](https://docs.docker.com/engine/reference/commandline/build/).
 


### PR DESCRIPTION
### Description

In #56580, we want to remove the outdated `code` and `codenew` shortcodes in favour of the newer `code_sample`. These shortcodes are compatible, so a simple replacement works.

Here's a similar, recently merged PR for English docs: #56581