### PR TITLE
Fix readability of deprecation warning banner of archived docs site (v1.35)

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -325,6 +325,7 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
       // inherited from main above would be unreadable on it.
       .k8s-deprecation-warning {
         background-color: $dark-bg-color-1;
+        color: $dark-text-color-1;
       }
 
       section:not(#video):not(#cncf) {

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -321,6 +321,12 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
       background-color: $dark-bg-color-2;
       color:$dark-text-color-1;
 
+      // Docsy styles .pageinfo with a light background only, so the light text
+      // inherited from main above would be unreadable on it.
+      .k8s-deprecation-warning {
+        background-color: $dark-bg-color-1;
+      }
+
       section:not(#video):not(#cncf) {
         background-color: $dark-bg-color-1;
         color:$dark-text-color-1;

--- a/assets/scss/_k8s_community.scss
+++ b/assets/scss/_k8s_community.scss
@@ -2,4 +2,10 @@ body.community .k8s-deprecation-warning {
   background-color: $primary;
   color: white;
   margin: 0;
+
+  // This is necessary to make anchor text readable on the blue background.
+  // The color is selected based on my(@kyu08) feeling, so it can be changed if needed.
+  a {
+    color: #93C5FD;
+  }
 }

--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -28,7 +28,7 @@
     height: 0 ;
 }
 
-.gridPage p:not(.announcement-main > p) {
+.gridPage p:not(.announcement-main > p):not(.k8s-deprecation-warning p) {
     color: rgb(255,255,255);
     margin-left: 0 !important;
     padding-left: 0 !important;


### PR DESCRIPTION
NOTE: The diff of this PR is same as https://github.com/kubernetes/website/pull/56839.

---
### Description
#### WHAT
- Currently, these are 3 readability issues exist with deprecation warnings.
- Please see the diff of corresponding commit and its message to know how I've changed and why.

| path(click to jump netlify preview) | current prod site | this PR | corresponding commit |
|---|---|---|---|
| [`/`](https://deploy-preview-56836--k8s-v1-35.netlify.app) |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 28 05@2x" src="https://github.com/user-attachments/assets/a51274ba-bb1d-4569-abdc-196d694c3a4b" /> |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 31 30@2x" src="https://github.com/user-attachments/assets/5381dec0-b2d5-4037-a1b9-23ccc587284f" /> | ea4d2d88, 84cc20be|
| [`/community`](https://deploy-preview-56836--k8s-v1-35.netlify.app/community) |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 28 20@2x" src="https://github.com/user-attachments/assets/1cdd422c-f438-449b-b0b7-ff4d9ad09526" /> | <img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 31 35@2x" src="https://github.com/user-attachments/assets/32194012-87b5-4e18-9473-7c7c2b797175" />| 5c67eac9 |
| [`/partners`](https://deploy-preview-56836--k8s-v1-35.netlify.app/partners) |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 28 26@2x" src="https://github.com/user-attachments/assets/f58f3a83-710f-4eb5-99a6-97692d6d10d3" /> |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 31 39@2x" src="https://github.com/user-attachments/assets/3be84387-6d1f-4b15-9942-e56bcdfdca38" /> | aa5de57d |



#### WHY
To fix a readability issue. For more details, see #56823.

#### AI usage disclosure
- I used AI to investigate and generate initial implementation.
- I didn't use AI to:
    - Fix generated code (I did it manually)
    - Write commit messages
    - Write this PR body
- I will not use AI to response to code review comments.

### Issue
#56823

I didn't put a `Close` keyword before the issue number intentionally, because this PR will not be merged to default branch. So I will close manually the issue after all PRs are merged.

- `release-1.35` (This PR)
- `release-1.34` https://github.com/kubernetes/website/pull/56837
- `release-1.33` https://github.com/kubernetes/website/pull/56838 
- `release-1.32` https://github.com/kubernetes/website/pull/56839
