### PR TITLE
[ja] Translate content/en/docs/reference/glossary/operator-pattern.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/operator-pattern.md
+++ b/content/ja/docs/reference/glossary/operator-pattern.md
@@ -9,7 +9,7 @@ aka:
 tags:
 - architecture
 ---
-[オペレーターパターン](/ja/docs/concepts/extend-kubernetes/operator/)は、{{< glossary_tooltip text="コントローラー" term_id="controller" >}}を1つ以上のカスタムリソースにリンクさせるシステム設計です。
+[オペレーターパターン](/docs/concepts/extend-kubernetes/operator/)は、{{< glossary_tooltip text="コントローラー" term_id="controller" >}}を1つ以上のカスタムリソースにリンクさせるシステム設計です。
 
 <!--more-->
 

--- a/content/ja/docs/reference/glossary/operator-pattern.md
+++ b/content/ja/docs/reference/glossary/operator-pattern.md
@@ -1,0 +1,18 @@
+---
+title: オペレーターパターン
+id: operator-pattern
+full_link: /ja/docs/concepts/extend-kubernetes/operator/
+short_description: >
+  カスタムリソースを管理するために使用される専用のコントローラー。
+
+aka:
+tags:
+- architecture
+---
+[オペレーターパターン](/ja/docs/concepts/extend-kubernetes/operator/)は、{{< glossary_tooltip text="コントローラー" term_id="controller" >}}を1つ以上のカスタムリソースにリンクさせるシステム設計です。
+
+<!--more-->
+
+Kubernetes自体の一部として提供される組み込みのコントローラーに加えて、クラスターにコントローラーを追加することで、Kubernetesを拡張できます。
+
+実行中のアプリケーションがコントローラーとして振る舞い、コントロールプレーンに定義されたカスタムリソースに対してタスクを実行するためのAPIアクセスを持っている場合、それはオペレーターパターンの一例です。

--- a/content/ja/docs/reference/glossary/operator-pattern.md
+++ b/content/ja/docs/reference/glossary/operator-pattern.md
@@ -1,7 +1,7 @@
 ---
 title: オペレーターパターン
 id: operator-pattern
-full_link: /ja/docs/concepts/extend-kubernetes/operator/
+full_link: /docs/concepts/extend-kubernetes/operator/
 short_description: >
   カスタムリソースを管理するために使用される専用のコントローラー。
 


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/operator-pattern.md` into Japanese: `content/ja/docs/reference/glossary/operator-pattern.md`.

Since the Japanese concept page `content/ja/docs/concepts/extend-kubernetes/operator.md` already exists, `full_link` and the body link use the `/ja/` prefix (same as `content/ja/docs/reference/glossary/controller.md`).

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?all=true#term-operator-pattern

### Issue

Closes: #56699

/area localization
/language ja

<!-- oss-radar:idempotency=auto-20260802-101009.w3.kubernetes_website.56699 -->
