### PR TITLE
Fix READY column description in scaling tutorial

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/scale/scale-intro.md
@@ -102,7 +102,7 @@ kubernetes-bootcamp   1/1     1            1           11m
 We should have 1 Pod. If not, run the command again. This shows:
 
 * _NAME_ lists the names of the Deployments in the cluster.
-* _READY_ shows the ratio of CURRENT/DESIRED replicas
+* _READY_ shows the ratio of READY/DESIRED replicas
 * _UP-TO-DATE_ displays the number of replicas that have been updated to achieve the desired state.
 * _AVAILABLE_ displays how many replicas of the application are available to your users.
 * _AGE_ displays the amount of time that the application has been running.


### PR DESCRIPTION
### Description

The "Scaling a Deployment" section of the Kubernetes Basics tutorial
described the `READY` column of `kubectl get deployments` as showing
the ratio of CURRENT/DESIRED replicas. That's inaccurate — the column
actually reports readyReplicas/replicas (ready/desired), with no
"current" concept involved for Deployments. This matches the wording
already used on the Deployment concept page
(`content/en/docs/concepts/workloads/controllers/deployment.md`),
which correctly states "It follows the pattern ready/desired."

I used AI (Claude Code) to assist with this contribution.

### Issue

Closes: #56652