### PR TITLE
Reject whitespace in css/js front matter params

### DIFF
--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -12,6 +12,10 @@
   Link: <{{ $jsUrl }}>; rel=preload; as=script
   {{- end -}}
 {{- range $pages }}
+{{- $owner := .RelPermalink -}}
+{{- with .File -}}
+  {{- $owner = .Path -}}
+{{- end -}}
 {{- if or (.Params.deprecated) (eq .Params.class "gridPage") (.Params.case_study_styles) (.Params.css) (.Params.js) }}
 {{ .RelPermalink }}
   {{- if eq .Params.class "gridPage" }}
@@ -22,11 +26,13 @@
   {{- end -}}
   {{- with .Params.css -}}
   {{- range (split . ",") }}
+  {{- if findRE `\s` (trim . " ") }}{{ errorf "css param %q on %s contains whitespace" . $owner }}{{ end }}
   Link: <{{ trim . " " }}>; rel=preload; as=style
   {{- end -}}
   {{- end -}}
   {{- with .Params.js -}}
   {{- range (split . ",") }}
+  {{- if findRE `\s` (trim . " ") }}{{ errorf "js param %q on %s contains whitespace" . $owner }}{{ end }}
   Link: <{{ trim . " " }}>; rel=preload; as=script
   {{- end -}}
   {{- end -}}


### PR DESCRIPTION
### Description

`layouts/index.redirects` rejects whitespace in front matter values, because those values are interpolated into a generated Netlify config file:

```gotemplate
{{- if findRE `\s` $alias -}}
  {{- errorf "alias %q on %s contains whitespace" $alias $owner -}}
{{- end -}}
```

`layouts/index.headers` does the same kind of interpolation, taking `css:` and `js:` front matter into the generated `_headers` file, but has no equivalent check. The `HEADERS` output format is declared `isPlainText = true`, so nothing escapes the value on the way out. In the `_headers` format a line at column zero opens a new path block and indented lines below it are headers for that path, so a `css:` value containing newlines produces additional path blocks and headers in the generated file instead of a single `Link:` entry.

This applies the existing guard to the sibling template, for both the `.Params.css` and `.Params.js` range blocks.

Two notes on the details:

- The check runs on the trimmed value, `findRE `\s` (trim . " ")`, rather than on the raw one. The surrounding `split . ","` and `trim . " "` exist to support the comma-separated form, and `css: "a.css, b.css"` yields a second element with a leading space. Checking the raw value would reject that legitimate input.
- The error names the source file via `$owner`, matching how `index.redirects` reports the same class of problem. `$` in this template is the home page rather than the page being ranged over, so the page is captured into a variable first.

Verified against a minimal Hugo site built with Hugo v0.144.2 extended, the version pinned in `netlify.toml`:

- generated `_headers` is byte-identical to the current output for all existing content, including `content/en/case-studies/daocloud/index.html`
- `css: "a.css, b.css"` still emits two `Link:` entries
- a `css:` value containing newlines now fails the build with `css param %q on <file> contains whitespace` instead of emitting extra blocks

No content changes, no change to the generated output for anything in the tree today.

### Issue

#56731

This PR was written in part with the assistance of generative AI.
