### PR TITLE
Skip npm lifecycle scripts to avoid unused Hugo binary download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=0 /go/bin/hugo /usr/local/bin/hugo
 
 WORKDIR /src
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 USER hugo:hugo
 


### PR DESCRIPTION
### Description

Fixes: ([reference](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-website-push-image-k8s-website-hugo/2080667306832171008)):

```
#24 [linux/arm64 stage-1 7/7] RUN npm ci
#24 195.7 npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
#24 674.4 npm error code 1
#24 674.4 npm error git dep preparation failed
#24 674.4 npm error command /usr/bin/node /usr/lib/node_modules/npm/bin/npm-cli.js install --force --cache=/root/.npm --prefer-offline=false --prefer-online=false --offline=false --no-progress --no-save --no-audit --include=dev --include=peer --include=optional --no-package-lock-only --no-dry-run
#24 674.9 npm error npm warn using --force Recommended protections disabled.
#24 674.9 npm error npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
#24 674.9 npm error npm warn deprecated whatwg-encoding@3.1.1: Use @exodus/bytes instead for a more spec-conformant and faster implementation
#24 674.9 npm error npm error code 1
#24 674.9 npm error npm error path /root/.npm/_cacache/tmp/git-cloneHgBgNo/node_modules/hugo-extended
#24 674.9 npm error npm error command failed
#24 674.9 npm error npm error command sh -c node postinstall.js
#24 674.9 npm error npm error ✖ Hugo installation failed. :(
#24 674.9 npm error npm error node:internal/process/promises:394
#24 674.9 npm error npm error     triggerUncaughtException(err, true /* fromPromise */);
#24 674.9 npm error npm error     ^
```

### Prior art

`kubernetes/contributor-site` already installs this way — [`Dockerfile#L24`](https://github.com/kubernetes/contributor-site/blob/2fb322a42302f5ffbb1596820830af20a300dfe9/Dockerfile#L24):

```dockerfile
COPY package*.json ./

RUN npm ci --ignore-scripts
```

That repo also skips the from-source Hugo build entirely in favour of downloading the release binary (`hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz`).


### Replication steps

Runs the same `npm ci` as `Dockerfile:45`, same base image, `linux/arm64`. This PR touches only the `Dockerfile`, so one checkout reproduces both legs.

```bash
git clone https://github.com/kubernetes/website.git
cd website
gh pr checkout 56605   # or: git remote add tineoc https://github.com/TineoC/website.git
                       #     git fetch tineoc && git checkout tineoc/fix/hugo-npm-ci-ignore-scripts

mkdir /tmp/repro && cp package.json package-lock.json /tmp/repro/

# Before
docker run --rm --platform linux/arm64 -v /tmp/repro:/src:ro -w /work \
  docker.io/library/golang:1.25-alpine \
  sh -c 'apk add --no-cache git npm && cp /src/package*.json . && npm ci'

# After (this PR)
docker run --rm --platform linux/arm64 -v /tmp/repro:/src:ro -w /work \
  docker.io/library/golang:1.25-alpine \
  sh -c 'apk add --no-cache git npm && cp /src/package*.json . && npm ci --ignore-scripts'
```

<details>
<summary>Before — <code>npm ci</code> fails (trimmed)</summary>

```
npm error code 1
npm error git dep preparation failed
npm error npm error code 1
npm error npm error path /root/.npm/_cacache/tmp/git-cloneNCDEPm/node_modules/hugo-extended
npm error npm error command failed
npm error npm error command sh -c node postinstall.js
npm error npm error ✔ Hugo installed successfully!
npm error npm error ✖ Hugo installation failed. :(
npm error npm error <ref *1> Error: spawnSync .../node_modules/hugo-extended/vendor/hugo ENOENT
npm error npm error   code: 'ENOENT',
```

Same script, same step as CI; the transient error differs (`ENOENT` on the downloaded binary here, HTTP 500 in CI). That variability is the problem — the postinstall has no retry and nothing in this image needs its output.

Running the same command with `--foreground-scripts` also surfaces a second postinstall in the same `docsy` git-dep prep — `unix-dgram`'s `node-gyp rebuild`, via `netlify-cli` — which cannot succeed in this image either, as it has no Python:

```
npm error gyp ERR! find Python Could not find any Python installation to use
npm error gyp ERR! cwd .../node_modules/netlify-cli/node_modules/unix-dgram
npm error gyp ERR! not ok
```

</details>

<details>
<summary>After — <code>npm ci --ignore-scripts</code> succeeds</summary>

```
added 1391 packages, and audited 1394 packages in 1m
real	1m 10.13s
```

No `hugo-extended` postinstall, no `node-gyp` rebuild, no request to `github.com/gohugoio/hugo/releases`.

</details>

<details>
<summary>Image still correct after the change</summary>

```bash
# from the same checkout as above
docker build --platform linux/arm64 --build-arg HUGO_VERSION=0.144.2 -t k8s-website-hugo:repro .
docker run --rm --platform linux/arm64 k8s-website-hugo:repro \
  sh -c 'hugo version; ls /src/node_modules/docsy/hugo.yaml'
```

```
hugo v0.144.2+extended linux/arm64 BuildDate=unknown
/src/node_modules/docsy/hugo.yaml
```

Extended Hugo from stage 1, and docsy's Hugo module/assets present — `--ignore-scripts` does not affect what the site build consumes.

</details>

### Issue

Closes: #56604
