### PR TITLE
Fix broken Kyverno link in Pod Security Standards alternatives

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -511,7 +511,7 @@ of individual policies are not defined here.
 Other alternatives for enforcing policies are being developed in the Kubernetes ecosystem, such as:
 
 - [Kubewarden](https://github.com/kubewarden)
-- [Kyverno](https://kyverno.io/policies/pod-security/)
+- [Kyverno](https://kyverno.io/policies/)
 - [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
 
 ## Pod OS field


### PR DESCRIPTION
### Desciption

Fix the Kyverno link in the Alternatives section of the Pod Security Standards page. The current URL (https://kyverno.io/policies/pod-security/) returns 404; the policies index (https://kyverno.io/policies/) resolves correctly.

### Issue

Fixes #56734