### PR TITLE
[uk] Replace codenew with code_sample shortcode

### DIFF
--- a/content/uk/docs/tutorials/hello-minikube.md
+++ b/content/uk/docs/tutorials/hello-minikube.md
@@ -49,9 +49,9 @@ You can also follow this tutorial if you've installed [Minikube locally](/docs/t
 -->
 У цьому навчальному матеріалі ми використовуємо образ контейнера, зібраний із наступних файлів:
 
-{{% codenew language="js" file="minikube/server.js" %}}
+{{% code_sample language="js" file="minikube/server.js" %}}
 
-{{% codenew language="conf" file="minikube/Dockerfile" %}}
+{{% code_sample language="conf" file="minikube/Dockerfile" %}}
 
 <!--For more information on the `docker build` command, read the [Docker documentation](https://docs.docker.com/engine/reference/commandline/build/).
 -->


### PR DESCRIPTION
### Description

In #56580, we want to remove the outdated `code` and `codenew` shortcodes in favour of the newer `code_sample`. These shortcodes are compatible, so a simple replacement works.

Here's a similar, recently merged PR for English docs: #56581