### PR TITLE
Fix navbar mode icon hidden between 767px and 799px

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -25,7 +25,7 @@
     <ul class="navbar-nav mt-lg-0">
     {{ $p := . }}
     {{ range .Site.Menus.main }}
-    <li class="nav-item me-4 mb-2 mb-lg-0">
+    <li class="nav-item me-2 me-lg-4 mb-2 mb-lg-0">
         {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
         {{ with .Page }}
         {{ $active = or $active ( $.IsDescendant .)  }}


### PR DESCRIPTION
### Description

Fixes the navbar mode icon visibility issue on screen widths between 767px and 799px.

The icon was partially hidden at these viewport widths due to the existing responsive layout. This change adjusts the navbar styling so that the mode icon remains fully visible without affecting other breakpoints.

### Issue

Closes: #56585