### PR TITLE
docs: fix broken idempotence anchor link in extensible-admission-controllers.md

### DIFF
--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -972,7 +972,7 @@ webhooks:
   reinvocationPolicy: IfNeeded
 ```
 
-Mutating webhooks must be [idempotent](#idempotence), able to successfully process an object they have already admitted
+Mutating webhooks must be [idempotent](/docs/concepts/cluster-administration/admission-webhooks-good-practices/#ensure-mutating-webhook-idempotent), able to successfully process an object they have already admitted
 and potentially modified. This is true for all mutating admission webhooks, since any change they can make
 in an object could already exist in the user-provided object, but it is essential for webhooks that opt into reinvocation.
 


### PR DESCRIPTION
The link at line 975 pointed to #idempotence, a same-page anchor that does
not exist anywhere in the file. The idempotence guidance lives in the
admission-webhooks-good-practices.md page (already linked from the
'Best practices and warnings' section at the bottom of the same file),
under the explicit anchor {#ensure-mutating-webhook-idempotent}.
Updated the link to point to the correct cross-page URL.