### PR TITLE
Move resource managers page to Resource Management section

### DIFF
--- a/content/en/docs/concepts/resource-management/resource-managers.md
+++ b/content/en/docs/concepts/resource-management/resource-managers.md
@@ -4,7 +4,7 @@ reviewers:
 - ffromani
 - ndixita
 content_type: concept
-weight: 60
+weight: 10
 ---
 
 <!-- overview -->

--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -187,4 +187,4 @@ For mode detail about the behavior of the individual options you can configure, 
 
 ## {{% heading "whatsnext" %}}
 
-* Read about [Pod-level resource managers](/docs/concepts/workloads/resource-managers/#pod-level-resource-managers).
+* Read about [Pod-level resource managers](/docs/concepts/resource-management/resource-managers/#pod-level-resource-managers).

--- a/content/en/docs/tasks/administer-cluster/memory-manager.md
+++ b/content/en/docs/tasks/administer-cluster/memory-manager.md
@@ -317,4 +317,4 @@ Notice that both CPU and memory requests must be specified for a Pod to lend it 
 
 - Read [Troubleshooting Topology Management](/docs/tasks/debug/debug-cluster/topology/)
 - Read the [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1769-memory-manager) (Kubernetes enhancement proposal) for memory manager
-* Read about [Pod-level resource managers](/docs/concepts/workloads/resource-managers/#pod-level-resource-managers).
+* Read about [Pod-level resource managers](/docs/concepts/resource-management/resource-managers/#pod-level-resource-managers).

--- a/content/en/docs/tasks/administer-cluster/topology-manager.md
+++ b/content/en/docs/tasks/administer-cluster/topology-manager.md
@@ -398,4 +398,4 @@ assignments.
 
 ## {{% heading "whatsnext" %}}
 
-* Read about [Pod-level resource managers](/docs/concepts/workloads/resource-managers/#pod-level-resource-managers).
+* Read about [Pod-level resource managers](/docs/concepts/resource-management/resource-managers/#pod-level-resource-managers).

--- a/content/en/docs/tasks/configure-pod-container/assign-pod-level-resources.md
+++ b/content/en/docs/tasks/configure-pod-container/assign-pod-level-resources.md
@@ -53,7 +53,7 @@ following limitations:
   pods.
 * **Resource Managers:** The Topology Manager, Memory Manager and CPU Manager
   support pod-level resources when the `PodLevelResourceManagers` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-  is enabled. See [Pod-level resource managers](/docs/concepts/workloads/resource-managers/#pod-level-resource-managers)
+  is enabled. See [Pod-level resource managers](/docs/concepts/resource-management/resource-managers/#pod-level-resource-managers)
   for more details. Without this feature gate enabled, they do not align pods
   and containers based on pod-level resources.
 * **In-Place Resize:** [In-place resize](/docs/tasks/configure-pod-container/resize-container-resources/)
@@ -300,4 +300,4 @@ kubectl delete namespace pod-resources-example
 
 * [Configure Memory and CPU Quotas for a Namespace](/docs/tasks/administer-cluster/manage-resources/quota-memory-cpu-namespace/)
 
-* [Pod-level resource managers](/docs/concepts/workloads/resource-managers/#pod-level-resource-managers)
+* [Pod-level resource managers](/docs/concepts/resource-management/resource-managers/#pod-level-resource-managers)

--- a/static/_redirects.base
+++ b/static/_redirects.base
@@ -486,7 +486,8 @@
 
 /kubertenes     /blog/2024/06/06/10-years-of-kubernetes/ 302
 /docs/concepts/architecture/cri/   /docs/concepts/containers/cri/   301
-/docs/concepts/policy/node-resource-managers/ /docs/concepts/workloads/resource-managers/ 301
+/docs/concepts/policy/node-resource-managers/ /docs/concepts/resource-management/resource-managers/ 301
+/docs/concepts/workloads/resource-managers/ /docs/concepts/resource-management/resource-managers/ 308
 
 # Redirects from old gen-resourcesdocs URL structure to gen-apidocs URLs.
 # Applied when kubernetes-api content was switched to the markdown backend.


### PR DESCRIPTION
### Description

For Kubernetes v1.37, consolidate the resource-managers concept page into
the new Resource Management section. This moves
`content/en/docs/concepts/workloads/resource-managers.md` to
`content/en/docs/concepts/resource-management/resource-managers.md`,
updates internal links referencing the old path, and adds a 308 permanent
redirect from the old URL to the new one in `static/_redirects.base`.

I used AI (Claude Code) to assist with this contribution.

### Issue

Closes: #56615
