### PR TITLE
[es] Translation (new) `content/es/docs/tasks/administer-cluster/safely-drain-node.md` file into spanish

### DIFF
--- a/content/es/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/es/docs/tasks/administer-cluster/safely-drain-node.md
@@ -54,8 +54,8 @@ es seguro apagar el nodo desconectando su máquina física o, si se ejecuta en
 una plataforma en la nube, eliminando su máquina virtual.
 
 {{< note >}}
-Si cualquier pod nuevo tolera la anotación (taint) `node.kubernetes.io/unschedulable`, es posible que esos pods
-se programen en el nodo que acabas de drenar. Evita tolerar esa anotación salvo para el caso de los DaemonSets.
+Si cualquier pod nuevo tolera la taint `node.kubernetes.io/unschedulable`, es posible que esos pods
+se programen en el nodo que acabas de drenar. Evita tolerar esa taint salvo para el caso de los DaemonSets.
 
 Si tú o cualquier usuario de la API configura directamente el campo [`nodeName`](/docs/concepts/scheduling-eviction/assign-pod-node/#nodename) 
 (evitando el {{< glossary_tooltip text="programador" term_id="kube-scheduler" >}}), dicho pod quedará
@@ -79,7 +79,7 @@ Si hay pods gestionados por un DaemonSet, necesitarás especificar
 `--ignore-daemonsets` con `kubectl` para poder drenar el nodo de forma exitosa. El subcomando `kubectl drain` en sí mismo no drena
 los pods del DaemonSet de un nodo:
 el controlador de DaemonSets (plano de control) inmediatamente reemplaza los pods que faltan por
-nuevos pods equivalentes. El controlador de DaemonSets también crea pods que toleran las anotaciones no programables
+nuevos pods equivalentes. El controlador de DaemonSets también crea pods que toleran las taints no programables
 (`node.kubernetes.io/unschedulable`), lo que permite que los nuevos pods se inicien en el nodo que estás drenando.
 
 Una vez que devuelva un resultado (sin dar ningún error), puedes apagar el nodo

--- a/content/es/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/es/docs/tasks/administer-cluster/safely-drain-node.md
@@ -1,130 +1,124 @@
 ---
-reviewers:
-  - ramrodo
-  - krol3
-  - electrocucaracha
 title: Drenar un Nodo de Forma Segura
 content_type: task
 weight: 310
 ---
 
 <!-- overview -->
-This page shows how to safely drain a {{< glossary_tooltip text="node" term_id="node" >}},
-optionally respecting the PodDisruptionBudget you have defined.
+Esta página muestra cómo drenar de forma segura un {{< glossary_tooltip text="nodo" term_id="node" >}},
+opcionalmente con respecto al Presupuesto de Interrupción de Pods definido.
 
 ## {{% heading "prerequisites" %}}
 
-This task assumes that you have met the following prerequisites:
-  1. You do not require your applications to be highly available during the
-     node drain, or
-  1. You have read about the [PodDisruptionBudget](/docs/concepts/workloads/pods/disruptions/) concept,
-     and have [configured PodDisruptionBudgets](/docs/tasks/run-application/configure-pdb/) for
-     applications that need them.
+Esta tarea asume que cumples los siguientes requisitos previos:
+
+  1. No requieres que tus aplicaciones sean altamente disponibles durante el drenaje del nodo, o
+  2. Has leído sobre el concepto de [Presupuesto de Interrupción de Pods](/es/docs/concepts/workloads/pods/disruptions/) 
+     y has [configurado Presupuestos de Interrupción de Pods](/es/docs/tasks/run-application/configure-pdb/) para
+     las aplicaciones que lo necesiten.
 
 <!-- steps -->
 
-## (Optional) Configure a disruption budget {#configure-poddisruptionbudget}
+## (Opcional) Configura un presupuesto de interrupción
 
-To ensure that your workloads remain available during maintenance, you can
-configure a [PodDisruptionBudget](/docs/concepts/workloads/pods/disruptions/).
+Para asegurarte de que tus cargas de trabajo permanecen disponibles durante el mantenimiento, puedes
+configurar un [Presupuesto de Interrupción de Pods](/es/docs/concepts/workloads/pods/disruptions/).
 
-If availability is important for any applications that run or could run on the node(s)
-that you are draining, [configure a PodDisruptionBudgets](/docs/tasks/run-application/configure-pdb/)
-first and then continue following this guide.
+Si la disponibilidad es importante para cualquiera de las aplicaciones que podrían ejecutarse en el/los nodo(s)
+que estás drenando, [configura un Presupuesto de Interrupción de Pods](/es/docs/tasks/run-application/configure-pdb/)
+antes de seguir con esta guía.
 
-It is recommended to set `AlwaysAllow` [Unhealthy Pod Eviction Policy](/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy)
-to your PodDisruptionBudgets to support eviction of misbehaving applications during a node drain.
-The default behavior is to wait for the application pods to become [healthy](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod)
-before the drain can proceed.
+Se recomienda configurar `AlwaysAllow` como [Política de Desalojo de Pods No Saludables](/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy)
+en tu Presupuesto de Interrupción de Pods para permitir el desalojo de aplicaciones que no funcionen correctamente durante el drenaje de un nodo.
+El comportamiento por defecto es esperar a que los pods de la aplicación pasen a estar [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod)
+antes de proceder con el drenaje.
 
-## Use `kubectl drain` to remove a node from service
+## Usa `kubectl drain` para eliminar un nodo del servicio
 
-You can use `kubectl drain` to safely evict all of your pods from a
-node before you perform maintenance on the node (e.g. kernel upgrade,
-hardware maintenance, etc.). Safe evictions allow the pod's containers
-to [gracefully terminate](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
-and will respect the PodDisruptionBudgets you have specified.
-
-{{< note >}}
-By default `kubectl drain` ignores certain system pods on the node
-that cannot be killed; see
-the [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain)
-documentation for more details.
-{{< /note >}}
-
-When `kubectl drain` returns successfully, that indicates that all of
-the pods (except the ones excluded as described in the previous paragraph)
-have been safely evicted (respecting the desired graceful termination period,
-and respecting the PodDisruptionBudget you have defined). It is then safe to
-bring down the node by powering down its physical machine or, if running on a
-cloud platform, deleting its virtual machine.
+Puedes usar `kubectl drain` para desalojar de forma segura todos los pods de
+un nodo antes de realizar las tareas de mantenimiento en dicho nodo (por ejemplo, la
+actualización del kernel, mantenimiento del hardware, etc.). Los desalojos seguros permiten
+que los contenedores de los pods [terminen con gracia](/es/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) y respeten el Presupuesto de Interrupción de Pods que has especificado.
 
 {{< note >}}
-If any new Pods tolerate the `node.kubernetes.io/unschedulable` taint, then those Pods
-might be scheduled to the node you have drained. Avoid tolerating that taint other than
-for DaemonSets.
-
-If you or another API user directly set the [`nodeName`](/docs/concepts/scheduling-eviction/assign-pod-node/#nodename)
-field for a Pod (bypassing the scheduler), then the Pod is bound to the specified node
-and will run there, even though you have drained that node and marked it unschedulable.
+Por defecto `kubectl drain` ignora ciertos pods de sistema que no podrán ser eliminados; revisa
+[kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain)
+para más detalles.
 {{< /note >}}
 
-First, identify the name of the node you wish to drain. You can list all of the nodes in your cluster with
+Cuando `kubectl drain` devuelve un resultado exitoso, esto indica que todos
+los pods (excepto los descritos en el párrafo anterior) han sido desalojados
+de forma segura (respetando el periodo de terminación con gracia y el
+Presupuesto de Interrupción de Pods que hayas definido). En este momento, 
+es seguro apagar el nodo desconectando su máquina física o, si se ejecuta en
+una plataforma en la nube, eliminando su máquina virtual.
+
+{{< note >}}
+Si cualquier pod nuevo tolera la mancha (taint, en inglés) `node.kubernetes.io/unschedulable`, es posible que esos pods
+se programen en el nodo que acabas de drenar. Evita tolerar esa mancha salvo para el caso de los DaemonSets.
+
+Si tú o cualquier usuario de la API configura directamente el campo [`nodeName`](/docs/concepts/scheduling-eviction/assign-pod-node/#nodename) 
+(evitando el {{< glossary_tooltip text="programador" term_id="kube-scheduler" >}}), dicho pod quedará
+vinculado al nodo especificado y se ejecutará allí aunque hayas vaciado ese nodo y haya quedado marcado 
+como no programable.
+{{< /note >}}
+
+En primer lugar, identifica el nombre del nodo que quieres drenar. Puedes ver la lista de todos los nodos de tu clúster con:
 
 ```shell
 kubectl get nodes
 ```
 
-Next, tell Kubernetes to drain the node:
+A continuación, dile a Kubernetes que drene el nodo:
 
 ```shell
 kubectl drain --ignore-daemonsets <node name>
 ```
 
-If there are pods managed by a DaemonSet, you will need to specify
-`--ignore-daemonsets` with `kubectl` to successfully drain the node. The `kubectl drain` subcommand on its own does not actually drain
-a node of its DaemonSet pods:
-the DaemonSet controller (part of the control plane) immediately replaces missing Pods with
-new equivalent Pods. The DaemonSet controller also creates Pods that ignore unschedulable
-taints, which allows the new Pods to launch onto a node that you are draining.
+Si hay Pods gestionados por un DaemonSet, necesitarás especificar 
+`--ignore-daemonsets` con `kubectl` para poder drenar el nodo de forma exitosa. El subcomando `kubectl drain` en sí mismo no drena
+un nodo de sus Pods DaemonSet:
+el controlador de DaemonSets (plano de control) inmediatamente reemplaza los Pods que faltan por
+nuevos Pods equivalentes. El controlador de DaemonSets también crea Pods que toleran las manchas no programables
+(`node.kubernetes.io/unschedulable`), lo que permite que los nuevos pods se inicien en el nodo que estás drenando.
 
-Once it returns (without giving an error), you can power down the node
-(or equivalently, if on a cloud platform, delete the virtual machine backing the node).
-If you leave the node in the cluster during the maintenance operation, you need to run
+Una vez que devuelva un resultado (sin dar ningún error), puedes apagar el nodo
+(o, si se trata de una plataforma en la nube, eliminar la máquina virtual que aloja el nodo).
+
+Posteriormente, cuando el nodo vuelva a estar operativo después de las tareas de mantenimiento, necesitas ejecutar:
 
 ```shell
 kubectl uncordon <node name>
 ```
-afterwards to tell Kubernetes that it can resume scheduling new pods onto the node.
 
-## Draining multiple nodes in parallel
+para indicarle a Kubernetes que puede reanudar la programación de nuevos Pods en el nodo.
 
-The `kubectl drain` command should only be issued to a single node at a
-time. However, you can run multiple `kubectl drain` commands for
-different nodes in parallel, in different terminals or in the
-background. Multiple drain commands running concurrently will still
-respect the PodDisruptionBudget you specify.
+## Drenando múltiples nodos en paralelo
 
-For example, if you have a StatefulSet with three replicas and have
-set a PodDisruptionBudget for that set specifying `minAvailable: 2`,
-`kubectl drain` only evicts a pod from the StatefulSet if all three
-replicas pods are [healthy](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod);
-if then you issue multiple drain commands in parallel,
-Kubernetes respects the PodDisruptionBudget and ensures that
-only 1 (calculated as `replicas - minAvailable`) Pod is unavailable
-at any given time. Any drains that would cause the number of [healthy](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod)
-replicas to fall below the specified budget are blocked.
+El comando `kubectl drain` solo debe ejecutarse en un único nodo a la
+vez. Sin embargo, puedes ejecutar múltiples comandos `kubectl drain` para
+diferentes nodos en paralelo, en diferentes terminales o en
+segundo plano. Aunque se ejecuten varios comandos de drenaje al mismo tiempo,
+seguirán respetando el Presupuesto de Interrupción de Pods que especifiques.
 
-## The Eviction API {#eviction-api}
+Por ejemplo, si tienes un StatefulSet con tres réplicas y un Presupuesto de Interrupción 
+de `minAvailable: 2` para él, `kubectl drain` solo desalojará un pod del StatefulSet si
+las tres réplicas están [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod);
+si ejecutas varios comandos de drenaje en paralelo, Kubernetes respetará el
+Presupuesto de Interrupción de Pods y asegurará que solo 1 Pod (calculado como `replicas - minAvailable`)
+esté no disponible en cualquier momento. Cualquier drenaje que pudiera causar que el número de
+réplicas [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod) caiga debajo
+del presupuesto especificado, sería bloqueado.
 
-If you prefer not to use [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain) (such as
-to avoid calling to an external command, or to get finer control over the pod
-eviction process), you can also programmatically cause evictions using the
-eviction API.
+## La API de desalojos
 
-For more information, see [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/).
+Si prefieres no usar [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain) (por ejemplo,
+para evitar llamar a un comando externo o para tener un control más preciso sobre el proceso de desalojo de
+Pods), puedes provocar los desalojos de manera programática usando la API de desalojos.
+
+Para más información, consulta [desalojo iniciado por API](/docs/concepts/scheduling-eviction/api-eviction/).
 
 ## {{% heading "whatsnext" %}}
 
-* Follow steps to protect your application by [configuring a Pod Disruption Budget](/docs/tasks/run-application/configure-pdb/).
+* Sigue estos pasos para proteger tu aplicación [configurando un Presupuesto de Interrupción de Pods](/es/docs/tasks/run-application/configure-pdb/).
 

--- a/content/es/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/es/docs/tasks/administer-cluster/safely-drain-node.md
@@ -1,20 +1,20 @@
 ---
-title: Drenar un Nodo de Forma Segura
+title: Drenar un nodo de forma segura
 content_type: task
 weight: 310
 ---
 
 <!-- overview -->
 Esta página muestra cómo drenar de forma segura un {{< glossary_tooltip text="nodo" term_id="node" >}},
-opcionalmente con respecto al Presupuesto de Interrupción de Pods definido.
+opcionalmente con respecto al presupuesto de interrupción de pods definido.
 
 ## {{% heading "prerequisites" %}}
 
 Esta tarea asume que cumples los siguientes requisitos previos:
 
   1. No requieres que tus aplicaciones sean altamente disponibles durante el drenaje del nodo, o
-  2. Has leído sobre el concepto de [Presupuesto de Interrupción de Pods](/es/docs/concepts/workloads/pods/disruptions/) 
-     y has [configurado Presupuestos de Interrupción de Pods](/es/docs/tasks/run-application/configure-pdb/) para
+  2. Has leído sobre el concepto de [presupuesto de interrupción de pods](/es/docs/concepts/workloads/pods/disruptions/) 
+     y has [configurado presupuestos de interrupción de pods](/es/docs/tasks/run-application/configure-pdb/) para
      las aplicaciones que lo necesiten.
 
 <!-- steps -->
@@ -22,14 +22,14 @@ Esta tarea asume que cumples los siguientes requisitos previos:
 ## (Opcional) Configura un presupuesto de interrupción
 
 Para asegurarte de que tus cargas de trabajo permanecen disponibles durante el mantenimiento, puedes
-configurar un [Presupuesto de Interrupción de Pods](/es/docs/concepts/workloads/pods/disruptions/).
+configurar un [presupuesto de interrupción de pods](/es/docs/concepts/workloads/pods/disruptions/).
 
 Si la disponibilidad es importante para cualquiera de las aplicaciones que podrían ejecutarse en el/los nodo(s)
-que estás drenando, [configura un Presupuesto de Interrupción de Pods](/es/docs/tasks/run-application/configure-pdb/)
+que estás drenando, [configura un presupuesto de interrupción de pods](/es/docs/tasks/run-application/configure-pdb/)
 antes de seguir con esta guía.
 
-Se recomienda configurar `AlwaysAllow` como [Política de Desalojo de Pods No Saludables](/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy)
-en tu Presupuesto de Interrupción de Pods para permitir el desalojo de aplicaciones que no funcionen correctamente durante el drenaje de un nodo.
+Se recomienda configurar `AlwaysAllow` como [Política de Desalojo de pods No Saludables](/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy)
+en tu presupuesto de interrupción de pods para permitir el desalojo de aplicaciones que no funcionen correctamente durante el drenaje de un nodo.
 El comportamiento por defecto es esperar a que los pods de la aplicación pasen a estar [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod)
 antes de proceder con el drenaje.
 
@@ -38,7 +38,7 @@ antes de proceder con el drenaje.
 Puedes usar `kubectl drain` para desalojar de forma segura todos los pods de
 un nodo antes de realizar las tareas de mantenimiento en dicho nodo (por ejemplo, la
 actualización del kernel, mantenimiento del hardware, etc.). Los desalojos seguros permiten
-que los contenedores de los pods [terminen con gracia](/es/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) y respeten el Presupuesto de Interrupción de Pods que has especificado.
+que los contenedores de los pods [no terminen abruptamente](/es/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) y respeten el presupuesto de interrupción de pods que has especificado.
 
 {{< note >}}
 Por defecto `kubectl drain` ignora ciertos pods de sistema que no podrán ser eliminados; revisa
@@ -48,14 +48,14 @@ para más detalles.
 
 Cuando `kubectl drain` devuelve un resultado exitoso, esto indica que todos
 los pods (excepto los descritos en el párrafo anterior) han sido desalojados
-de forma segura (respetando el periodo de terminación con gracia y el
-Presupuesto de Interrupción de Pods que hayas definido). En este momento, 
+de forma segura (respetando el periodo de terminación no abrupta y el
+presupuesto de interrupción de pods que hayas definido). En este momento, 
 es seguro apagar el nodo desconectando su máquina física o, si se ejecuta en
 una plataforma en la nube, eliminando su máquina virtual.
 
 {{< note >}}
-Si cualquier pod nuevo tolera la mancha (taint, en inglés) `node.kubernetes.io/unschedulable`, es posible que esos pods
-se programen en el nodo que acabas de drenar. Evita tolerar esa mancha salvo para el caso de los DaemonSets.
+Si cualquier pod nuevo tolera la anotación (taint) `node.kubernetes.io/unschedulable`, es posible que esos pods
+se programen en el nodo que acabas de drenar. Evita tolerar esa anotación salvo para el caso de los DaemonSets.
 
 Si tú o cualquier usuario de la API configura directamente el campo [`nodeName`](/docs/concepts/scheduling-eviction/assign-pod-node/#nodename) 
 (evitando el {{< glossary_tooltip text="programador" term_id="kube-scheduler" >}}), dicho pod quedará
@@ -72,14 +72,14 @@ kubectl get nodes
 A continuación, dile a Kubernetes que drene el nodo:
 
 ```shell
-kubectl drain --ignore-daemonsets <node name>
+kubectl drain --ignore-daemonsets <nombre del nodo>
 ```
 
-Si hay Pods gestionados por un DaemonSet, necesitarás especificar 
+Si hay pods gestionados por un DaemonSet, necesitarás especificar 
 `--ignore-daemonsets` con `kubectl` para poder drenar el nodo de forma exitosa. El subcomando `kubectl drain` en sí mismo no drena
-un nodo de sus Pods DaemonSet:
-el controlador de DaemonSets (plano de control) inmediatamente reemplaza los Pods que faltan por
-nuevos Pods equivalentes. El controlador de DaemonSets también crea Pods que toleran las manchas no programables
+los pods del DaemonSet de un nodo:
+el controlador de DaemonSets (plano de control) inmediatamente reemplaza los pods que faltan por
+nuevos pods equivalentes. El controlador de DaemonSets también crea pods que toleran las anotaciones no programables
 (`node.kubernetes.io/unschedulable`), lo que permite que los nuevos pods se inicien en el nodo que estás drenando.
 
 Una vez que devuelva un resultado (sin dar ningún error), puedes apagar el nodo
@@ -88,10 +88,10 @@ Una vez que devuelva un resultado (sin dar ningún error), puedes apagar el nodo
 Posteriormente, cuando el nodo vuelva a estar operativo después de las tareas de mantenimiento, necesitas ejecutar:
 
 ```shell
-kubectl uncordon <node name>
+kubectl uncordon <nombre del nodo>
 ```
 
-para indicarle a Kubernetes que puede reanudar la programación de nuevos Pods en el nodo.
+para indicarle a Kubernetes que puede reanudar la programación de nuevos pods en el nodo.
 
 ## Drenando múltiples nodos en paralelo
 
@@ -99,13 +99,13 @@ El comando `kubectl drain` solo debe ejecutarse en un único nodo a la
 vez. Sin embargo, puedes ejecutar múltiples comandos `kubectl drain` para
 diferentes nodos en paralelo, en diferentes terminales o en
 segundo plano. Aunque se ejecuten varios comandos de drenaje al mismo tiempo,
-seguirán respetando el Presupuesto de Interrupción de Pods que especifiques.
+seguirán respetando el presupuesto de interrupción de pods que especifiques.
 
-Por ejemplo, si tienes un StatefulSet con tres réplicas y un Presupuesto de Interrupción 
+Por ejemplo, si tienes un StatefulSet con tres réplicas y un presupuesto de interrupción 
 de `minAvailable: 2` para él, `kubectl drain` solo desalojará un pod del StatefulSet si
 las tres réplicas están [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod);
 si ejecutas varios comandos de drenaje en paralelo, Kubernetes respetará el
-Presupuesto de Interrupción de Pods y asegurará que solo 1 Pod (calculado como `replicas - minAvailable`)
+presupuesto de interrupción de pods y asegurará que solo 1 pod (calculado como `replicas - minAvailable`)
 esté no disponible en cualquier momento. Cualquier drenaje que pudiera causar que el número de
 réplicas [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod) caiga debajo
 del presupuesto especificado, sería bloqueado.
@@ -114,11 +114,11 @@ del presupuesto especificado, sería bloqueado.
 
 Si prefieres no usar [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain) (por ejemplo,
 para evitar llamar a un comando externo o para tener un control más preciso sobre el proceso de desalojo de
-Pods), puedes provocar los desalojos de manera programática usando la API de desalojos.
+pods), puedes provocar los desalojos de manera programática usando la API de desalojos.
 
 Para más información, consulta [desalojo iniciado por API](/docs/concepts/scheduling-eviction/api-eviction/).
 
 ## {{% heading "whatsnext" %}}
 
-* Sigue estos pasos para proteger tu aplicación [configurando un Presupuesto de Interrupción de Pods](/es/docs/tasks/run-application/configure-pdb/).
+* Sigue estos pasos para proteger tu aplicación [configurando un presupuesto de interrupción de pods](/es/docs/tasks/run-application/configure-pdb/).
 

--- a/content/es/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/es/docs/tasks/administer-cluster/safely-drain-node.md
@@ -1,0 +1,130 @@
+---
+reviewers:
+  - ramrodo
+  - krol3
+  - electrocucaracha
+title: Drenar un Nodo de Forma Segura
+content_type: task
+weight: 310
+---
+
+<!-- overview -->
+This page shows how to safely drain a {{< glossary_tooltip text="node" term_id="node" >}},
+optionally respecting the PodDisruptionBudget you have defined.
+
+## {{% heading "prerequisites" %}}
+
+This task assumes that you have met the following prerequisites:
+  1. You do not require your applications to be highly available during the
+     node drain, or
+  1. You have read about the [PodDisruptionBudget](/docs/concepts/workloads/pods/disruptions/) concept,
+     and have [configured PodDisruptionBudgets](/docs/tasks/run-application/configure-pdb/) for
+     applications that need them.
+
+<!-- steps -->
+
+## (Optional) Configure a disruption budget {#configure-poddisruptionbudget}
+
+To ensure that your workloads remain available during maintenance, you can
+configure a [PodDisruptionBudget](/docs/concepts/workloads/pods/disruptions/).
+
+If availability is important for any applications that run or could run on the node(s)
+that you are draining, [configure a PodDisruptionBudgets](/docs/tasks/run-application/configure-pdb/)
+first and then continue following this guide.
+
+It is recommended to set `AlwaysAllow` [Unhealthy Pod Eviction Policy](/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy)
+to your PodDisruptionBudgets to support eviction of misbehaving applications during a node drain.
+The default behavior is to wait for the application pods to become [healthy](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod)
+before the drain can proceed.
+
+## Use `kubectl drain` to remove a node from service
+
+You can use `kubectl drain` to safely evict all of your pods from a
+node before you perform maintenance on the node (e.g. kernel upgrade,
+hardware maintenance, etc.). Safe evictions allow the pod's containers
+to [gracefully terminate](/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+and will respect the PodDisruptionBudgets you have specified.
+
+{{< note >}}
+By default `kubectl drain` ignores certain system pods on the node
+that cannot be killed; see
+the [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain)
+documentation for more details.
+{{< /note >}}
+
+When `kubectl drain` returns successfully, that indicates that all of
+the pods (except the ones excluded as described in the previous paragraph)
+have been safely evicted (respecting the desired graceful termination period,
+and respecting the PodDisruptionBudget you have defined). It is then safe to
+bring down the node by powering down its physical machine or, if running on a
+cloud platform, deleting its virtual machine.
+
+{{< note >}}
+If any new Pods tolerate the `node.kubernetes.io/unschedulable` taint, then those Pods
+might be scheduled to the node you have drained. Avoid tolerating that taint other than
+for DaemonSets.
+
+If you or another API user directly set the [`nodeName`](/docs/concepts/scheduling-eviction/assign-pod-node/#nodename)
+field for a Pod (bypassing the scheduler), then the Pod is bound to the specified node
+and will run there, even though you have drained that node and marked it unschedulable.
+{{< /note >}}
+
+First, identify the name of the node you wish to drain. You can list all of the nodes in your cluster with
+
+```shell
+kubectl get nodes
+```
+
+Next, tell Kubernetes to drain the node:
+
+```shell
+kubectl drain --ignore-daemonsets <node name>
+```
+
+If there are pods managed by a DaemonSet, you will need to specify
+`--ignore-daemonsets` with `kubectl` to successfully drain the node. The `kubectl drain` subcommand on its own does not actually drain
+a node of its DaemonSet pods:
+the DaemonSet controller (part of the control plane) immediately replaces missing Pods with
+new equivalent Pods. The DaemonSet controller also creates Pods that ignore unschedulable
+taints, which allows the new Pods to launch onto a node that you are draining.
+
+Once it returns (without giving an error), you can power down the node
+(or equivalently, if on a cloud platform, delete the virtual machine backing the node).
+If you leave the node in the cluster during the maintenance operation, you need to run
+
+```shell
+kubectl uncordon <node name>
+```
+afterwards to tell Kubernetes that it can resume scheduling new pods onto the node.
+
+## Draining multiple nodes in parallel
+
+The `kubectl drain` command should only be issued to a single node at a
+time. However, you can run multiple `kubectl drain` commands for
+different nodes in parallel, in different terminals or in the
+background. Multiple drain commands running concurrently will still
+respect the PodDisruptionBudget you specify.
+
+For example, if you have a StatefulSet with three replicas and have
+set a PodDisruptionBudget for that set specifying `minAvailable: 2`,
+`kubectl drain` only evicts a pod from the StatefulSet if all three
+replicas pods are [healthy](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod);
+if then you issue multiple drain commands in parallel,
+Kubernetes respects the PodDisruptionBudget and ensures that
+only 1 (calculated as `replicas - minAvailable`) Pod is unavailable
+at any given time. Any drains that would cause the number of [healthy](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod)
+replicas to fall below the specified budget are blocked.
+
+## The Eviction API {#eviction-api}
+
+If you prefer not to use [kubectl drain](/docs/reference/generated/kubectl/kubectl-commands/#drain) (such as
+to avoid calling to an external command, or to get finer control over the pod
+eviction process), you can also programmatically cause evictions using the
+eviction API.
+
+For more information, see [API-initiated eviction](/docs/concepts/scheduling-eviction/api-eviction/).
+
+## {{% heading "whatsnext" %}}
+
+* Follow steps to protect your application by [configuring a Pod Disruption Budget](/docs/tasks/run-application/configure-pdb/).
+

--- a/content/es/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/content/es/docs/tasks/administer-cluster/safely-drain-node.md
@@ -28,9 +28,9 @@ Si la disponibilidad es importante para cualquiera de las aplicaciones que podr�
 que estás drenando, [configura un presupuesto de interrupción de pods](/es/docs/tasks/run-application/configure-pdb/)
 antes de seguir con esta guía.
 
-Se recomienda configurar `AlwaysAllow` como [Política de Desalojo de pods No Saludables](/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy)
+Se recomienda configurar `AlwaysAllow` como [política de desalojo de pods no saludables](/es/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy)
 en tu presupuesto de interrupción de pods para permitir el desalojo de aplicaciones que no funcionen correctamente durante el drenaje de un nodo.
-El comportamiento por defecto es esperar a que los pods de la aplicación pasen a estar [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod)
+El comportamiento por defecto es esperar a que los pods de la aplicación pasen a estar [saludables](/es/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod)
 antes de proceder con el drenaje.
 
 ## Usa `kubectl drain` para eliminar un nodo del servicio
@@ -103,11 +103,11 @@ seguirán respetando el presupuesto de interrupción de pods que especifiques.
 
 Por ejemplo, si tienes un StatefulSet con tres réplicas y un presupuesto de interrupción 
 de `minAvailable: 2` para él, `kubectl drain` solo desalojará un pod del StatefulSet si
-las tres réplicas están [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod);
+las tres réplicas están [saludables](/es/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod);
 si ejecutas varios comandos de drenaje en paralelo, Kubernetes respetará el
 presupuesto de interrupción de pods y asegurará que solo 1 pod (calculado como `replicas - minAvailable`)
 esté no disponible en cualquier momento. Cualquier drenaje que pudiera causar que el número de
-réplicas [saludables](/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod) caiga debajo
+réplicas [saludables](/es/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod) caiga debajo
 del presupuesto especificado, sería bloqueado.
 
 ## La API de desalojos

--- a/content/es/docs/tasks/run-application/configure-pdb.md
+++ b/content/es/docs/tasks/run-application/configure-pdb.md
@@ -1,22 +1,22 @@
 ---
-title: Especificando un presupuesto de disrupción para tu aplicación
+title: Especificando un presupuesto de interrupción para tu aplicación
 content_type: task
 weight: 110
 ---
 
 <!-- overview -->
 
-Ésta pagina enseña como limitar el numero de disrupciones concurrentes que afectan a tu aplicación definiendo presupuestos de disrupción de pods, Pod Disruption Budgets (PDB) en inglés. Estos presupuestos definen el mínimo número de pods que deben estar ejecutándose en todo momento para asegurar la disponibilidad de la aplicación durante operaciones de mantenimiento efectuadas sobre los nodos por los administradores del cluster.
+{{< feature-state for_k8s_version="v1.21" state="stable" >}}
 
-
+Esta pagina enseña cómo limitar el número de interrupciones concurrentes que afectan a tu aplicación definiendo presupuestos de interrupción de pods, Pod Disruption Budgets (PDB) en inglés. Estos presupuestos definen el mínimo número de pods que deben estar ejecutándose en todo momento para asegurar la disponibilidad de la aplicación durante operaciones de mantenimiento efectuadas sobre los nodos por los administradores del clúster.
 
 ## {{% heading "prerequisites" %}}
 
-* Tener permisos de administrador sobre la aplicación que esta corriendo en Kubernetes y requiere alta disponibilidad
-* Deberías saber como desplegar [Múltiples réplicas de aplicaciones stateless](/docs/tasks/run-application/run-stateless-application-deployment/)
+* Tener permisos de administrador sobre la aplicación que está corriendo en Kubernetes y requiere alta disponibilidad
+* Deberías saber cómo desplegar [Múltiples réplicas de aplicaciones stateless](/docs/tasks/run-application/run-stateless-application-deployment/)
   y/o [Múltiples réplicas de aplicaciones stateful](/docs/tasks/run-application/run-replicated-stateful-application/).
-* Deberías haber leido acerca de [Disrupciones de un Pod](/docs/concepts/workloads/pods/disruptions/).
-* Deberías confirmar con el propietario del cluster o proveedor de servicio que respetan Presupuestos de Disrupción para Pods.
+* Deberías haber leído acerca de [Interrupciones de un Pod](/docs/concepts/workloads/pods/disruptions/).
+* Deberías confirmar con el propietario del clúster o proveedor del servicio que respeten los presupuestos de interrupción de pods.
 
 
 <!-- steps -->
@@ -24,15 +24,13 @@ weight: 110
 ## Protegiendo una aplicación con un PodDisruptionBudget
 
 1. Identifica la aplicación que quieres proteger con un PodDisruptionBudget (PDB).
-2. Revisa como afectan las disrupciones a tú aplicación.
+2. Revisa cómo afectan las interrupciones a tu aplicación.
 3. Crea un PDB usando un archivo YAML.
-4. Crea el objecto PDB desde el archivo YAML.
-
-
+4. Crea el objeto PDB desde el archivo YAML.
 
 <!-- discussion -->
 
-## Identifica la applicación que quieres proteger
+## Identifica la aplicación que quieres proteger
 
 El caso más común es proteger aplicaciones que usan uno de los controladores incorporados
 en Kubernetes:
@@ -44,28 +42,49 @@ en Kubernetes:
 
 En este caso, toma nota del `.spec.selector` que utiliza el controlador; el mismo se utilizará en el `spec.selector` del PDB.
 
-También puedes utilizar PDBs para proteger pods que no estan gestionados por uno de los controladores listados arriba, o agrupaciones arbitrarias de pods, con algunas restricciones descritas en [Controladores Arbitrarios y Selectors](#arbitrary-controladores-and-selectors).
+También puedes utilizar PDBs para proteger pods que no están gestionados por uno de los controladores listados arriba, o agrupaciones arbitrarias de pods, con algunas restricciones descritas en [controladores arbitrarios y selectores](#arbitrary-controllers-and-selectors).
 
 
-## Revisa como afectan las disrupciones a tú aplicación
+## Revisa cómo afectan las interrupciones a tu aplicación
 
 Decide cuántas instancias de tu aplicación pueden estar fuera de servicio al mismo
-tiempo debido a disrupciones voluntarias de corto plazo.
+tiempo debido a interrupciones voluntarias de corto plazo.
 
 - Frontend stateless:
-  - Objetivo: evitar reducir capacidad para servir por mas de 10%.
+  - Objetivo: evitar reducir capacidad para servir por más de 10%.
     - Solución: usar un PDB que especifica minAvailable 90%.
 - Aplicación Stateful con una sola instancia:
   - Objetivo: no terminar esta aplicación sin primero confirmar conmigo.
     - Posible Solución 1: No usar un PDB y tolerar inactividad ocasional.
-    - Posible Solución 2: Crea un PDB con maxUnavailable=0. Entiende que el operador del cluster debe consultar contigo antes de terminar tu aplicación. Cuando el operador te contacte, prepara tu aplicación para downtime y elimina el PDB para indicar que estas preparado para la disrupción. Crea el PDB de nuevo al terminar la disrupción.
+    - Posible Solución 2: Crea un PDB con maxUnavailable=0. Entiende que el operador del clúster debe consultar contigo antes de terminar tu aplicación. Cuando el operador te contacte, prepara tu aplicación para downtime y elimina el PDB para indicar que estás preparado para la interrupción. Crea el PDB de nuevo al terminar la interrupción.
 - Aplicación Stateful con múltiples instancias como Consul, ZooKeeper, etcd, Redis o MySQL:
-  - Objetivo: no reducir el numero de instancias por debajo del quorum, de lo contrario, las escrituras fallarían.
+  - Objetivo: no reducir el número de instancias por debajo del quorum, de lo contrario, las escrituras fallarían.
     - Posible Solución 1: fijar maxUnavailable a 1 (funciona con diferentes escalas de aplicación).
-    - Posible Solución 2: fijar minAvailable al tamaño del quorum (e.g. 3 cuando hay un total de 5 instancias).  (Permite mas disrupciones a la vez.).
+    - Posible Solución 2: fijar minAvailable al tamaño del quorum (e.g. 3 cuando hay un total de 5 instancias).  (Permite más interrupciones a la vez.).
 - Trabajos por lote reiniciables:
   - Objetivo: El trabajo debe completarse en caso de una interrupción voluntaria.
     - Posible solución: No cree un PDB. El controlador de Jobs creará un pod de reemplazo.
+
+### Lógica de redondeo al especificar porcentajes
+
+Los valores de `minAvailable` o `maxUnavailable` pueden expresarse como un número entero o como porcentaje.
+
+- Cuando se especifica un número entero, este representa el número de pods. Por ejemplo, si estableces
+  `minAvailable` en 10, siempre deben estar disponibles 10 pods, incluso durante una interrupción.
+- Cuando se especifica un porcentaje, asignando al valor una cadena de un porcentaje 
+  (por ejemplo, `"50%"`), este representa un porcentaje del total de pods. Por ejemplo, si 
+  estableces `minAvailable` a `"50%"`, al menos el 50% de pods seguirán estando disponibles
+  durante una interrupción.
+
+Cuando se especifica el valor como porcentaje, es posible que no se corresponda con un número exacto de pods.
+Por ejemplo, si tienes 7 pods y configuras `minAvailable` a `"50%"`, no queda claro si eso significa que 
+deben estar disponibles 3 o 4 pods. Kubernetes redondea al número entero superior más cercano, por lo que en este caso, 
+deben estar disponibles 4 pods. Cuando especificas el valor `maxUnavailable` como porcentaje, Kubernetes 
+redondea al alza el número de pods que pueden sufrir interrupciones. Por lo tanto, una interrupción puede 
+superar el porcentaje `maxUnavailable` definido. Puedes examinar el 
+[código](https://github.com/kubernetes/kubernetes/blob/23be9587a0f8677eb8091464098881df939c44a9/pkg/controller/disruption/disruption.go#L539)
+que controla este comportamiento.
+
 
 ## Especificando un PodDisruptionBudget
 
@@ -75,11 +94,12 @@ Un `PodDisruptionBudget` tiene tres atributos:
 pods donde aplicar el presupuesto. Este campo es requerido.
 * `.spec.minAvailable` que es una descripción del número de pods del grupo que deben estar disponibles después del desalojo, incluso en ausencia del pod desalojado. `minAvailable` puede ser un número absoluto o un porcentaje.
 * `.spec.maxUnavailable` (disponible en Kubernetes 1.7 y superior) que es una descripción
-del numero de pods del grupo que pueden estar indisponibles despues del desalojo. Puede ser un número absoluto o un porcentaje.
+del número de pods del grupo que pueden estar indisponibles después del desalojo. Puede ser un número absoluto o un porcentaje.
 
 {{< note >}}
-Para las versiones 1.8 y anteriores: al crear un `PodDisruptionBudget`
-utilizando la herramienta de línea de comandos `kubectl`, el campo `minAvailable` es 1 por defecto si no se especifica `minAvailable` ni `maxUnavailable`.
+El comportamiento para un selector vacío difiere entre las APIs policy/v1beta1 y policy/v1 para
+`PodDisruptionBudgets`. En el caso de policy/v1beta1 un selector vacío no coincide con ningún pod, mientras
+que para el caso de policy/v1, un selector vacío coincide con todos los pods en el namespace.
 {{< /note >}}
 
 Puedes especificar únicamente un valor para `maxUnavailable` y `minAvailable` por `PodDisruptionBudget`.
@@ -89,60 +109,46 @@ hace referencia al valor 'scale' del controlador que gestiona el grupo de pods s
 `PodDisruptionBudget`.
 
 Ejemplo 1: Con un `minAvailable` de 5, se permiten los desalojos siempre que dejen
-5 o más pods disponibles entre las seleccionadas por el `selector` del PodDisruptionBudget.
+5 o más pods [saludables](/es/docs/tasks/run-application/configure-pdb/#healthiness-of-a-pod) seleccionadas por el `selector` del presupuesto de interrupción de pods.
 
-Ejemplo 2: Con un `minAvailable` del 30%, se permiten los desalojos mientras que al menos 30% de la cantidad de réplicas se mantengan disponibles.
+Ejemplo 2: Con un `minAvailable` del 30%, se permiten los desalojos mientras que al menos 30% de la cantidad de réplicas se mantengan saludables.
 
 Ejemplo 3: Con un `maxUnavailable` de 5, se permiten desalojos siempre que haya como máximo 5
-réplicas indisponibles entre el número total de réplicas deseadas.
+réplicas no saludables entre el número total de réplicas deseadas.
 
-Ejemplo 4: Con un `maxUnavailable` de 30%, se permiten los desalojos siempre y cuando no más del 30%
-de las réplicas esten indisponibles.
+Ejemplo 4: Con un `maxUnavailable` de 30%, se permiten los desalojos siempre y cuando el número de réplicas
+no saludables no supere el 30% del total de réplicas deseadas redondeando al número entero superior más cercano.
+Si el número total de réplicas deseadas es solo uno, se permite que esa única réplica sufra una interrupción, 
+lo que daría lugar a una indisponibilidad efectiva del 100%.
 
 En el uso típico, se usaría un solo presupuesto para una colección de pods administrados por
 un controlador, por ejemplo, los pods en un solo ReplicaSet o StatefulSet.
 
 {{< note >}}
-Un presupuesto de disrupción no garantiza que el número/porcentaje de pods especificado
-siempre estarán disponibles. Por ejemplo, un nodo que alberga un
-pod del grupo puede fallar cuando el grupo está en el tamaño mínimo
-especificados en el presupuesto, lo que hace que el número de pods disponibles este por debajo del tamaño especificado. El presupuesto solo puede proteger contra
-desalojos voluntarios, pero no todas las causas de indisponibilidad.
+Un presupuesto de interrupción no garantiza que el número/porcentaje de pods especificado
+siempre esté disponible. Por ejemplo, un nodo que alberga un
+pod del grupo puede fallar cuando el grupo está en el tamaño mínimo especificado en el presupuesto, 
+lo que hace que el número de pods disponibles esté por debajo del tamaño especificado. 
+El presupuesto solo puede proteger contra desalojos voluntarios, no contra todas las causas de indisponibilidad.
 {{< /note >}}
 
-Un `maxUnavailable` de 0% (o 0) o un `minAvailable` de 100% (o igual al
-número de réplicas) puede prevenir que los nodos sean purgados completamente.
+Si estableces un `maxUnavailable` de 0% (o 0) o un `minAvailable` de 100% (o igual al
+número de réplicas), estás exigiendo que no se produzcan desalojos voluntarios.  
+puede prevenir que los nodos sean purgados completamente. Cuando estableces cero desalojos voluntarios para un controlador,
+como un ReplicaSet, no es posible drenar correctamente un nodo en el que se esté ejecutando uno de esos pods.
+Si intentas drenar un nodo en el que se está ejecutando un pod que no puede ser desalojado, el drenaje nunca se completará.
 Esto está permitido según la semántica de `PodDisruptionBudget`.
 
-Puedes encontrar ejemplos de presupuestos de disrupción de pods definidas a continuación. Los ejemplos aplican al grupo de pods que tienen la etiqueta `app: zookeeper`.
+Puedes encontrar ejemplos de presupuestos de interrupción de pods definidos a continuación. Los ejemplos aplican al 
+grupo de pods que tienen la etiqueta `app: zookeeper`.
 
 Ejemplo de PDB usando minAvailable:
 
-```yaml
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: zk-pdb
-spec:
-  minAvailable: 2
-  selector:
-    matchLabels:
-      app: zookeeper
-```
+{{% code_sample file="policy/zookeeper-pod-disruption-budget-minavailable.yaml" %}}
 
-Ejemplo de PDB usando maxUnavailable (Kubernetes 1.7 o superior):
+Ejemplo de PDB usando maxUnavailable:
 
-```yaml
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: zk-pdb
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: zookeeper
-```
+{{% code_sample file="policy/zookeeper-pod-disruption-budget-maxunavailable.yaml" %}}
 
 Por ejemplo, si el objeto anterior `zk-pdb` selecciona los pods de un StatefulSet de tamaño 3, ambas
 especificaciones tienen el mismo significado exacto. Se recomienda el uso de `maxUnavailable` ya que
@@ -150,23 +156,24 @@ responde automáticamente a los cambios en el número de réplicas del controlad
 
 ## Crea el objeto PDB
 
-Puedes crear el objeto PDB con el comando `kubectl apply -f mypdb.yaml`.
-
-No puedes actualizar objetos PDB. Deben ser eliminados y recreados.
+Puedes crear o actualizar el objeto PDB haciendo uso de kubectl.
+```shell
+kubectl apply -f mypdb.yaml
+```
 
 ## Comprueba el estado del PDB
 
 Utiliza kubectl para comprobar que se ha creado tu PDB.
 
-Suponiendo que en realidad no tengas pods que coincidan con `app: zookeeper` en su namespace,
-entonces verás algo como esto:
+Suponiendo que en realidad no tengas pods que coincidan con `app: zookeeper` en tu namespace, 
+verás algo como esto:
 
 ```shell
 kubectl get poddisruptionbudgets
 ```
 ```
-NAME      MIN-AVAILABLE   ALLOWED-DISRUPTIONS   AGE
-zk-pdb    2               0                     7s
+NAME     MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
+zk-pdb   2               N/A               0                     7s
 ```
 
 Si hay pods que coinciden (por ejemplo, 3), entonces debes ver algo similar a esto:
@@ -175,11 +182,11 @@ Si hay pods que coinciden (por ejemplo, 3), entonces debes ver algo similar a es
 kubectl get poddisruptionbudgets
 ```
 ```
-NAME      MIN-AVAILABLE   ALLOWED-DISRUPTIONS   AGE
-zk-pdb    2               1                     7s
+NAME     MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
+zk-pdb   2               N/A               1                     7s
 ```
 
-El valor distinto a cero de `ALLOWED-DISRUPTIONS` significa que el controlador de disrupción ha visto los pods, contó los pods coincidentes, y actualizó el estado del PDB.
+El valor distinto a cero de `ALLOWED DISRUPTIONS` significa que el controlador de interrupción ha visto los pods, contó los pods coincidentes, y actualizó el estado del PDB.
 
 Puedes obtener más información sobre el estado de un PDB con este comando:
 
@@ -187,34 +194,70 @@ Puedes obtener más información sobre el estado de un PDB con este comando:
 kubectl get poddisruptionbudgets zk-pdb -o yaml
 ```
 ```yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  creationTimestamp: 2017-08-28T02:38:26Z
+  annotations:
+…
+  creationTimestamp: "2020-03-04T04:22:56Z"
   generation: 1
   name: zk-pdb
-...
+…
 status:
   currentHealthy: 3
-  desiredHealthy: 3
-  disruptedPods: null
+  desiredHealthy: 2
   disruptionsAllowed: 1
   expectedPods: 3
   observedGeneration: 1
 ```
 
-Por último, los PodDisruptionBudgets también se pueden consultar con kubectl utilizando el nombre corto pdb:
+### Estado de salud de un pod {#healthiness-of-a-pod}
 
-```shell
-kubectl get pdb
-```
+La implementación actual considera pods saludables a aquellos que tienen el elemento `.status.conditions`
+con `type="Ready"` y `status="True"`.
+Estos pods son supervisados a través del campo `.status.currentHealthy` en el estado del PDB.
 
-```shell
-NAME      MIN-AVAILABLE   ALLOWED-DISRUPTIONS   AGE
-zk-pdb    2               0                     7s
-```
+## Política de desalojo de pods no saludables {#unhealthy-pod-eviction-policy}
 
-## Controladores y selectors arbitrarios
+{{< feature-state feature_gate_name="PDBUnhealthyPodEvictionPolicy" >}}
+
+Proteger una aplicación con un presupuesto de interrupción de pods garantiza que el número de pods con
+`.status.currentHealthy` no sea inferior al número especificado en `.status.desiredHealthy` impidiendo el
+desalojo de pods en estado saludable. Usando `.spec.unhealthyPodEvictionPolicy`, también puedes definir el
+criterio para considerar el desalojo de pods en estado no saludable. El comportamiento por defecto cuando
+no se especifica ninguna política es `IfHealthyBudget`.
+
+Políticas:
+
+`IfHealthyBudget`
+: Los pods en ejecución (`.status.phase="Running"`), pero que aún no estén en estado saludable, pueden ser
+  desalojados solo si la aplicación protegida no sufre interrupciones (`.status.currentHealthy` es igual o
+  mayor que `.status.desiredHealthy`).
+
+: Esta política garantiza que los pods en ejecución de una aplicación que ya ha sido interrumpida tenga las
+  máximas posibilidades de llegar a un estado saludable. Esto tiene implicaciones negativas en el drenaje
+  de nodos, que puede verse bloqueado por aplicaciones que presentan un comportamiento anómalo y que estén 
+  protegidas por un PDB. Más concretamente, aplicaciones con pods en estado `CrashLoopBackOff` (debido a 
+  un bug o a una configuración incorrecta), o simplemente pods que no consiguen notificar la condición 
+  `Ready` por cualquier motivo.
+
+`AlwaysAllow`
+: Los pods en ejecución (`.status.phase="Running"`), pero que aún no estén en estado saludable, son considerados
+  para su interrupción y pueden ser desalojados independientemente de si cumplen o no con el criterio definido
+  en su PDB.
+
+: Esto significa que los pods de una aplicación que estén en proceso de ejecutarse, podrían no tener la oportunidad
+  de alcanzar un estado saludable si son interrumpidos. Al aplicar esta política, los gestores de clústeres pueden 
+  desalojar fácilmente las aplicaciones que presentan un comportamiento anómalo y que están protegidas por un PDB. 
+  Más concretamente, aplicaciones con pods en estado `CrashLoopBackOff` (debido a un bug o a una configuración 
+  incorrecta), o simplemente pods que no consiguen notificar la condición `Ready` por cualquier motivo.
+
+{{< note >}}
+Los pods en fase "pendiente" (`Pending`), "exitoso" (`Succeeded`) o "fallido" (`Failed`), siempre son considerados
+para su desalojo.
+{{< /note >}}
+
+## Controladores y selectores arbitrarios {#arbitrary-controllers-and-selectors}
 
 Puedes omitir esta sección si solo utilizas PDBs con los controladores integrados de aplicaciones (Deployment, Replicationcontrolador, ReplicaSet y StatefulSet), con el selector de PDB coincidiendo con el selector del controlador.
 


### PR DESCRIPTION
### Description
Translate the file `content/es/docs/tasks/administer-cluster/safely-drain-node.md` into Spanish.

/language es
/sig docs