### PR TITLE
[zh-cn] sync feature-gates VolumeAttributesClass SELinuxChangePolicy

### DIFF
--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/SELinuxChangePolicy.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/SELinuxChangePolicy.md
@@ -13,6 +13,10 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.33"
+    toVersion: "1.35"
+  - stage: stable
+    defaultValue: true
+    fromVersion: "1.36"
 ---
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/VolumeAttributesClass.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/VolumeAttributesClass.md
@@ -17,6 +17,11 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.34"
+    toVersion: "1.35"
+  - stage: stable
+    defaultValue: true
+    locked: true
+    fromVersion: "1.36"
 ---
 
 <!--


### PR DESCRIPTION
Sync the `stages` metadata of two feature-gate pages with the English source:

- `VolumeAttributesClass.md`: add `toVersion: "1.35"` to the existing stable stage and the locked stable stage from 1.36
- `SELinuxChangePolicy.md`: add `toVersion: "1.35"` to the beta stage and the stable stage from 1.36

The stages blocks now match `content/en` exactly. No translatable text changed.