### PR TITLE
Extract navbar language option lookups

### DIFF
--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -5,32 +5,24 @@
      if possible, simplified to align with the default upstream configuration.
      See: https://github.com/google/docsy/pull/2303
      Related PR: https://github.com/kubernetes/website/pull/53804 -->
-{{ $currentLang := .Language.Lang }}
-{{ $translationMap := dict }}
-{{ range .Translations }}
-  {{ $translationMap = merge $translationMap (dict .Language.Lang .) }}
-{{ end }}
-{{ $homeMap := dict }}
-{{ range .Site.Home.Translations }}
-  {{ $homeMap = merge $homeMap (dict .Language.Lang .) }}
-{{ end }}
+{{ $languageOptions := partial "navbar-language-options.html" . }}
 <div class="dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     {{ .Language.LanguageName }}
   </a>
   <ul class="dropdown-menu dropdown-menu-end">
     {{ range site.Languages }}
-        {{- if ne .Lang $currentLang -}}
-            {{- with index $translationMap .Lang -}}
+        {{- if ne .Lang $languageOptions.currentLang -}}
+            {{- with index $languageOptions.translationMap .Lang -}}
                 <li><a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
             {{- end }}
         {{- end }}
     {{- end }} 
     {{ range site.Languages }}
-        {{- if and (ne .Lang $currentLang) (not (index $translationMap .Lang)) }}
+        {{- if and (ne .Lang $languageOptions.currentLang) (not (index $languageOptions.translationMap .Lang)) }}
             <li>
                 <span class="dropdown-item text-muted" title="{{ T "page_not_available_in_language" (dict "Language" .LanguageName) }}">
-                    {{ with index $homeMap .Lang }}
+                    {{ with index $languageOptions.homeMap .Lang }}
                         {{ .Language.LanguageName }}
                         <a href="{{ .RelPermalink }}" class="ms-1" data-auto-burger-exclude><i class="fas fa-home fa-xs"></i></a>
                     {{- end }}

--- a/layouts/partials/navbar-language-options.html
+++ b/layouts/partials/navbar-language-options.html
@@ -1,0 +1,17 @@
+{{/*
+  Build page-specific lookups shared by all language selector renderers.
+*/}}
+{{- $page := . -}}
+{{- $translationMap := dict -}}
+{{- range .Translations -}}
+  {{- $translationMap = merge $translationMap (dict .Language.Lang .) -}}
+{{- end -}}
+{{- $homeMap := dict -}}
+{{- range .Site.Home.Translations -}}
+  {{- $homeMap = merge $homeMap (dict .Language.Lang .) -}}
+{{- end -}}
+{{- return (dict
+  "currentLang" $page.Language.Lang
+  "translationMap" $translationMap
+  "homeMap" $homeMap
+) -}}


### PR DESCRIPTION
### Description

Extracts the page-specific translation and home fallback maps from `navbar-lang-selector.html` into `navbar-language-options.html`.

The existing desktop language selector consumes the returned data without changing its rendered markup. This is a behavior-neutral enabling refactor for #55851, where the same lookups are shared with the mobile language selector.

The helper remains uncached because its output varies by page and per-page cache entries would provide little reuse.

### Testing

The same extraction has been validated as part of the full site build for #55851.

### AI disclosure

AI was used to generate this code under human direction and review. I have reviewed the changes and take responsibility for them.