### PR TITLE
Update update-schedule.yml actions to Node 24 ready versions

### DIFF
--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.22'
           check-latest: true
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6.0.2
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         if: ${{ steps.create_pr.outputs.create_pr == 'true' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Bump the three actions pinned in `.github/workflows/update-schedule.yml` to their current
Node 24 releases, ahead of the Node 20 removal from Actions runners on September 16, 2026:

- `actions/checkout` v4.1.1 → v7.0.1
- `actions/setup-go` v5.0.0 → v7.0.0
- `peter-evans/create-pull-request` v6.0.2 → v8.1.1

Breaking changes between the pinned and target majors were reviewed against this workflow;
none apply (details in the linked issue).

### Issue

Closes: #56610 