### PR TITLE
Note container runtime requirement for image volume subPath

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -512,7 +512,8 @@ Besides that:
 - [`subPath`](/docs/concepts/storage/volumes/#using-subpath) or
   [`subPathExpr`](/docs/concepts/storage/volumes/#using-subpath-expanded-environment)
   mounts for containers (`spec.containers[*].volumeMounts[*].subPath`, `spec.containers[*].volumeMounts[*].subPathExpr`)
-  are only supported from Kubernetes v1.33.
+  are only supported from Kubernetes v1.33, and are applied by the container
+  runtime: support is available since containerd v2.2 and CRI-O v1.33.
 - The field `spec.securityContext.fsGroupChangePolicy` has no effect on this
   volume type.
 - The [`AlwaysPullImages` Admission Controller](/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages)

--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -512,8 +512,8 @@ Besides that:
 - [`subPath`](/docs/concepts/storage/volumes/#using-subpath) or
   [`subPathExpr`](/docs/concepts/storage/volumes/#using-subpath-expanded-environment)
   mounts for containers (`spec.containers[*].volumeMounts[*].subPath`, `spec.containers[*].volumeMounts[*].subPathExpr`)
-  are only supported from Kubernetes v1.33, and are applied by the container
-  runtime: support is available since containerd v2.2 and CRI-O v1.33.
+  are only supported from Kubernetes v1.33. The container runtime applies them:
+  support is available since containerd v2.2 and CRI-O v1.33.
 - The field `spec.securityContext.fsGroupChangePolicy` has no effect on this
   volume type.
 - The [`AlwaysPullImages` Admission Controller](/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages)

--- a/content/en/docs/tasks/configure-pod-container/image-volumes.md
+++ b/content/en/docs/tasks/configure-pod-container/image-volumes.md
@@ -73,6 +73,15 @@ It is possible to utilize
 [`subPathExpr`](/docs/concepts/storage/volumes/#using-subpath-expanded-environment)
 from Kubernetes v1.33 when using the image volume feature.
 
+{{< note >}}
+`subPath` and `subPathExpr` for image volumes are applied by the container runtime,
+so a recent enough Kubernetes version is not sufficient on its own. This support is
+available since containerd v2.2 and CRI-O v1.33.
+
+If your container runtime does not support it, the field is ignored and the whole
+image is mounted at the mount path.
+{{< /note >}}
+
 {{% code_sample file="pods/image-volumes-subpath.yaml" %}}
 
 1. Create the pod on your cluster:

--- a/content/en/docs/tasks/configure-pod-container/image-volumes.md
+++ b/content/en/docs/tasks/configure-pod-container/image-volumes.md
@@ -73,13 +73,15 @@ It is possible to utilize
 [`subPathExpr`](/docs/concepts/storage/volumes/#using-subpath-expanded-environment)
 from Kubernetes v1.33 when using the image volume feature.
 
-{{< note >}}
-`subPath` and `subPathExpr` for image volumes are applied by the container runtime,
-so a recent enough Kubernetes version is not sufficient on its own. This support is
-available since containerd v2.2 and CRI-O v1.33.
+{{% thirdparty-content %}}
 
-If your container runtime does not support it, the field is ignored and the whole
-image is mounted at the mount path.
+{{< note >}}
+The container runtime handles the `subPath` and `subPathExpr` fields for image
+volumes, so a recent enough Kubernetes version is not sufficient on its own. This
+support is available since containerd v2.2 and CRI-O v1.33.
+
+If your container runtime does not support this, it ignores the field and mounts the
+whole image at the mount path.
 {{< /note >}}
 
 {{% code_sample file="pods/image-volumes-subpath.yaml" %}}


### PR DESCRIPTION
### Description

Both pages that document `subPath` / `subPathExpr` for image volumes state that the
feature is supported "from Kubernetes v1.33". That condition is necessary but not
sufficient: sub paths for image volumes are applied by the **container runtime**, so a
cluster running a recent Kubernetes version with an older runtime silently mounts the
whole image instead of the requested sub path, with no error surfaced to the user.

This adds the missing runtime requirement to both places, and names the version floor
so a reader can tell whether their runtime is affected.

Why the runtime, and where the floors come from:

- The CRI API assigns sub path handling to the runtime. `Mount.image_sub_path` is
  documented as *"Specific image sub path to be used from inside the image instead of
  its root"*, with *"If the sub path is not empty and does not exist in the image, then
  runtimes should fail and return an error."*
- The kubelet does its part — it passes the field over CRI
  (`pkg/kubelet/kuberuntime/kuberuntime_container.go`, `ImageSubPath: v.ImageSubPath`).
- **containerd**: sub path handling lives in `internal/cri/server/container_image_mount.go`.
  It is absent at `v2.1.6` and at `v2.1.9` (the latest 2.1 patch) and present at `v2.2.6`.
  A backport to `release/2.1` was proposed in containerd#12298 and closed unmerged, so
  the 2.1 line will not gain it. Floor: **containerd v2.2**.
- **CRI-O**: handling lives in `server/container_create_linux.go`. Absent at `v1.32.0`
  and `v1.32.12`, present from `v1.33.0`. Floor: **CRI-O v1.33**.

This also explains kubernetes/kubernetes#138640, where the reporter is on containerd
2.1.6 — that issue is still open awaiting information.

Kept deliberately narrow: only the runtime condition is added. No restructuring of the
surrounding sections.

Verified locally with the pinned Hugo version from `netlify.toml` (v0.144.2 extended) —
clean build, and both pages render as intended (the note renders as an `alert-info`
block; the concept-page bullet renders as continuous list text).

### Issue

Closes: #55589

🤖 _Claude Code was used for assistance; I orchestrated and reviewed the change throughout._
