### PR TITLE
Publish KYAML blog post on August 11, 2026

### DIFF
--- a/content/en/blog/_posts/2026/how-to-pretty-print-kubernetes-yaml-as-kyaml.md
+++ b/content/en/blog/_posts/2026/how-to-pretty-print-kubernetes-yaml-as-kyaml.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "How to Pretty-Print Your Kubernetes YAML as KYAML and Why You'd Want To"
-draft: true
+date: 2026-08-11T10:00:00-08:00
 slug: how-to-pretty-print-kubernetes-yaml-as-kyaml
 author: >
   [Kashish Verma](https://github.com/KashishV999)


### PR DESCRIPTION
This PR schedules the KYAML blog post for publication on August 11, 2026, and marks it as not draft.