### PR TITLE
tasks/administer-cluster/kubelet-in-userns: update outdated information

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
@@ -32,11 +32,11 @@ If you are just looking for how to run a pod as a non-root user, see [SecurityCo
 
 <!-- steps -->
 
-## Running Kubernetes inside Rootless Docker/Podman
+## Running Kubernetes inside Rootless Docker/Podman/nerdctl
 
 ### kind
 
-[kind](https://kind.sigs.k8s.io/) supports running Kubernetes inside Rootless Docker or Rootless Podman.
+[kind](https://kind.sigs.k8s.io/) supports running Kubernetes inside Rootless Docker, Rootless Podman, or Rootless nerdctl.
 
 See [Running kind with Rootless Docker](https://kind.sigs.k8s.io/docs/user/rootless/).
 
@@ -48,6 +48,28 @@ See the Minikube documentation:
 
 * [Rootless Docker](https://minikube.sigs.k8s.io/docs/drivers/docker/)
 * [Rootless Podman](https://minikube.sigs.k8s.io/docs/drivers/podman/)
+
+### Usernetes
+
+{{% thirdparty-content %}}
+
+[Usernetes](https://github.com/rootless-containers/usernetes) also supports running Kubernetes inside Rootless Docker, Rootless Podman, or Rootless nerdctl.
+
+Unlike kind and minikube, Usernetes supports composing a cluster using multiple Docker/Podman/nerdctl nodes using VXLAN.
+
+See the [Usernetes documentation](https://github.com/rootless-containers/usernetes/blob/master/README.md) for usage.
+
+## Running Kubernetes inside Kubernetes, as user namespace pods
+
+{{% thirdparty-content single="true" %}}
+
+### Usernetes
+
+[Usernetes](https://github.com/rootless-containers/usernetes) supports Kubernetes-in-Kubernetes mode in addition to Kubernetes-in-Docker mode.
+Kubernetes-in-Kubernetes mode creates the nodes of an inner cluster as pods running on an outer cluster
+with [user namespaces](/docs/concepts/workloads/pods/user-namespaces/) enabled (`hostUsers: false`).
+
+See the [Usernetes documentation](https://github.com/rootless-containers/usernetes/blob/master/README.md) for usage.
 
 ## Running Kubernetes inside Unprivileged Containers
 
@@ -77,13 +99,11 @@ the container plus several other advanced OS virtualization techniques.
 
 See [Running K3s with Rootless mode](https://rancher.com/docs/k3s/latest/en/advanced/#running-k3s-with-rootless-mode-experimental) for the usage.
 
-### Usernetes
-[Usernetes](https://github.com/rootless-containers/usernetes) is a reference distribution of Kubernetes that can be installed under `$HOME` directory without the root privilege.
+### Usernetes (until 2023)
+The first generation of [Usernetes](https://github.com/rootless-containers/usernetes) supported running rootless Kubernetes directly on a host.
+This mode was archived in 2023.
 
-Usernetes supports both containerd and CRI-O as CRI runtimes.
-Usernetes supports multi-node clusters using Flannel (VXLAN).
-
-See [the Usernetes repo](https://github.com/rootless-containers/usernetes) for the usage.
+See [the `gen1` branch of the Usernetes repo](https://github.com/rootless-containers/usernetes/tree/gen1) for the archived information.
 
 ## Manually deploy a node that runs the kubelet in a user namespace {#userns-the-hard-way}
 

--- a/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
+++ b/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md
@@ -51,7 +51,7 @@ See the Minikube documentation:
 
 ### Usernetes
 
-{{% thirdparty-content %}}
+{{% thirdparty-content single="true" %}}
 
 [Usernetes](https://github.com/rootless-containers/usernetes) also supports running Kubernetes inside Rootless Docker, Rootless Podman, or Rootless nerdctl.
 
@@ -73,7 +73,7 @@ See the [Usernetes documentation](https://github.com/rootless-containers/usernet
 
 ## Running Kubernetes inside Unprivileged Containers
 
-{{% thirdparty-content %}}
+{{% thirdparty-content single="true" %}}
 
 ### sysbox
 
@@ -91,7 +91,7 @@ the container plus several other advanced OS virtualization techniques.
 
 ## Running Rootless Kubernetes directly on a host
 
-{{% thirdparty-content %}}
+{{% thirdparty-content single="true" %}}
 
 ### K3s
 
@@ -162,7 +162,7 @@ Containers documentation.
 
 ### Configuring network
 
-{{% thirdparty-content %}}
+{{% thirdparty-content single="true" %}}
 
 The network namespace of the Node components has to have a non-loopback interface, which can be for example configured with
 [slirp4netns](https://github.com/rootless-containers/slirp4netns),


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

https://github.com/kubernetes/website/blob/b424574dfa5ed98d3bf4e0ff4510a7499a604c61/content/en/docs/tasks/administer-cluster/kubelet-in-userns.md?plain=1#L35-L87

[Usernetes](https://github.com/rootless-containers/usernetes) was categorized in `Running Rootless Kubernetes directly on a host`, but this is not true since 2023:

> - **Generation 1** ([`gen1`](https://github.com/rootless-containers/usernetes/tree/gen1) branch, 2018-2023):
>   The original Usernetes, implemented in the style of ["Kubernetes The Hard Way"](https://github.com/kelseyhightower/kubernetes-the-hard-way).
>   This generation was hard to use due to lack of support for kubeadm.
> - **Generation 2** ([`gen2`](https://github.com/rootless-containers/usernetes/tree/gen2) branch, 2023-2026):
>   Switched to **Kubernetes-in-Docker** mode for simplicity. This switch enabled supporting kubeadm.
> - **Generation 3** (2026-present):
>   Additionally added support for **Kubernetes-in-Kubernetes** mode.

https://github.com/rootless-containers/usernetes/blob/gen3-v20260728.0/README.md#project-history

This PR updates the outdated information.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #56637



- - -

### Preview
https://deploy-preview-56638--kubernetes-io-main-staging.netlify.app/docs/tasks/administer-cluster/kubelet-in-userns/