### PR TITLE
Fix readability of deprecation warning banner of archived docs site (v1.32)

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -349,6 +349,7 @@ footer {
       // inherited from main above would be unreadable on it.
       .k8s-deprecation-warning {
         background-color: $dark-bg-color-1;
+        color: $dark-text-color-1;
       }
 
       section:not(#video):not(#cncf) {

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -345,6 +345,12 @@ footer {
       background-color: $dark-bg-color-2;
       color:$dark-text-color-1;
 
+      // Docsy styles .pageinfo with a light background only, so the light text
+      // inherited from main above would be unreadable on it.
+      .k8s-deprecation-warning {
+        background-color: $dark-bg-color-1;
+      }
+
       section:not(#video):not(#cncf) {
         background-color: $dark-bg-color-1;
         color:$dark-text-color-1;

--- a/assets/scss/_k8s_community.scss
+++ b/assets/scss/_k8s_community.scss
@@ -2,4 +2,10 @@ body.community .k8s-deprecation-warning {
   background-color: $primary;
   color: white;
   margin: 0;
+
+  // This is necessary to make anchor text readable on the blue background.
+  // The color is selected based on my(@kyu08) feeling, so it can be changed if needed.
+  a {
+    color: #93C5FD;
+  }
 }

--- a/static/css/gridpage.css
+++ b/static/css/gridpage.css
@@ -28,7 +28,7 @@
     height: 0 ;
 }
 
-.gridPage p:not(.announcement-main > p) {
+.gridPage p:not(.announcement-main > p):not(.k8s-deprecation-warning p) {
     color: rgb(255,255,255);
     margin-left: 0 !important;
     padding-left: 0 !important;


### PR DESCRIPTION
### Description
#### WHAT
- Currently, these are 3 readability issues exist with deprecation warnings.
- Please see the diff of corresponding commit and its message to know how I've changed and why.

| path(click to jump netlify preview) | current prod site | this PR | corresponding commit |
|---|---|---|---|
| [`/`](https://deploy-preview-56839--k8s-v1-32.netlify.app) | <img width="2974" height="1368" alt="Image" src="https://github.com/user-attachments/assets/d32f7247-8bae-400d-af8e-af4e6d98db8c" /> | <img width="2974" height="1368" alt="CleanShot 2026-08-09 at 09 40 13@2x" src="https://github.com/user-attachments/assets/5122584c-c22e-43d9-bd45-000a68df722c" /> | 51692b99fe1659aba6d772421899da5db4ea8215, ba8a86ad0bdbd3c8b160ed23a987b1eb62e7d71a |
| [`/community`](https://deploy-preview-56839--k8s-v1-32.netlify.app/community) | <img width="2974" height="1368" alt="CleanShot 2026-08-09 at 09 42 29@2x" src="https://github.com/user-attachments/assets/3339556b-1136-4aea-8bec-348925b2adfc" /> | <img width="2974" height="1368" alt="CleanShot 2026-08-09 at 09 41 58@2x" src="https://github.com/user-attachments/assets/e335ad8c-9cfe-4d40-8dfc-0751a25d15ad" /> |1c5a21ab6ca0 |
| [`/partners`](https://deploy-preview-56839--k8s-v1-32.netlify.app/partners) | <img width="2974" height="1368" alt="Image" src="https://github.com/user-attachments/assets/9d83eeb3-c768-4185-84ac-fea5b6fc28be" /> | <img width="2974" height="1368" alt="CleanShot 2026-08-09 at 09 43 42@2x" src="https://github.com/user-attachments/assets/e9590921-4a1d-4faf-b61c-2c04d15133e0" /> | 2efda0b7ffe8 |

#### WHY
To fix a readability issue. For more details, see #56823.

#### AI usage disclosure
- I used AI to investigate and generate initial implementation.
- I didn't use AI to:
    - Fix generated code (I did it manually)
    - Write commit messages
    - Write this PR body
- I will not use AI to response to code review comments.

### Issue
#56823

I didn't put a `Close` keyword before the issue number intentionally, because the issue needs to be fixed on these 4 branches.

- `release-1.35` https://github.com/kubernetes/website/pull/56836
- `release-1.34` https://github.com/kubernetes/website/pull/56837
- `release-1.33` https://github.com/kubernetes/website/pull/56838
- `release-1.32` (This PR)

So, I will close the issue when the last PR is merged.
