### PR TITLE
improve Create Cluster tutorial flow

### DIFF
--- a/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
@@ -103,7 +103,7 @@ To verify the cluster status:
 minikube status
 ```
 
-For a complete walkthrough including deploying your first app and exploring the Kubernetes dashboard, see the [Hello Minikube](/docs/tutorials/hello-minikube/) tutorial.
+
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
## Summary

Improve the Create Cluster tutorial flow by removing the intermediate "Hello Minikube" redirection.

This keeps users on the intended learning path and provides a smoother transition to the next tutorial step.

## Changes

* Removed the paragraph redirecting readers to the "Hello Minikube" tutorial.
* Preserved the existing tutorial sequence leading to the deployment step.

## Testing

* Reviewed the updated documentation flow.
* Documentation-only change.

## AI Assistance

AI tools were used as an assistant during the preparation of this PR. I reviewed and verified the changes myself and remain responsible for the final implementation.
 
Fixes #55942