### PR TITLE
Fix --cpu-percent flag: remove invalid % suffix in kubectl autoscale examples

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -649,7 +649,7 @@ in your cluster, you can set up an autoscaler for your Deployment and choose the
 Pods you want to run based on the CPU utilization of your existing Pods.
 
 ```shell
-kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80%
+kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80
 ```
 The output is similar to this:
 ```

--- a/content/en/docs/concepts/workloads/controllers/deployment.md
+++ b/content/en/docs/concepts/workloads/controllers/deployment.md
@@ -649,7 +649,7 @@ in your cluster, you can set up an autoscaler for your Deployment and choose the
 Pods you want to run based on the CPU utilization of your existing Pods.
 
 ```shell
-kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80
+kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu=80%
 ```
 The output is similar to this:
 ```

--- a/content/ja/docs/concepts/workloads/controllers/deployment.md
+++ b/content/ja/docs/concepts/workloads/controllers/deployment.md
@@ -674,7 +674,7 @@ deployment.apps/nginx-deployment scaled
 クラスターで[水平Podオートスケーリング](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/)が有効になっていると仮定すると、Deploymentのオートスケーラーを設定し、既存のPodのCPU使用率に基づいて、稼働させたいPodの最小数と最大数を選択できます。
 
 ```shell
-kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80
+kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu=80%
 ```
 
 実行結果は以下のとおりです:

--- a/content/ja/docs/concepts/workloads/controllers/deployment.md
+++ b/content/ja/docs/concepts/workloads/controllers/deployment.md
@@ -674,7 +674,7 @@ deployment.apps/nginx-deployment scaled
 クラスターで[水平Podオートスケーリング](/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/)が有効になっていると仮定すると、Deploymentのオートスケーラーを設定し、既存のPodのCPU使用率に基づいて、稼働させたいPodの最小数と最大数を選択できます。
 
 ```shell
-kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80%
+kubectl autoscale deployment/nginx-deployment --min=10 --max=15 --cpu-percent=80
 ```
 
 実行結果は以下のとおりです:


### PR DESCRIPTION
### Description

The `--cpu-percent` flag in `kubectl autoscale` expects a plain integer (e.g. `80`), not a percentage string (e.g. `80%`). The docs in the Deployment page had `--cpu-percent=80%` inside a `shell` code block, which would produce the following error if run:

```
error: strconv.ParseInt: parsing "80%": invalid syntax
```

Fixed in both the English and Japanese (`ja`) versions of the Deployment docs.