### PR TITLE
docs: clarify macOS is not supported natively for ref docs

### DIFF
--- a/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
+++ b/content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md
@@ -1,7 +1,7 @@
 
 ### Requirements:
 
-- You need a machine that is running Linux or macOS. On Windows, use
+- You need a machine that is running Linux. macOS is not currently supported natively for generating reference documentation, though you can use a Linux VM or Docker container. On Windows, use
   [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install),
   since the build tooling relies on `make` and Bash scripts.
 


### PR DESCRIPTION
Fixes #56553

### Why are we solving this issue?
macOS users were getting stuck trying to run the reference-docs generator tooling because the docs implied macOS was supported natively. This explicitly clarifies that macOS is not supported natively, saving contributors time.

### To address this issue, are there any code changes?
No code changes, only documentation updates in `content/en/docs/contribute/generate-ref-docs/prerequisites-ref-docs.md`.

### How can the assignee reach out to you for help?
Feel free to leave a comment on this PR.