### PR TITLE
docs: fix broken Kyverno link in Pod Security Standards

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -511,7 +511,7 @@ of individual policies are not defined here.
 Other alternatives for enforcing policies are being developed in the Kubernetes ecosystem, such as:
 
 - [Kubewarden](https://github.com/kubewarden)
-- [Kyverno](https://kyverno.io/policies/pod-security/)
+- [Kyverno](https://kyverno.io/policies)
 - [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
 
 ## Pod OS field


### PR DESCRIPTION
### Description
The Kyverno link under **Alternatives** on the Pod Security Standards page pointed at `https://kyverno.io/policies/pod-security/`, which returns **404**.

Update it to the working policies index: `https://kyverno.io/policies`.

### Related issue
Fixes #56734

### Checklist
- [x] I have read and followed the [Kubernetes website contribution guide](https://kubernetes.io/docs/contribute/)
- [x] English-only change (translations can follow)