### PR TITLE
Fix readability of deprecation warning banner of archived docs site (v1.33)

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -301,6 +301,7 @@ footer {
       // inherited from main above would be unreadable on it.
       .k8s-deprecation-warning {
         background-color: $dark-bg-color-1;
+        color: $dark-text-color-1;
       }
 
       section:not(#video):not(#cncf) {

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -297,6 +297,12 @@ footer {
       background-color: $dark-bg-color-2;
       color:$dark-text-color-1;
 
+      // Docsy styles .pageinfo with a light background only, so the light text
+      // inherited from main above would be unreadable on it.
+      .k8s-deprecation-warning {
+        background-color: $dark-bg-color-1;
+      }
+
       section:not(#video):not(#cncf) {
         background-color: $dark-bg-color-1;
         color:$dark-text-color-1;

--- a/assets/scss/_k8s_community.scss
+++ b/assets/scss/_k8s_community.scss
@@ -2,4 +2,10 @@ body.community .k8s-deprecation-warning {
   background-color: $primary;
   color: white;
   margin: 0;
+
+  // This is necessary to make anchor text readable on the blue background.
+  // The color is selected based on my(@kyu08) feeling, so it can be changed if needed.
+  a {
+    color: #93C5FD;
+  }
 }

--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -28,7 +28,7 @@
     height: 0 ;
 }
 
-.gridPage p:not(.announcement-main > p) {
+.gridPage p:not(.announcement-main > p):not(.k8s-deprecation-warning p) {
     color: rgb(255,255,255);
     margin-left: 0 !important;
     padding-left: 0 !important;


### PR DESCRIPTION
NOTE: The diff of this PR is same as https://github.com/kubernetes/website/pull/56839.

---

### Description
#### WHAT
- Currently, these are 3 readability issues exist with deprecation warnings.
- Please see the diff of corresponding commit and its message to know how I've changed and why.

| path(click to jump netlify preview) | current prod site | this PR | corresponding commit |
|---|---|---|---|
| [`/`](https://deploy-preview-56838--k8s-v1-33.netlify.app/) | <img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 11 16@2x" src="https://github.com/user-attachments/assets/27a4cb29-d0f7-4f41-bb28-1708fdd254d5" /> | <img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 11 14@2x" src="https://github.com/user-attachments/assets/e5a3dc65-c1a9-42b6-970c-b2f923d936fd" />| f2a86144, 3a082233 |
| [`/community`](https://deploy-preview-56838--k8s-v1-33.netlify.app/community) |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 12 01@2x" src="https://github.com/user-attachments/assets/25598122-cac6-47a4-9ec0-84a50f6caa98" /> | <img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 11 59@2x" src="https://github.com/user-attachments/assets/986471c3-61bf-4f36-8680-ef5d7d2baeac" />| c0290ab6 |
| [`/partners`](https://deploy-preview-56838--k8s-v1-33.netlify.app/partners) |<img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 12 30@2x" src="https://github.com/user-attachments/assets/dfc3212c-9dae-4ba5-99a4-404fe7e4e7fc" /> | <img width="2994" height="1124" alt="CleanShot 2026-08-17 at 08 12 29@2x" src="https://github.com/user-attachments/assets/77c714d9-06b0-4bf2-a34c-90500a325ebe" />| f7c50acc |


#### WHY
To fix a readability issue. For more details, see #56823.

#### AI usage disclosure
- I used AI to investigate and generate initial implementation.
- I didn't use AI to:
    - Fix generated code (I did it manually)
    - Write commit messages
    - Write this PR body
- I will not use AI to response to code review comments.

### Issue
#56823

I didn't put a `Close` keyword before the issue number intentionally, because the issue needs to be fixed on these 4 branches.

- `release-1.35` https://github.com/kubernetes/website/pull/56836
- `release-1.34` https://github.com/kubernetes/website/pull/56837
- `release-1.33` (This PR)
- `release-1.32` https://github.com/kubernetes/website/pull/56839

So, I will close the issue when the last PR is merged.

