### PR TITLE
docs: fix broken Kyverno link in Pod Security Standards

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -511,7 +511,7 @@ of individual policies are not defined here.
 Other alternatives for enforcing policies are being developed in the Kubernetes ecosystem, such as:
 
 - [Kubewarden](https://github.com/kubewarden)
-- [Kyverno](https://kyverno.io/policies/pod-security/)
+- [Kyverno](https://kyverno.io/policies)
 - [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
 
 ## Pod OS field


### PR DESCRIPTION
#### What this PR does / why we need it:

The Kyverno link under **Alternatives** on the Pod Security Standards page pointed at `https://kyverno.io/policies/pod-security/`, which returns 404. Update it to `https://kyverno.io/policies`.

#### Which issue(s) this PR fixes:

Fixes #56734

#### Special notes for your reviewer:

/sig docs
/language en

#### Does this PR introduce a user-facing change?

```release-note
NONE
```