### PR TITLE
Extract cached navbar version options

### DIFF
--- a/layouts/partials/navbar-version-options.html
+++ b/layouts/partials/navbar-version-options.html
@@ -1,0 +1,15 @@
+{{- $versionPath := "" -}}
+{{- if .Site.Params.version_menu_pagelinks -}}
+  {{- $versionPath = .Page.RelPermalink -}}
+{{- end -}}
+{{- $options := slice (dict
+  "label" (i18n "release_information_navbar" .)
+  "url" ("releases" | relLangURL)
+) -}}
+{{- range .Site.Params.versions -}}
+  {{- $options = $options | append (dict
+    "label" .version
+    "url" (printf "%s%s" .url $versionPath)
+  ) -}}
+{{- end -}}
+{{- return $options -}}

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -3,13 +3,13 @@
     {{ T "version_menu" }}
   </a>
   <ul class="dropdown-menu">
-    {{ $path := "" -}}
+    {{ $versionPath := "" -}}
     {{ if .Site.Params.version_menu_pagelinks -}}
-      {{ $path = .Page.RelPermalink -}}
+      {{ $versionPath = .Page.RelPermalink -}}
     {{ end -}}
-	<li><a class="dropdown-item" href="{{ "releases" | relLangURL }}">{{ i18n "release_information_navbar" . }}</a></li>
-    {{ range .Site.Params.versions -}}
-    <li><a class="dropdown-item" href="{{ .url }}{{ $path }}">{{ .version }}</a></li>
+    {{ $options := partialCached "navbar-version-options.html" . .Language.Lang $versionPath -}}
+    {{ range $options -}}
+    <li><a class="dropdown-item" href="{{ .url }}">{{ .label }}</a></li>
     {{ end -}}
   </ul>
 </div>


### PR DESCRIPTION
### Description

Extracts navbar version-link construction into a shared, value-returning partial and updates the existing version selector to use it.

The options are cached by language and resolved version path so page-relative links remain correct when `version_menu_pagelinks` is enabled.

This is a behavior-neutral refactor that makes the version options reusable by the mobile navigation introduced in #55851.

### AI disclosure

AI was used to generate this code under human direction and review. I have reviewed the changes and take responsibility for them.