### PR TITLE
Update gang-scheduling docs for beta promotion

### DIFF
--- a/content/en/docs/concepts/resource-management/dynamic-resource-allocation/dra-api.md
+++ b/content/en/docs/concepts/resource-management/dynamic-resource-allocation/dra-api.md
@@ -200,7 +200,7 @@ The PodGroup API defines a `spec.resourceClaims` field with the same structure
 and similar meaning as the `spec.resourceClaims` field in the Pod API:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: training-group
@@ -246,7 +246,7 @@ ResourceClaim is no longer reserved.
 Consider the following example:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: training-group

--- a/content/en/docs/concepts/scheduling-eviction/gang-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/gang-scheduling.md
@@ -5,15 +5,22 @@ weight: 70
 ---
 
 <!-- overview -->
-{{< feature-state feature_gate_name="GangScheduling" >}}
+{{< feature-state feature_gate_name="GenericWorkload" >}}
 
 Gang scheduling ensures that a group of Pods are scheduled on an "all-or-nothing" basis.
-If the cluster cannot accommodate the entire group (or a defined minimum number of Pods),
+If the cluster cannot accommodate the entire group (or a defined minimum number of Pods, specified by `minCount`),
 none of the Pods are bound to a node.
 
+{{< note >}}
+While the scheduler never admits fewer Pods than the configured `minCount` during initial placement, the actual runtime
+count of scheduled Pods can drop below this threshold if running Pods are later deleted or evicted, or if the
+`minCount` requirement increases. When this happens, the scheduler will only place additional Pods if the
+combined total of already scheduled Pods and newly feasible unscheduled Pods reaches or exceeds `minCount`.
+{{< /note >}}
+
 This feature depends on the [PodGroup API](/docs/concepts/workloads/podgroup-api/).
-Ensure the  [`GenericWorkload`](/docs/reference/command-line-tools-reference/feature-gates/#GenericWorkload)
-feature gate and the `scheduling.k8s.io/v1alpha2`
+Ensure the [`GenericWorkload`](/docs/reference/command-line-tools-reference/feature-gates/#GenericWorkload)
+feature gate and the `scheduling.k8s.io/v1beta1`
 {{< glossary_tooltip text="API group" term_id="api-group" >}} are enabled in the cluster.
 
 <!-- body -->
@@ -27,15 +34,15 @@ The process follows these steps for each PodGroup:
 
 1. The scheduler holds Pods in the `PreEnqueue` phase until:
    * The referenced PodGroup object exists.
-   * The number of `Pods` created for the `PodGroup` is at least equal to `minCount`.
+   * The number of Pods created for the PodGroup (both already scheduled and unscheduled) is at least equal to `minCount`.
 
-   `Pods` do not enter the active scheduling queue until both conditions are met.
+   The PodGroup does not enter the active scheduling queue until both conditions are met.
 
-2. Once the quorum is met, the scheduler attempts to find placements for all Pods in the group.
+2. Once the quorum is met, the scheduler attempts to find placements for all unscheduled Pods in the group.
    It utilizes the [PodGroup scheduling](/docs/concepts/scheduling-eviction/podgroup-scheduling/) cycle to make a single,
-   atomic scheduling decision. `GangScheduling` plugin implements a `Permit` extension point that is evaluated for each
-   schedulable Pod during the cycle. This is used to determine whether the `minCount` constraint is satisfied,
-   by comparing the number of successfully placed pods against the `minCount` value.
+   atomic scheduling decision. The `GangScheduling` plugin implements a `PlacementFeasible` extension point that is invoked for each
+   evaluated Pod during the cycle. This is used to determine whether the `minCount` constraint is satisfied
+   by comparing the number of successfully placed Pods (including those already scheduled in previous cycles) against the `minCount` value.
 
 3. If the scheduler finds valid placements for at least the `minCount` number of Pods,
    it allows those successfully placed Pods to be bound to their assigned nodes.

--- a/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
@@ -19,9 +19,8 @@ Additionally, treating the group as a unified entity establishes a foundational 
 that simplifies the implementation of other group-based scheduling features.
 
 This feature depends on the [Workload API](/docs/concepts/workloads/workload-api/).
-Ensure the [`GenericWorkload`](/docs/reference/command-line-tools-reference/feature-gates/#GenericWorkload)
-feature gate and the `scheduling.k8s.io/v1alpha1`
-{{< glossary_tooltip text="API group" term_id="api-group" >}} are enabled in the cluster.
+Ensure the `scheduling.k8s.io/v1beta1`
+{{< glossary_tooltip text="API group" term_id="api-group" >}} is enabled in the cluster.
 
 <!-- body -->
 
@@ -33,7 +32,9 @@ the scheduler evaluates the entire group of pending Pods belonging to a specific
 Rather than executing separate scheduling cycles for each Pod,
 it evaluates feasibility for the entire group and moves directly to the binding phase afterwards.
 
-When the scheduler pops a Pod belonging to a PodGroup, it retrieves all other queued Pods in that group.
+When observing a Pod belonging to a PodGroup, the scheduler associates the Pod with that PodGroup rather than adding it directly to the scheduling queue.
+A PodGroup does not enter the scheduling queue until the scheduler observes both the PodGroup object and at least one Pod belonging to it.
+When the scheduler pops a PodGroup, it retrieves all observed unscheduled Pods in that group.
 It then sorts them deterministically based on priority and the time they were initially observed by the scheduler,
 and initiates the PodGroup scheduling cycle as follows:
 
@@ -50,15 +51,14 @@ and initiates the PodGroup scheduling cycle as follows:
    * **Success:** If the scheduler finds sufficient resources and valid placements for the Pods
      (e.g., satisfying the `minCount` constraint for [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)),
      those Pods proceed directly to the binding cycle with their selected nodes.
-     Any remaining unschedulable Pods are returned to the scheduling queue to wait for available resources
-     so they can join the already scheduled Pods. 
+     Any remaining unschedulable Pods in the group are requeued directly into the active scheduling queue without backoff, retaining their previous timestamp so they are re-evaluated immediately to attempt preemption.
      
      Furthermore, if new Pods are added to a PodGroup after others have already been scheduled,
      the cycle evaluates the new Pods while accounting for the existing ones.
 
    * **Failure:** If the scheduler cannot find enough resources to make the PodGroup feasible
      (e.g., failing to meet the `minCount` constraint), the entire PodGroup is considered unschedulable.
-     No Pods are bound, but instead, all are returned to the scheduling queue.
+     No Pods are bound; instead, the PodGroup is returned to the scheduling queue.
      Standard scheduling backoff logic applies, allowing the PodGroup to be retried later.
 
 By using this single-cycle approach, the scheduler avoids inefficient bottlenecks
@@ -70,14 +70,12 @@ The default PodGroup scheduling algorithm relies heavily on the baseline Pod-bas
 It iterates over the Pods and performs the following for each:
 
 1. Finds a feasible node using the standard per-Pod filtering and scoring phases.
-   
-   * If the Pod fits, it is temporarily assumed and reserved on the selected node until the end of the scheduling algorithm.
-   * If the Pod cannot fit, the scheduler attempts preemption by running the `PostFilter` extension point.
+   If the Pod fits, it is temporarily assumed and reserved on the selected node until the end of the scheduling algorithm.
 
 2. Checks whether the schedulable Pods meet the group's scheduling criteria
-   (e.g., the `minCount` for [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)) using the `Permit` extension point.
+   (e.g., the `minCount` for [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)) by invoking the `PlacementFeasible` extension point after evaluating each Pod in the group against the cumulative scheduling results.
    If it returns a `Success` status for any Pod, the PodGroup is deemed feasible.
-   If the algorithm processes all Pods without achieving a `Success` status, the PodGroup is considered unschedulable.
+   If the algorithm processes all Pods without achieving a `Success` status, or if no Pods are scheduled during this cycle, the PodGroup is considered unschedulable.
 
 ## Placement scheduling algorithm
 {{< feature-state feature_gate_name="TopologyAwareWorkloadScheduling" >}}
@@ -134,11 +132,9 @@ and the PodGroup is rejected if the constraint is not met.
 After a PodGroup scheduling cycle completes, the scheduler updates conditions on the
 PodGroup's `status.conditions`:
 
-* `PodGroupScheduled`: reports whether the PodGroup has been successfully scheduled.
-* `DisruptionTarget`: indicates the PodGroup is about to be terminated due to a
-  disruption such as preemption.
+* `PodGroupInitiallyScheduled`: reports whether the PodGroup has been successfully scheduled for the first time.
 
-### `PodGroupScheduled`
+### `PodGroupInitiallyScheduled`
 
 When the scheduling cycle succeeds, the condition is set to `True` with reason
 `Scheduled`. For `gang` policy PodGroups, this means at least `minCount` Pods were
@@ -152,10 +148,7 @@ reasons:
 * `SchedulerError` — scheduling failed because of an internal scheduler error
   (for example, while parsing scheduling constraints such as `nodeAffinity`).
 
-### `DisruptionTarget`
-
-When the scheduler preempts a PodGroup to make room for higher-priority PodGroups or
-Pods, it sets this condition to `True` with reason `PreemptionByScheduler`.
+Once this condition is set to `True`, it never changes.
 
 You can check conditions with:
 

--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -320,7 +320,7 @@ or completed for the same index will be deleted by the Job controller once they 
 When the [`WorkloadWithJob`](/docs/reference/command-line-tools-reference/feature-gates/) feature gate is enabled,
 the Job controller automatically creates
 [Workload](/docs/concepts/workloads/workload-api/) and
-[PodGroup](/docs/reference/kubernetes-api/workload-resources/workload-v1alpha1/) objects
+[PodGroup](/docs/concepts/workloads/podgroup-api/) objects
 for [qualifying parallel Jobs](#qualifying-criteria) before creating any Pods.
 This enables native [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)
 where all Pods in a Job are scheduled together or none are scheduled.
@@ -371,7 +371,7 @@ When the Job controller processes this Job, it automatically:
    `podGroupTemplate` with a
    [gang scheduling policy](/docs/concepts/workloads/workload-api/policies/#gang-policy)
    where `minCount` equals the Job's parallelism.
-1. Creates a [PodGroup](/docs/reference/kubernetes-api/workload-resources/workload-v1alpha1/)
+1. Creates a [PodGroup](/docs/concepts/workloads/podgroup-api/)
    object based on that template.
    The PodGroup is a standalone runtime scheduling unit that carries an inline copy
    of the gang policy.

--- a/content/en/docs/concepts/workloads/podgroup-api/_index.md
+++ b/content/en/docs/concepts/workloads/podgroup-api/_index.md
@@ -16,7 +16,7 @@ for a specific instance of that group.
 
 ## What is a PodGroup?
 
-The PodGroup API resource is part of the `scheduling.k8s.io/v1alpha2`
+The PodGroup API resource is part of the `scheduling.k8s.io/v1beta1`
 {{< glossary_tooltip text="API group" term_id="api-group" >}}
 and your cluster must have that API group enabled, as well as the `GenericWorkload`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
@@ -67,7 +67,7 @@ spec:
 can be requested by a PodGroup through its `spec.resourceClaims` field:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: training-group
@@ -96,11 +96,11 @@ For more details and a more complete example, see the
 ### Status
 
 The scheduler updates `status.conditions` to report whether the group has been
-successfully scheduled. The primary condition is `PodGroupScheduled`, which is `True`
+successfully scheduled. The primary condition is `PodGroupInitiallyScheduled`, which is `True`
 when all required Pods have been placed and `False` when scheduling fails.
 
 {{< note >}}
-The `PodGroupScheduled` condition reflects the initial scheduling decision only.
+The `PodGroupInitiallyScheduled` condition reflects the initial scheduling decision only.
 The scheduler does not update it if Pods later fail or are evicted. See
 [Limitations](/docs/concepts/workloads/podgroup-api/lifecycle/#limitations)
 for details.
@@ -111,7 +111,7 @@ page for the full list of conditions and reasons.
 
 ## Creating a PodGroup
 
-A PodGroup API resource is part of the `scheduling.k8s.io/v1alpha2`
+A PodGroup API resource is part of the `scheduling.k8s.io/v1beta1`
 {{< glossary_tooltip text="API group" term_id="api-group" >}}.
 (and your cluster must have that API group enabled, as well as the `GenericWorkload`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
@@ -121,7 +121,7 @@ The following manifest creates a PodGroup with a gang scheduling policy that req
 at least 4 Pods to be schedulable simultaneously:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: training-worker-0
@@ -158,7 +158,7 @@ workload controller that follows this pattern for now.
 Custom controllers can implement the same flow for their own workload types.
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: Workload
 metadata:
   name: training-policy
@@ -169,7 +169,7 @@ spec:
       gang:
         minCount: 4
 ---
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: training-worker-0

--- a/content/en/docs/concepts/workloads/podgroup-api/lifecycle.md
+++ b/content/en/docs/concepts/workloads/podgroup-api/lifecycle.md
@@ -56,14 +56,12 @@ If you need more control over naming and lifecycle, you can create `PodGroup` ob
 
 * All Pods in a `PodGroup` must use the same `.spec.schedulerName`.
   If a mismatch is detected, the scheduler rejects all Pods in the group as unschedulable.
-* The `spec.schedulingPolicy.gang.minCount` field on a PodGroup is immutable.
-  Once created, you cannot change the minimum number of Pods that must be schedulable for the group to be admitted.
 * The `spec.schedulingGroup` field on a Pod is immutable.
   Once set, a Pod cannot move to a different PodGroup.
 * The maximum number of `PodGroupTemplates` in a single `Workload` is 8.
-* The `PodGroupScheduled` condition reflects the outcome of the initial scheduling
-  attempt only. Once the condition is set to `True`, the scheduler does not update it
-  if Pods later fail, are evicted, or stop running.
+* The scheduler does not update status information regarding the ongoing operational state of a PodGroup
+  or subsequent scheduling attempts after initial placement. Consequently, the PodGroup status is not updated
+  when existing Pods fail, are evicted, or terminate, or when newly observed Pods fail to schedule.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/workloads/workload-api/_index.md
+++ b/content/en/docs/concepts/workloads/workload-api/_index.md
@@ -18,7 +18,7 @@ should be scheduled. The Job controller is the only built-in controller that cre
 
 ## What is a Workload?
 
-The Workload API resource is part of the `scheduling.k8s.io/v1alpha2`
+The Workload API resource is part of the `scheduling.k8s.io/v1beta1`
 {{< glossary_tooltip text="API group" term_id="api-group" >}}
 and your cluster must have that API group enabled, as well as the `GenericWorkload`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
@@ -49,7 +49,7 @@ If the [`WorkloadAwarePreemption`](/docs/reference/command-line-tools-reference/
 The maximum number of PodGroupTemplates in a single Workload is 8.
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: Workload
 metadata:
   name: training-job-workload

--- a/content/en/docs/concepts/workloads/workload-api/topology-aware-scheduling.md
+++ b/content/en/docs/concepts/workloads/workload-api/topology-aware-scheduling.md
@@ -72,7 +72,7 @@ the exact same value for this specified label.
 Here is an example of a PodGroup configured with a topology constraint:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: example-podgroup

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/GangScheduling.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/GangScheduling.md
@@ -9,8 +9,13 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.35"
+    toVersion: "1.36"
+
+removed: true
 ---
 
 Enables the GangScheduling plugin in kube-scheduler, which implements "all-or-nothing"
 scheduling algorithm. The [Workload API](/docs/concepts/workloads/workload-api/) is used
 to express the requirements.
+
+This feature gate was removed in 1.37 and merged together with the `GenericWorkload` feature gate.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/GenericWorkload.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/GenericWorkload.md
@@ -9,9 +9,12 @@ stages:
   - stage: alpha
     defaultValue: false
     fromVersion: "1.35"
+    toVersion: "1.36"
+  - stage: beta
+    defaultValue: false
+    fromVersion: "1.37"
 ---
 
-Enables the support for [Workload API](/docs/concepts/workloads/workload-api/) to express scheduling requirements at the workload level.
+Enables support for the [Workload API](/docs/concepts/workloads/workload-api/) and [PodGroup API](/docs/concepts/workloads/podgroup-api/) to express scheduling requirements at the workload level.
 
-When enabled Pods can reference a specific pod group and use this to influence
-the way that they are scheduled.
+When enabled, Pods can reference a specific PodGroup to influence the way that they are scheduled. Starting in Kubernetes v1.37, this feature gate also encompasses [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/), and [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/).

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/WorkloadWithJob.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/WorkloadWithJob.md
@@ -11,6 +11,6 @@ stages:
     fromVersion: "1.36"
 ---
 
-Enables the Job controller to automatically create [Workload](/docs/concepts/workloads/workload-api/) and [PodGroup](/docs/reference/kubernetes-api/workload-resources/workload-v1alpha1/) objects
+Enables the Job controller to automatically create [Workload](/docs/concepts/workloads/workload-api/) and [PodGroup](/docs/concepts/workloads/podgroup-api/) objects
 for [qualifying Jobs](/docs/concepts/workloads/controllers/job#qualifying-criteria). See [Integrate with Workload APIs](/docs/concepts/workloads/controllers/job#integrate-with-workload-apis)
 for details.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

/sig scheduling

Add docs relating to gang scheduling promotion to beta.

The change intentionally omits workload-aware scheduling changes as those will be addressed in https://github.com/kubernetes/website/pull/56236.

Key changes:

* Consolidation of feature gates (GangScheduling merged into GenericWorkload)
* API version updates in snippets and api-group references
* Update from PodGroupScheduled to PodGroupInitiallyScheduled condition
* Clarification of limitations after recent changes: removal of minCount immutability limitation and update of PodGroup status limitation
* Update to algorithm description to include `PlacementFeasible` and minor scheduling queue changes
* Fixes to links for PodGroup API docs

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

https://github.com/kubernetes/enhancements/issues/4671