### PR TITLE
blog: add a caution banner to the controller-runtime cache post

### DIFF
--- a/content/en/blog/_posts/2026/controller-runtime-cache-explained/index.md
+++ b/content/en/blog/_posts/2026/controller-runtime-cache-explained/index.md
@@ -8,6 +8,13 @@ author: >
   Timofei Larkin (Ænix)
 ---
 
+<!-- TODO: remove this banner once the corrections to this article have merged. -->
+{{< caution >}}
+Some of the technical detail in this article is not accurate. We are reviewing it and preparing
+corrections. Until then, check what you read here against the
+[`controller-runtime` documentation](https://pkg.go.dev/sigs.k8s.io/controller-runtime).
+{{< /caution >}}
+
 Kubernetes has long been the default platform for distributed workloads, and writing your own
 controller for it is now a matter of a few hours. The common path — Golang, using `kubebuilder` on top of
 `controller-runtime` — gives you a project scaffold, types, and a reconciler. For typical


### PR DESCRIPTION
### Description

Adds a banner to "How the controller-runtime Cache Actually Works" warning readers that the article is undergoing additional technical review while corrections are being prepared.

I'm the author of the post. After publication on 2026-07-29, `controller-runtime` maintainers identified several technical inaccuracies. This is the interim step discussed in `#sig-docs-blog` on Kubernetes Slack. A separate PR with the content corrections will follow.

The wording is adapted from the existing banner shown on articles older than a year (`outdated_blog__message` in `i18n/en/en.toml`), following the same structure: explain the situation, then tell readers how to treat the article.

**Points for reviewers:**

- The banner text was requested to be signed off by `controller-runtime` maintainers. If you'd prefer stronger or different wording, I'm happy to adjust it. `caution` can also become `warning` if that better reflects the intended severity.
- There is an open translation of this post in #56612. If it merges, the zh-cn version should receive the same banner.
- If #56671 (reverting the post to `draft: true`) is merged instead, this PR is no longer needed.

### AI assistance disclosure

An AI agent (Claude) helped locate the existing old-article banner and drafted the initial wording. I reviewed the changes and take responsibility for the final content.

### Issue

N/A — follow-up to #55914 / #56619, discussed in `#sig-docs-blog` on Kubernetes Slack.