### PR TITLE
Add blog post for KEP-6060: API server authentication to webhooks (v1.37 alpha)

### DIFF
--- a/content/en/blog/_posts/2026/2026-08-03-auth-to-webhooks/index.md
+++ b/content/en/blog/_posts/2026/2026-08-03-auth-to-webhooks/index.md
@@ -1,0 +1,186 @@
+---
+layout: blog
+title: "Kubernetes v1.37: A Webhook That Never Asks Who Wants to Know"
+date: 2026-08-03
+slug: kubernetes-v1-37-api-server-authentication-to-webhooks-alpha
+author: >
+  [Ben Petersen](https://github.com/benjaminapetersen) (Microsoft),
+  [Peter Engelbert](https://github.com/pmengelbert) (Microsoft)
+---
+
+## A webhook that never asks who wants to know
+
+Here is something that surprises a lot of people the first time they hear it: when
+the Kubernetes API server calls one of your admission webhooks, it does not, by
+default, prove that it is the API server. The webhook receives a request that
+looks like it came from the control plane, and it takes that on faith. If some
+other workload on the cluster can reach the webhook's network address, it can send
+the very same request, and the webhook has no built-in way to tell the difference.
+
+For a component whose whole job is to say "yes, admit this object" or "no, reject
+it," trusting the caller without checking who the caller is turns out to be a real
+gap. It is not a hypothetical, either. [CVE-2025-1974](https://nvd.nist.gov/vuln/detail/CVE-2025-1974)
+is a recent, real-world example of what can go wrong when something on the cluster
+network can talk to a component that assumed only the control plane would ever call
+it. In Kubernetes v1.37, we - SIG Auth - are starting to close that gap.
+
+{{< note >}}
+This work is scoped to **admission webhooks**: the validating and mutating webhooks
+that can accept, reject, or modify objects as they are created or updated. It does
+not change authentication, authorization, audit, or conversion webhooks. When this
+post says "webhook," it means an admission webhook.
+{{< /note >}}
+
+## A day in the life of a webhook that asks no questions
+
+Let's make it concrete. Say you run a validating admission webhook called
+`policy-webhook` in namespace `guardrails`. Its job is to inspect every new Pod and
+decide whether it satisfies your organization's rules. The API server is configured
+to call `policy-webhook` on every Pod create, sends it an `AdmissionReview` request,
+and honors the allow-or-deny answer that comes back.
+
+`policy-webhook` is reachable at a Service address on the cluster network. That is
+exactly how the API server reaches it. But a Service address does not care who is
+dialing it. Now suppose an attacker gets a foothold: a compromised Pod, a leaky
+sidecar, anything that can open a connection on the service network. That workload
+can craft its own `AdmissionReview` request and send it straight to `policy-webhook`.
+
+From the webhook's point of view, the two requests are indistinguishable. It has no
+standard, on-by-default way to confirm that the request in front of it actually came
+from the API server. Depending on what your webhook does with that request, an
+attacker who can pose as the API server might learn about policy that governs
+resources they have no business seeing, or nudge the webhook into behavior it should
+only ever perform for the control plane. The same concern applies to aggregated API
+servers (add-on API servers registered through an `APIService` so their API groups
+show up under the main Kubernetes API), which also call admission webhooks. A
+compromised aggregated API server should not be able to probe a webhook about
+resources it does not own.
+
+There has always been an opt-in way to authenticate the caller. You can hand the API
+server a kubeconfig, via `--admission-control-config-file`, carrying a client
+certificate, a bearer token, or basic auth. It works, but it is a lot to ask. Someone
+has to manage those credentials by hand, and changing them means restarting the API
+server. The mechanism is unopinionated about which method you use, so a webhook that
+wants to be broadly compatible has to be ready to verify all three. And the pain is
+worst in the most common case: when the person running the API server and the person
+who wrote the webhook are different people, which is exactly the situation for
+off-the-shelf, community-maintained webhooks.
+
+## Making the API server show some ID
+
+The idea behind [KEP-6060](https://github.com/kubernetes/enhancements/issues/6060) is
+to let the API server prove it is the caller, without any of that manual credential
+wrangling. The API server (and aggregated API servers) can now mint a service account
+token specifically for authenticating to an admission webhook, and present it as a
+bearer token on the call. A service account token is just a signed JWT that stands in
+for an identity. The twist here is that these tokens are short-lived, scoped to a
+single webhook, and carry a claim about which API group the caller is allowed to ask
+about.
+
+The design goals are the part we care most about, because they are what make this
+usable rather than just possible:
+
+- **Low friction.** The aim is for this to work with minimal setup. Friction is what
+  kills adoption, so the design leans toward being easy to turn on rather than a pile
+  of configuration.
+- **Backward compatible.** Existing kubeconfig-based setups keep working, and a
+  webhook that simply ignores the `Authorization` header is unaffected. Nothing breaks
+  by upgrading.
+- **Scoped.** A token is tied to one webhook, by its audience, and to a specific API
+  group, by an attested claim. It cannot be replayed against a different webhook or
+  used to ask about a different API group.
+- **Verifiable without a callback.** The webhook checks the token by verifying its
+  signature against the API server's public keys, which the API server already
+  publishes. There is no round-trip back to the API server to validate each token.
+
+Two terms are worth pinning down. The **audience** (`aud`) of a token is the recipient
+it is meant for; a verifier rejects any token whose audience is not itself. Here the
+audience is derived from the target webhook's configuration, so a token minted for
+`policy-webhook` is meaningless to any other webhook. And **JWKS / OIDC discovery** is
+the mechanism that lets verification happen offline: the API server publishes its
+public signing keys (a JSON Web Key Set) at a well-known endpoint, and a webhook fetches
+those keys to check a token's signature on its own, without asking the API server about
+that specific token.
+
+![Diagram: the API server mints a short-lived, webhook-scoped service account token, presents it as a bearer token on the AdmissionReview call, and the webhook verifies the token signature offline against the API server's public keys. An attacker on the service network can reach the webhook but cannot forge a validly signed token.](webhook-auth-flow.svg)
+
+The API server mints a scoped token, presents it to the webhook, and the webhook verifies it offline. An attacker can still reach the address, but has no valid token to present.
+
+## How it all works
+
+What follows is a simplified description. For the complete version, including the exact
+claims and the authorization checks, please read
+[KEP-6060](https://github.com/kubernetes/enhancements/issues/6060).
+
+1. When the API server needs to call an admission webhook, it asks for a service
+   account token that is bound to that specific webhook's configuration (its
+   `ValidatingWebhookConfiguration` or `MutatingWebhookConfiguration`). The request also
+   asks the API server to attest to which API group the caller may ask the webhook
+   about.
+
+2. Before issuing anything, the API server runs a series of authorization checks: that
+   the caller is allowed to request a token for that service account, that the bound
+   webhook configuration actually exists, and that the caller is permitted to attest to
+   the API group it asked for. Only then does it sign the token. This is the important
+   move: the API server will not vouch for a claim the caller is not authorized to make.
+
+3. The resulting token is short-lived, its lifetime capped at ten minutes, and its
+   audience is derived from the target webhook so it cannot be reused elsewhere. The API
+   server caches these tokens per webhook and refreshes them as they expire, rather than
+   minting a fresh one on every call.
+
+4. The token is presented to the webhook as an `Authorization: Bearer` header on the
+   `AdmissionReview` call. The webhook verifies the signature against the API server's
+   published keys, checks that the audience matches itself, and checks that the attested
+   API group covers the resource in the request. Because all of that is signature and
+   claim inspection, the webhook never has to call back to the API server to trust the
+   caller.
+
+A note on what actually shipped in this alpha, because it matters for what you can try
+today. The machinery that lives in the API server, issuing these webhook-scoped tokens
+and enforcing the authorization checks at issuance time, is what landed in v1.37.
+
+## Try it out
+
+In Kubernetes v1.37 this ships as alpha, off by default, behind the
+`APIServerWebhookAuthenticationToken` feature gate on the `kube-apiserver`. To
+experiment with it, start your API server with:
+
+```
+--feature-gates=APIServerWebhookAuthenticationToken=true
+```
+
+Because this is alpha and off by default, it will not affect any existing cluster until
+you deliberately turn it on. The user-facing documentation is coming together in
+[kubernetes/website PR #56400](https://github.com/kubernetes/website/pull/56400); if you
+want to follow the config surface as it settles, that is the place to watch.
+
+## What's next?
+
+This is an early step, and we have been deliberate about shipping the foundation first.
+Several pieces are still ahead of us, and honestly, some of them are still being shaped:
+
+- **A verification library for webhook authors.** We want webhook maintainers to validate these
+  tokens without hand-rolling JWT and JWKS handling. A reusable library
+  ([kubernetes/kubernetes#140665](https://github.com/kubernetes/kubernetes/pull/140665))
+  is in progress but did not land in v1.37.
+- **controller-runtime integration.** Many webhooks are built on controller-runtime, so
+  first-class support there ([controller-runtime#3554](https://github.com/kubernetes-sigs/controller-runtime/pull/3554))
+  is something we want, and it is still a work in progress.
+
+If you look at that list and think "these are exactly the pieces I would have opinions
+about," good. That is the point of shipping an alpha. The shape of the verification
+library and the audience derivation is genuinely still open, and feedback right now is
+great!
+
+## How to get involved
+
+Reading [KEP-6060](https://github.com/kubernetes/enhancements/issues/6060) is the best
+way to understand the design in depth, including the parts this post simplified.
+
+This is a SIG Auth effort, and we would love your help thinking through the open pieces.
+You can find us on the [#sig-auth-authenticators-dev](https://kubernetes.slack.com/archives/C04UMAUC4UA)
+channel on Kubernetes Slack (for an invitation, visit https://slack.k8s.io/). You are also welcome to join the bi-weekly [SIG Auth meetings](https://github.com/kubernetes/community/blob/master/sig-auth/README.md#meetings), held every other Wednesday.
+
+If you maintain an admission webhook, or you have been burned by the caller-trust gap
+before, we especially want to hear from you!

--- a/content/en/blog/_posts/2026/2026-08-03-auth-to-webhooks/webhook-auth-flow.svg
+++ b/content/en/blog/_posts/2026/2026-08-03-auth-to-webhooks/webhook-auth-flow.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" font-family="Helvetica, Arial, sans-serif" role="img" aria-labelledby="title desc">
+  <title id="title">Authenticating the API server to an admission webhook (KEP-6060)</title>
+  <desc id="desc">The API server mints a short-lived, webhook-scoped service account token, presents it as a bearer token on the AdmissionReview call, and the webhook verifies the signature offline against the API server's JWKS endpoint. An attacker on the service network can reach the webhook but cannot forge a validly signed token.</desc>
+
+  <defs>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#326CE5"/>
+    </marker>
+    <marker id="arrowGray" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#5F6368"/>
+    </marker>
+    <marker id="arrowRed" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#D93025"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="600" fill="#ffffff"/>
+
+  <text x="480" y="34" text-anchor="middle" font-size="21" font-weight="700" fill="#202124">Authenticating the API server to an admission webhook</text>
+  <text x="480" y="58" text-anchor="middle" font-size="14" fill="#5F6368">KEP-6060, alpha in Kubernetes v1.37</text>
+
+  <!-- JWKS / OIDC discovery box -->
+  <rect x="350" y="82" width="300" height="66" rx="8" fill="#E8F0FE" stroke="#326CE5" stroke-width="1.5"/>
+  <text x="500" y="108" text-anchor="middle" font-size="14" font-weight="700" fill="#1A2E5A">API server public keys</text>
+  <text x="500" y="128" text-anchor="middle" font-size="12.5" fill="#3C4043">JWKS / OIDC discovery endpoint</text>
+
+  <!-- API server box -->
+  <rect x="40" y="196" width="240" height="120" rx="10" fill="#326CE5"/>
+  <text x="160" y="244" text-anchor="middle" font-size="17" font-weight="700" fill="#ffffff">kube-apiserver</text>
+  <text x="160" y="268" text-anchor="middle" font-size="12.5" fill="#DCE7FB">(or an aggregated</text>
+  <text x="160" y="286" text-anchor="middle" font-size="12.5" fill="#DCE7FB">API server)</text>
+
+  <!-- Webhook box -->
+  <rect x="680" y="196" width="240" height="120" rx="10" fill="#ffffff" stroke="#326CE5" stroke-width="2"/>
+  <text x="800" y="244" text-anchor="middle" font-size="17" font-weight="700" fill="#1A2E5A">Admission webhook</text>
+  <text x="800" y="270" text-anchor="middle" font-size="13" fill="#3C4043">policy-webhook</text>
+  <text x="800" y="288" text-anchor="middle" font-size="12" fill="#5F6368">in namespace guardrails</text>
+
+  <!-- Main flow arrow: API server -> webhook -->
+  <line x1="280" y1="256" x2="676" y2="256" stroke="#326CE5" stroke-width="2.5" marker-end="url(#arrowBlue)"/>
+  <text x="478" y="228" text-anchor="middle" font-size="13.5" font-weight="700" fill="#1A2E5A">2. AdmissionReview request</text>
+  <text x="478" y="292" text-anchor="middle" font-size="12.5" fill="#3C4043">Authorization: Bearer &lt;token&gt;</text>
+  <!-- token pill on the line -->
+  <rect x="444" y="240" width="70" height="30" rx="15" fill="#FCE8B2" stroke="#B06000" stroke-width="1.2"/>
+  <text x="479" y="260" text-anchor="middle" font-size="12.5" font-weight="700" fill="#5A3B00">JWT</text>
+
+  <!-- Step 1: mint token box -->
+  <rect x="40" y="360" width="300" height="176" rx="10" fill="#F8F9FA" stroke="#9AA0A6" stroke-width="1.3"/>
+  <text x="56" y="386" font-size="14" font-weight="700" fill="#202124">1. Mint a webhook-scoped token</text>
+  <text x="56" y="412" font-size="12.5" fill="#3C4043">&#8226; a service account token (a signed JWT)</text>
+  <text x="56" y="434" font-size="12.5" fill="#3C4043">&#8226; bound to this webhook's configuration</text>
+  <text x="56" y="456" font-size="12.5" fill="#3C4043">&#8226; audience = this webhook only</text>
+  <text x="56" y="478" font-size="12.5" fill="#3C4043">&#8226; attests the allowed API group</text>
+  <text x="56" y="500" font-size="12.5" fill="#3C4043">&#8226; short-lived, expires in 10 minutes or less</text>
+  <text x="56" y="522" font-size="11.5" font-style="italic" fill="#5F6368">verified at issuance, not on every call</text>
+  <line x1="160" y1="316" x2="160" y2="360" stroke="#9AA0A6" stroke-width="1.3" stroke-dasharray="4 3" marker-end="url(#arrowGray)"/>
+
+  <!-- Step 3: offline verification, webhook -> JWKS -->
+  <path d="M770,196 C760,168 690,150 654,132" fill="none" stroke="#5F6368" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrowGray)"/>
+  <text x="820" y="170" text-anchor="middle" font-size="13" font-weight="700" fill="#202124">3. Verify signature offline</text>
+  <text x="820" y="188" text-anchor="middle" font-size="12" fill="#5F6368">no callback to the API server</text>
+
+  <!-- Attacker box -->
+  <rect x="360" y="446" width="300" height="104" rx="10" fill="#FCE8E6" stroke="#D93025" stroke-width="1.6"/>
+  <text x="510" y="480" text-anchor="middle" font-size="14.5" font-weight="700" fill="#8C1D18">Attacker on the service network</text>
+  <text x="510" y="504" text-anchor="middle" font-size="12.5" fill="#5F1C17">can reach the webhook's address,</text>
+  <text x="510" y="522" text-anchor="middle" font-size="12.5" fill="#5F1C17">but cannot forge a validly signed token</text>
+
+  <!-- Attacker arrow -> webhook, rejected -->
+  <path d="M615,452 C680,420 720,370 758,318" fill="none" stroke="#D93025" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrowRed)"/>
+  <g>
+    <line x1="678" y1="372" x2="700" y2="394" stroke="#D93025" stroke-width="3"/>
+    <line x1="700" y1="372" x2="678" y2="394" stroke="#D93025" stroke-width="3"/>
+  </g>
+  <text x="600" y="410" text-anchor="middle" font-size="12" font-weight="700" fill="#8C1D18">rejected</text>
+</svg>


### PR DESCRIPTION
Announce the alpha of API server authentication to admission webhooks (KEP-6060) shipping in Kubernetes v1.37 behind the APIServerWebhookAuthenticationToken feature gate. Includes a flow diagram (webhook-auth-flow.svg).

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #