### PR TITLE
Fix readability of deprecation warning banner of archived docs site (v1.34)

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -342,6 +342,12 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
       background-color: $dark-bg-color-2;
       color:$dark-text-color-1;
 
+      // Docsy styles .pageinfo with a light background only, so the light text
+      // inherited from main above would be unreadable on it.
+      .k8s-deprecation-warning {
+        background-color: $dark-bg-color-1;
+      }
+
       section:not(#video):not(#cncf) {
         background-color: $dark-bg-color-1;
         color:$dark-text-color-1;

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -346,6 +346,7 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
       // inherited from main above would be unreadable on it.
       .k8s-deprecation-warning {
         background-color: $dark-bg-color-1;
+        color: $dark-text-color-1;
       }
 
       section:not(#video):not(#cncf) {

--- a/assets/scss/_k8s_community.scss
+++ b/assets/scss/_k8s_community.scss
@@ -2,4 +2,10 @@ body.community .k8s-deprecation-warning {
   background-color: $primary;
   color: white;
   margin: 0;
+
+  // This is necessary to make anchor text readable on the blue background.
+  // The color is selected based on my(@kyu08) feeling, so it can be changed if needed.
+  a {
+    color: #93C5FD;
+  }
 }

--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -28,7 +28,7 @@
     height: 0 ;
 }
 
-.gridPage p:not(.announcement-main > p) {
+.gridPage p:not(.announcement-main > p):not(.k8s-deprecation-warning p) {
     color: rgb(255,255,255);
     margin-left: 0 !important;
     padding-left: 0 !important;


### PR DESCRIPTION
NOTE: The diff of this PR is same as https://github.com/kubernetes/website/pull/56839.

---

### Description
#### WHAT
- Currently, these are 3 readability issues exist with deprecation warnings.
- Please see the diff of corresponding commit and its message to know how I've changed and why.

| path(click to jump netlify preview) | current prod site | this PR | corresponding commit |
|---|---|---|---|
| [`/`](https://deploy-preview-56837--k8s-v1-34.netlify.app) |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 19 21@2x" src="https://github.com/user-attachments/assets/cb22d887-aa5b-497e-b2f2-6a7df5c746cc" /> |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 19 23@2x" src="https://github.com/user-attachments/assets/752b4026-68b3-4ac7-b6e5-f40bd9ef9fde" /> |8b2d5e1f, b7ec1019 |
| [`/community`](https://deploy-preview-56837--k8s-v1-34.netlify.app/community) |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 20 09@2x" src="https://github.com/user-attachments/assets/19fe5e25-2fd2-401f-bac4-8acbe8427fec" /> | <img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 20 07@2x" src="https://github.com/user-attachments/assets/c870a534-9c98-473d-b9c5-8a9c17b5612e" />| 29fabf62 |
| [`/partners`](https://deploy-preview-56837--k8s-v1-34.netlify.app/partners) |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 21 22@2x" src="https://github.com/user-attachments/assets/4d2dd476-1a9b-4114-96eb-e8a7bd4c69f8" /> |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 21 21@2x" src="https://github.com/user-attachments/assets/7cd558e6-3951-485e-a5b9-1b20d859ac55" /> | 3ea47ce3 |

#### WHY
To fix a readability issue. For more details, see #56823.

#### AI usage disclosure
- I used AI to investigate and generate initial implementation.
- I didn't use AI to:
    - Fix generated code (I did it manually)
    - Write commit messages
    - Write this PR body
- I will not use AI to response to code review comments.

### Issue
#56823

I didn't put a `Close` keyword before the issue number intentionally, because the issue needs to be fixed on these 4 branches.

- `release-1.35` https://github.com/kubernetes/website/pull/56836
- `release-1.34` (This PR)
- `release-1.33` https://github.com/kubernetes/website/pull/56838 
- `release-1.32` https://github.com/kubernetes/website/pull/56839

So, I will close the issue when the last PR is merged.
