### PR TITLE
[ja] Translate content/en/docs/reference/glossary/preemption.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/preemption.md
+++ b/content/ja/docs/reference/glossary/preemption.md
@@ -1,15 +1,15 @@
 ---
 title: プリエンプション
 id: preemption
-full_link: /ja/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
 short_description: >
-  Kubernetesのプリエンプションロジックは、Node上に存在する優先度の低いPodを追い出すことで、保留中のPodが適切なNodeを見つけられるようにします。
+  Kubernetesのプリエンプションロジックは、ノード上に存在する優先度の低いPodを追い出すことで、保留中のPodが適切なノードを見つけられるようにします。
 
 aka:
 tags:
 - operation
 ---
-Kubernetesのプリエンプションロジックは、Node上に存在する優先度の低いPodを追い出すことで、保留中の{{< glossary_tooltip term_id="pod" >}}が適切な{{< glossary_tooltip term_id="node" >}}を見つけられるようにします。
+Kubernetesのプリエンプションロジックは、ノード上に存在する優先度の低いPodを追い出すことで、保留中の{{< glossary_tooltip term_id="pod" >}}が適切な{{< glossary_tooltip term_id="node" >}}を見つけられるようにします。
 
 <!--more-->
 

--- a/content/ja/docs/reference/glossary/preemption.md
+++ b/content/ja/docs/reference/glossary/preemption.md
@@ -1,0 +1,16 @@
+---
+title: プリエンプション
+id: preemption
+full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
+short_description: >
+  Kubernetesのプリエンプションロジックは、Node上に存在する優先度の低いPodを追い出すことで、保留中のPodが適切なNodeを見つけられるようにします。
+
+aka:
+tags:
+- operation
+---
+Kubernetesのプリエンプションロジックは、Node上に存在する優先度の低いPodを追い出すことで、保留中の{{< glossary_tooltip term_id="pod" >}}が適切な{{< glossary_tooltip term_id="node" >}}を見つけられるようにします。
+
+<!--more-->
+
+Podをスケジューリングできない場合、スケジューラーはそのPodをスケジューリングできるようにするため、優先度の低いPodを[プリエンプトする](/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption)（追い出す）ことを試みます。

--- a/content/ja/docs/reference/glossary/preemption.md
+++ b/content/ja/docs/reference/glossary/preemption.md
@@ -1,7 +1,7 @@
 ---
 title: プリエンプション
 id: preemption
-full_link: /docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
+full_link: /ja/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption
 short_description: >
   Kubernetesのプリエンプションロジックは、Node上に存在する優先度の低いPodを追い出すことで、保留中のPodが適切なNodeを見つけられるようにします。
 
@@ -13,4 +13,4 @@ Kubernetesのプリエンプションロジックは、Node上に存在する優
 
 <!--more-->
 
-Podをスケジューリングできない場合、スケジューラーはそのPodをスケジューリングできるようにするため、優先度の低いPodを[プリエンプトする](/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption)（追い出す）ことを試みます。
+Podをスケジューリングできない場合、スケジューラーはそのPodをスケジューリングできるようにするため、優先度の低いPodを[プリエンプトする](/ja/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption)（追い出す）ことを試みます。

--- a/content/ja/docs/reference/glossary/preemption.md
+++ b/content/ja/docs/reference/glossary/preemption.md
@@ -13,4 +13,4 @@ Kubernetesのプリエンプションロジックは、Node上に存在する優
 
 <!--more-->
 
-Podをスケジューリングできない場合、スケジューラーはそのPodをスケジューリングできるようにするため、優先度の低いPodを[プリエンプトする](/ja/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption)（追い出す）ことを試みます。
+Podをスケジューリングできない場合、スケジューラーはそのPodをスケジューリングできるようにするため、優先度の低いPodを[プリエンプトする](/docs/concepts/scheduling-eviction/pod-priority-preemption/#preemption)(追い出す)ことを試みます。


### PR DESCRIPTION
### Description

Add the Japanese translation of the glossary term `preemption` (`content/ja/docs/reference/glossary/preemption.md`).

This term is referenced by several Japanese pages via `glossary_tooltip`, which currently fall back to the English tooltip. Terminology follows the existing Japanese content: プリエンプション / スケジューラー / 追い出す as used in `content/ja/docs/concepts/scheduling-eviction/pod-priority-preemption.md`, and the file structure follows `content/ja/docs/reference/glossary/pod-priority.md`.

### Issue

Closes: #56698

/language ja
/area localization

<!-- oss-radar:idempotency=auto-20260802-101009.w4.kubernetes_website.56698 -->