### PR TITLE
[ko] Update Port Forwarding to Access Applications in a Cluster

### DIFF
--- a/content/ko/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/ko/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -207,13 +207,13 @@ UDP 프로토콜에 대한 지원은
 [이슈 47862](https://github.com/kubernetes/kubernetes/issues/47862)에서 추적되고 있다.
 {{< /note >}}
 
-## 인증 및 보안 고려 사항
+## 인가 및 보안 고려 사항
 
-`kubectl port-forward`에 대한 접근은 {{< glossary_tooltip text="역할 기반 접근 제어(RBAC)" term_id="rbac" >}}와 같은 쿠버네티스의 인증 메커니즘에 의해 제어된다. 권한 부여는 `kubectl` 클라이언트가 아닌 쿠버네티스 API 서버에서 수행된다.
+`kubectl port-forward`에 대한 접근은 {{< glossary_tooltip text="역할 기반 접근 제어(RBAC)" term_id="rbac" >}}와 같은 쿠버네티스의 인가 메커니즘에 의해 제어된다. 인가는 `kubectl` 클라이언트가 아닌 쿠버네티스 API 서버에서 수행된다.
 
 `kubectl port-forward`를 사용하려면 사용자는 대상 리소스(예를 들어, 파드 또는 서비스)와 `portforward` 서브리소스에 접근할 수 있는 권한이 있어야 한다. 일반적으로 필요한 권한에는 `pods`에 대한 `get`과 `pods/portforward`에 대한 `create`가 포함된다.
 
-포트 포워딩은 네트워크 수준의 제어를 우회하며 워크로드에 대한 직접적인 네트워크 접근을 제공할 수 있기 때문에, 클러스터 관리자는 이러한 권한을 신중하게 제한해야 한다. 
+포트 포워딩은 워크로드에 대한 직접적인 네트워크 접근을 제공하고 네트워크 수준의 제어를 우회할 수 있으므로, 클러스터 관리자는 이러한 권한을 신중하게 제한해야 한다.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/ko/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
+++ b/content/ko/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md
@@ -14,7 +14,6 @@ min-kubernetes-server-version: v1.10
 ## {{% heading "prerequisites" %}}
 
 * {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
-
 * [MongoDB Shell](https://www.mongodb.com/try/download/shell)을 설치한다.
 
 <!-- steps -->
@@ -207,6 +206,14 @@ Forwarding from [::1]:63753 -> 27017
 UDP 프로토콜에 대한 지원은
 [이슈 47862](https://github.com/kubernetes/kubernetes/issues/47862)에서 추적되고 있다.
 {{< /note >}}
+
+## 인증 및 보안 고려 사항
+
+`kubectl port-forward`에 대한 접근은 {{< glossary_tooltip text="역할 기반 접근 제어(RBAC)" term_id="rbac" >}}와 같은 쿠버네티스의 인증 메커니즘에 의해 제어된다. 권한 부여는 `kubectl` 클라이언트가 아닌 쿠버네티스 API 서버에서 수행된다.
+
+`kubectl port-forward`를 사용하려면 사용자는 대상 리소스(예를 들어, 파드 또는 서비스)와 `portforward` 서브리소스에 접근할 수 있는 권한이 있어야 한다. 일반적으로 필요한 권한에는 `pods`에 대한 `get`과 `pods/portforward`에 대한 `create`가 포함된다.
+
+포트 포워딩은 네트워크 수준의 제어를 우회하며 워크로드에 대한 직접적인 네트워크 접근을 제공할 수 있기 때문에, 클러스터 관리자는 이러한 권한을 신중하게 제한해야 한다. 
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Update the Korean translation of content/ko/docs/tasks/access-application-cluster/port-forward-access-application-cluster.md to match the latest English version.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #56582