### PR TITLE
Fix typo in DRADeviceTaintRules feature gate page

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DRADeviceTaintRules.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DRADeviceTaintRules.md
@@ -18,4 +18,4 @@ Enables support for
 [tainting devices through DeviceTaintRule objects](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#device-taints-and-tolerations)
 when using dynamic resource allocation to manage devices.
 
-This feature gate has no effect unless you also enable the `DRADeviceTaint` feature gate.
+This feature gate has no effect unless you also enable the `DRADeviceTaints` feature gate.


### PR DESCRIPTION
### Description

This PR fixes a typo which referenced a non-existent feature gate `DRADeviceTaint`. The correct name is `DRADeviceTaints`.

https://github.com/kubernetes/kubernetes/blob/9353e673e0045cc1b4bab58d89ebee846cfe402d/pkg/features/kube_features.go#L2439