### PR TITLE
[fr] Fix the KubeSchedulerConfiguration example in topology spread constraints

### DIFF
--- a/content/fr/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
+++ b/content/fr/docs/concepts/workloads/pods/pod-topology-spread-constraints.md
@@ -202,18 +202,19 @@ replication controllers, replica sets ou stateful sets auxquels le Pod appartien
 Un exemple de configuration pourrait ressembler à :
 
 ```yaml
-apiVersion: kubescheduler.config.k8s.io/v1alpha2
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 
 profiles:
   - schedulerName: default-scheduler
-  - pluginConfig:
+    pluginConfig:
       - name: PodTopologySpread
         args:
           defaultConstraints:
             - maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: ScheduleAnyway
+          defaultingType: List
 ```
 
 {{< note >}}


### PR DESCRIPTION
### Description

The `KubeSchedulerConfiguration` example on the French page
[Contraintes de propagation de la topologie d'un Pod](https://kubernetes.io/fr/docs/concepts/workloads/pods/pod-topology-spread-constraints/#contraintes-par-d%C3%A9faut-au-niveau-du-cluster)
cannot be applied as written. Three problems, all fixed here against the current
English source
([`topology-spread-constraints.md`](https://github.com/kubernetes/website/blob/main/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md)):

1. **`pluginConfig` is a separate list item.** The French example has
   `- pluginConfig:` where it should be a field of the same profile. As written,
   the YAML defines *two* scheduling profiles — the second one without a
   `schedulerName` — instead of one profile carrying its plugin configuration.
   This is the reason a reader copying the example cannot use it.

2. **Obsolete API version.** `kubescheduler.config.k8s.io/v1alpha2` no longer
   exists; the English page uses `kubescheduler.config.k8s.io/v1`.

3. **Missing `defaultingType: List`.** Present in the English example and
   required for the configuration to have the described effect.

No prose is changed — only the code block.

### Not addressed here

Two adjacent points I noticed but deliberately left out of this PR, happy to
follow up if you would like them handled:

- The `{{< note >}}` right below the example recommends disabling the
  `DefaultPodTopologySpread` plugin. That plugin no longer exists outside of the
  removed-feature-gates reference, and the English page dropped this note.
- More broadly, this French page (242 lines) has drifted from its English source
  (656 lines), which has also moved to
  `content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md`.
  Re-syncing and relocating the page is a larger job better done on its own.

### Issue

Not tracked by an existing issue — found while auditing the French localization.
