### PR TITLE
docs: fix broken in-page anchor links for none/static CPU policy sections

### DIFF
--- a/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
+++ b/content/en/docs/tasks/administer-cluster/cpu-management-policies.md
@@ -65,8 +65,8 @@ The CPU Manager policy is set with the `--cpu-manager-policy` kubelet
 flag or the `cpuManagerPolicy` field in [KubeletConfiguration](/docs/reference/config-api/kubelet-config.v1beta1/).
 There are two supported policies:
 
-* [`none`](#none-policy): the default policy.
-* [`static`](#static-policy): allows pods with certain resource characteristics to be
+* [`none`](#none-policy-configuration): the default policy.
+* [`static`](#static-policy-configuration): allows pods with certain resource characteristics to be
   granted increased CPU affinity and exclusivity on the node.
 
 The CPU manager periodically writes resource updates through the CRI in


### PR DESCRIPTION
The intro bullets link to #none-policy and #static-policy, but the actual
headings further down are '### `none` policy configuration' and
'### `static` policy configuration'. Hugo/Goldmark auto-generates their
anchor IDs as #none-policy-configuration and #static-policy-configuration
(backticks are stripped, spaces become hyphens, 'configuration' is part of
the slug), so the shorter anchors #none-policy and #static-policy never
existed and the links were silently broken.

Updated the two bullets to use the correct auto-generated anchor slugs.
This also makes them consistent with the existing external link in
pod-qos.md, which already correctly uses #static-policy-configuration.