### PR TITLE
clarify multiple inter-pod affinity term behavior

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
+++ b/content/en/docs/concepts/scheduling-eviction/assign-pod-node.md
@@ -305,6 +305,13 @@ When scheduling a new Pod, the Kubernetes scheduler evaluates the Pod's affinity
    - Existing Pods' `podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution`:
      - Similarly, preferred anti-affinity rules of existing Pods are ignored during scheduling.
 
+#### Multiple Affinity Terms
+
+If you specify multiple terms in `podAffinity.requiredDuringSchedulingIgnoredDuringExecution` or `podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution`, the elements of the array are intersected. In other words, all terms must be satisfied in order for the node to be selected.
+
+- **Pod affinity**: The node must satisfy all specified affinity terms.
+- **Pod anti-affinity**: The node must satisfy all specified anti-affinity terms. Since anti-affinity means the node should *not* match the given term, having multiple terms means that the node will be excluded if it matches *any* of the anti-affinity terms.
+
 #### Scheduling a Group of Pods with Inter-pod Affinity to Themselves
 
 If the current Pod being scheduled is the first in a series that have affinity to themselves,


### PR DESCRIPTION
## Summary

Clarify how multiple inter-pod affinity terms are evaluated.

The updated documentation explains how multiple affinity terms are interpreted, reducing ambiguity and aligning the explanation with the Kubernetes API behavior.

## Changes

* Added clarification for multiple inter-pod affinity terms.
* Improved wording around affinity evaluation semantics.
* No behavioral changes.

## Testing

* Reviewed the updated documentation for clarity and consistency.
* Documentation-only change.

## AI Assistance

AI tools were used as an assistant during the preparation of this PR. I reviewed and verified the changes myself and remain responsible for the final implementation.

Fixes #55875