### PR TITLE
Replace stale images in Services tutorial

### DIFF
--- a/content/en/docs/tutorials/services/connect-applications-service.md
+++ b/content/en/docs/tutorials/services/connect-applications-service.md
@@ -238,20 +238,16 @@ Service from any pod in your cluster using standard methods (e.g. `gethostbyname
 If CoreDNS isn't running, you can enable it referring to the
 [CoreDNS README](https://github.com/coredns/deployment/tree/master/kubernetes)
 or [Installing CoreDNS](/docs/tasks/administer-cluster/coredns/#installing-coredns).
-Let's run another curl application to test this:
+Let's run a temporary BusyBox Pod to test this:
 
 ```shell
-kubectl run curl --image=radial/busyboxplus:curl -i --tty --rm
-```
-```
-Waiting for pod default/curl-131556218-9fnch to be running, status is Pending, pod ready: false
-Hit enter for command prompt
+kubectl run dnsutils --image=docker.io/library/busybox:1.37.0 --restart=Never --rm -i -t -- sh
 ```
 
-Then, hit enter and run `nslookup my-nginx`:
+At the command prompt, run `nslookup my-nginx`:
 
 ```shell
-[ root@curl-131556218-9fnch:/ ]$ nslookup my-nginx
+/ # nslookup my-nginx
 Server:    10.0.0.10
 Address 1: 10.0.0.10
 

--- a/content/en/examples/service/networking/curlpod.yaml
+++ b/content/en/examples/service/networking/curlpod.yaml
@@ -22,7 +22,7 @@ spec:
         - sh
         - -c
         - while true; do sleep 1; done
-        image: radial/busyboxplus:curl
+        image: docker.io/curlimages/curl:8.18.0
         volumeMounts:
         - mountPath: /etc/nginx/ssl
           name: secret-volume

--- a/content/en/examples/service/networking/nginx-secure-app.yaml
+++ b/content/en/examples/service/networking/nginx-secure-app.yaml
@@ -39,8 +39,8 @@ spec:
         configMap:
           name: nginxconfigmap
       containers:
-      - name: nginxhttps
-        image: bprashanth/nginxhttps:1.0
+      - name: nginx
+        image: docker.io/library/nginx:1
         ports:
         - containerPort: 443
         - containerPort: 80


### PR DESCRIPTION
### Description

- replace the stale third-party images in the Services tutorial with maintained BusyBox, curl, and NGINX images
- use BusyBox exclusively for the DNS lookup step and update the command prompt accordingly
- pin the BusyBox and curl images; use the official NGINX major-version tag

This is intentionally limited to the image remediation in this issue. It does not include the broader archived-example rewrite attempted in #53553.

### Issue

Closes #47372

### Validation

- `docker run --rm docker.io/library/busybox:1.37.0 nslookup localhost`
- `docker run --rm --entrypoint sh docker.io/curlimages/curl:8.18.0 -c 'curl --version'`
- `docker run --rm docker.io/library/nginx:1 nginx -t`
- `git diff --check`
- `make module-init`
- `make build` *(blocked: Hugo is not installed in this environment)*
