### PR TITLE
Fix unreadable deprecation banner on archived site home pages

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -321,6 +321,15 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
       background-color: $dark-bg-color-2;
       color:$dark-text-color-1;
 
+      // The deprecation banner shown on archived doc sets keeps the light
+      // background it gets from Docsy's .pageinfo, so it must keep dark text
+      // too. Without this it inherits the white text set above and ends up
+      // white-on-near-white (contrast ratio 1.05:1).
+      .k8s-deprecation-warning {
+        background-color: $white;
+        color: $dark-grey;
+      }
+
       section:not(#video):not(#cncf) {
         background-color: $dark-bg-color-1;
         color:$dark-text-color-1;


### PR DESCRIPTION
### Description

The deprecation banner on the archived docs site home pages is unreadable when the browser is in dark mode.

`layouts/partials/version-banner.html` renders the banner as `.pageinfo.pageinfo-primary.k8s-deprecation-warning`, directly inside `main`. Docsy 0.7's `.pageinfo` sets `background: #f8f9fa; color: inherit`, and the home page dark-mode block in `assets/scss/_custom.scss` sets `color: $dark-text-color-1` (white) on `body.cid-home main`. So the banner keeps a near-white background but inherits white text.

| | Background | Text | Contrast |
|---|---|---|---|
| before (dark mode) | `#f8f9fa` | `#ffffff` | **1.05:1** |
| after | `$white` `#ffffff` | `$dark-grey` `#303030` | **13.2:1** |
| after, link inside banner | `#ffffff` | `$primary` `#326ce5` | **4.76:1** |

Both pass WCAG AA (4.5:1 for normal text). Light mode is untouched.

This targets `release-1.35` rather than `main` because that is where the bug lives: `main` is on Docsy 0.11, where `.pageinfo` uses `background: var(--bs-alert-bg)`, which Bootstrap 5.3 resolves to `#0a162e` in dark mode — 18:1 against the inherited white text — so `main` is not affected. The archived branches are pinned to Docsy 0.7.2 (#55769) and still hit it.

The same one-line-ish patch applies unchanged to `release-1.34`, `release-1.33` and `release-1.32`, which have the identical problem. Happy to open those PRs too — I did not want to file four at once without checking first.

Verified by building the site locally with Hugo 0.133.0 (the version pinned in `netlify.toml`) and checking the compiled `main.min.css`; I did not have a browser available to screenshot the result, so a deploy preview check would be welcome.

/kind bug
/sig docs
/area web-development

### Issue

Fixes #56823
