### PR TITLE
Document DRA and Topology Manager NUMA alignment limitations

### DIFF
--- a/content/en/docs/concepts/resource-management/dynamic-resource-allocation/_index.md
+++ b/content/en/docs/concepts/resource-management/dynamic-resource-allocation/_index.md
@@ -89,6 +89,25 @@ The workflow of using DRA to allocate devices involves the following types of us
   becomes available, which happens when the conflicting Pod terminates or is
   manually deleted.
 
+### DRA and Topology Manager NUMA alignment
+
+DRA resources don't participate in
+[Topology Manager](/docs/tasks/administer-cluster/topology-manager/) decisions.
+Topology Manager makes Pod admission decisions using topology hints from
+kubelet-local resource managers, such as CPU Manager, Memory Manager, and
+Device Manager. The kubelet prepares DRA resources after Pod admission and
+before it creates the Pod sandbox.
+
+As a result, Topology Manager policies, including `single-numa-node`, don't
+guarantee NUMA alignment between DRA devices and CPU or memory that
+kubelet-local resource managers allocate.
+
+For topology-aware co-selection, model the resources that need alignment with
+DRA and use [ResourceClaim device constraints](/docs/reference/kubernetes-api/resource/resource-claim-v1/#DeviceConstraint),
+such as `matchAttribute`, with a shared topology attribute. These constraints
+co-select DRA resources; they don't align DRA resources with resources managed
+by kubelet-local resource managers.
+
 ## {{% heading "whatsnext" %}}
 
 - [Set Up DRA in a Cluster](/docs/tasks/configure-pod-container/assign-resources/set-up-dra-cluster/)

--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -615,6 +615,25 @@ the `.spec.nodeName` field and to use a node selector instead.
   becomes available, which happens when the conflicting Pod terminates or is
   manually deleted.
 
+### DRA and Topology Manager NUMA alignment
+
+DRA resources don't participate in
+[Topology Manager](/docs/tasks/administer-cluster/topology-manager/) decisions.
+Topology Manager makes Pod admission decisions using topology hints from
+kubelet-local resource managers, such as CPU Manager, Memory Manager, and
+Device Manager. The kubelet prepares DRA resources after Pod admission and
+before it creates the Pod sandbox.
+
+As a result, Topology Manager policies, including `single-numa-node`, don't
+guarantee NUMA alignment between DRA devices and CPU or memory that
+kubelet-local resource managers allocate.
+
+For topology-aware co-selection, model the resources that need alignment with
+DRA and use [ResourceClaim device constraints](/docs/reference/kubernetes-api/resource/resource-claim-v1/#DeviceConstraint),
+such as `matchAttribute`, with a shared topology attribute. These constraints
+co-select DRA resources; they don't align DRA resources with resources managed
+by kubelet-local resource managers.
+
 ## DRA beta features {#beta-features}
 
 The following sections describe DRA features that support advanced use


### PR DESCRIPTION
## Summary

- document that DRA resources do not participate in kubelet Topology Manager decisions
- clarify that Topology Manager policies, including `single-numa-node`, do not guarantee NUMA alignment between DRA devices and CPU or memory allocated by kubelet-local managers
- direct DRA-to-DRA topology-aware co-selection to `ResourceClaim` `matchAttribute` constraints
- relocate the documentation into the DRA overview's Limitations section after the upstream DRA documentation restructure

## Why

Kubelet prepares DRA resources after Pod admission, before creating the Pod sandbox. Therefore, DRA devices cannot provide topology hints for Topology Manager decisions.

## Impact

This documents the current boundary so that users do not rely on mixed DRA and kubelet-local resource allocations being NUMA aligned.

Closes #56232

## Validation

- `git diff --check`
- `make build` with the repository-pinned Hugo v0.144.2

## AI assistance

I used an LLM to help structure and edit this documentation. I reviewed the suggestions, verified the final content, and take responsibility for this contribution.
