### PR TITLE
[ja] Fix broken url which shows example of `translator` field in content/ja/docs/contribute/localization.md

### DIFF
--- a/content/ja/docs/contribute/localization.md
+++ b/content/ja/docs/contribute/localization.md
@@ -81,7 +81,7 @@ card:
   - 見出しIDは、英語ページでの見出しのパーマリンクを確認して、URLの`#`以降を使用する
 - ブログ記事については、次のことに留意する
   - メタデータの`evergreen: true`は削除する
-  - PR作成者とレビュアーは、以下の形式で翻訳者として名前を掲載できる([サンプル](https://github.com/kubernetes/website/blob/main/content/ja/blog/_posts/2025-04-23-Kubernetes-v1-33-Release/index.md?plain=1))
+  - PR作成者とレビュアーは、以下の形式で翻訳者として名前を掲載できる([サンプル](https://github.com/kubernetes/website/blob/main/content/ja/blog/_posts/2025/kubernetes-v1-33-release/index.md?plain=1))
     ```
     translator: >
       [PR作成者の名前](GitHubのURL) ([所属](所属のURL)),


### PR DESCRIPTION
### Description
- WHAT
	- Update broken url
- WHY
	- The url was broken

### Tets plan
- [x] Confirmed the url is fixed in deployed preview site: https://deploy-preview-56875--kubernetes-io-main-staging.netlify.app/ja/docs/contribute/localization/#style-guide

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #56874