### PR TITLE
docs: fix broken in-page anchor link in authorization.md

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authorization.md
+++ b/content/en/docs/reference/access-authn-authz/authorization.md
@@ -355,7 +355,7 @@ or deny a request.
 
 You cannot combine the `--authorization-mode` command line argument with the
 `--authorization-config` command line argument used for
-[configuring authorization using a local file](#using-configuration-file-for-authorization-mode).
+[configuring authorization using a local file](#using-configuration-file-for-authorization).
 
 For more information on command line arguments to the API server, read the
 [`kube-apiserver` reference](/docs/reference/command-line-tools-reference/kube-apiserver/).


### PR DESCRIPTION
The link at line 358 pointed to #using-configuration-file-for-authorization-mode
(with a trailing '-mode'), but the actual heading uses the explicit anchor
{#using-configuration-file-for-authorization} (without '-mode'). The same
correct anchor is already used in line 171 of the same file and in
feature-gates/AuthorizeWithSelectors.md, making this the only outlier.