### PR TITLE
Align CompositePodGroup docs with the style guide

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/gang-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/gang-scheduling.md
@@ -50,20 +50,20 @@ The process follows these steps for each PodGroup:
    Instead, they are moved to the unschedulable queue to wait for cluster resources to free up,
    allowing other workloads to be scheduled in the meantime.
 
-## Hierarchical gang scheduling with CompositePodGroups
+## Hierarchical gang scheduling with CompositePodGroup objects
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
 When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
-are enabled, gang scheduling extends its support to `CompositePodGroups`.
+are enabled, gang scheduling extends its support to CompositePodGroup objects.
 
-Contrary to `PodGroups` that group Pods, `CompositePodGroups` group child groups together - either
-`PodGroups` or other `CompositePodGroups`. `CompositePodGroup` specifies a scheduling policy that
-applies to its child groups during scheduling:
+Unlike PodGroup objects, which group Pods, CompositePodGroup objects group child groups together,
+either PodGroup objects or other CompositePodGroup objects. A CompositePodGroup specifies a
+scheduling policy that applies to its child groups during scheduling:
 
 * `gang` policy with a `minGroupCount` field, specifying the minimum number of child groups (either
-  `CompositePodGroup` or `PodGroup` objects) that must be scheduled together as a single unit
+  CompositePodGroup or PodGroup objects) that must be scheduled together as a single unit
   atomically.
 * `basic` policy which indicates that child groups can be scheduled independently.
 
@@ -72,39 +72,39 @@ multiple child groups, ensuring that a minimum number of child groups are schedu
 example workload with such needs is replicated AI training.
 
 `basic` policy can be used for workloads that comprise multiple groups of Pods each of which can be
-scheduled as an independent gang, e.g. for AI inference workloads.
+scheduled as an independent gang, for example for AI inference workloads.
 
 ### Hierarchical quorum
 
-The `GangScheduling` plugin holds the root `CompositePodGroup` from entering the active scheduling
+The `GangScheduling` plugin holds the root CompositePodGroup from entering the active scheduling
 queue in the `PreEnqueue` phase until it satisfies the **hierarchical quorum**. This quorum is
-evaluated bottom-up, from leaf `PodGroup` objects up to the root `CompositePodGroup`:
+evaluated bottom-up, from leaf PodGroup objects up to the root CompositePodGroup:
 
-- A leaf `PodGroup` **satisfies quorum** if and only if the `PodGroup` object exists and can
+- A leaf PodGroup **satisfies quorum** if and only if the PodGroup object exists and can
   potentially meet its scheduling policy criteria:
   - For a `gang` policy: at least `minCount` of its constituent Pods have been created.
   - For a `basic` policy: at least one of its constituent Pods has been created.
-- A `CompositePodGroup` **satisfies quorum** if and only if the `CompositePodGroup` object exists
+- A CompositePodGroup **satisfies quorum** if and only if the CompositePodGroup object exists
   and can potentially meet its scheduling policy criteria:
   - For a `gang` policy: at least `minGroupCount` of its direct child groups satisfy quorum.
   - For a `basic` policy: at least one of its direct child groups satisfies quorum.
-- The overall **hierarchical quorum** is satisfied if and only if the root `CompositePodGroup`
+- The overall **hierarchical quorum** is satisfied if and only if the root CompositePodGroup
   satisfies the quorum.
 
-Ultimately, a root `CompositePodGroup` is admitted into the active scheduling queue if and only if
+Ultimately, a root CompositePodGroup is admitted into the active scheduling queue if and only if
 it satisfies the hierarchical quorum and there is at least one pending Pod that belongs to one of
-its descendant `PodGroups`.
+its descendant PodGroup objects.
 
 ### Placement feasibility
 
 The `GangScheduling` plugin's `PlacementFeasible` method supports evaluation for both
-`PodGroups` and `CompositePodGroups`. It is invoked by the scheduling cycle before starting child
-evaluation and after evaluating each child group of a `CompositePodGroup`.
+PodGroup and CompositePodGroup objects. It is invoked by the scheduling cycle before starting child
+evaluation and after evaluating each child group of a CompositePodGroup.
 
 By taking into account the number of child groups that were successfully scheduled and the child
 groups that were not evaluated in the scheduling cycle just yet, `PlacementFeasible` determines
 whether the group's policy constraint is still achievable, allowing the scheduling cycle to abort
-the evaluation of the `CompositePodGroup` early if its underlying scheduling policy cannot be
+the evaluation of the CompositePodGroup early if its underlying scheduling policy cannot be
 satisfied anymore.
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
@@ -49,24 +49,24 @@ and initiates the PodGroup scheduling cycle as follows:
    is applied atomically for the entire PodGroup.
 
    * **Success:** If the scheduler finds sufficient resources and valid placements for the Pods
-     (e.g., satisfying the `minCount` constraint for [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)),
+     (for example, satisfying the `minCount` constraint for [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)),
      those Pods proceed directly to the binding cycle with their selected nodes.
      Any remaining unschedulable Pods in the group are requeued directly into the active scheduling queue without backoff, retaining their previous timestamp so they are re-evaluated immediately to attempt preemption.
-     
+
      Furthermore, if new Pods are added to a PodGroup after others have already been scheduled,
      the cycle evaluates the new Pods while accounting for the existing ones.
 
    * **Failure:** If the scheduler cannot find enough resources to make the PodGroup feasible
-     (e.g., failing to meet the `minCount` constraint), the entire PodGroup is considered unschedulable.
-     
+     (for example, failing to meet the `minCount` constraint), the entire PodGroup is considered unschedulable.
+
      The scheduler attempts to make a PodGroup schedulable by running the `PodGroupPostFilter` extension point.
-     The `DefaultPreemption` plugin's `PodGroupPostFilter` extenion point runs
-     [workload aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/).
-     If any plugin implementing `PodGroupPostFilter`extension point returns `Success`, no more
+     The `DefaultPreemption` plugin's `PodGroupPostFilter` extension point runs
+     [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/).
+     If any plugin implementing the `PodGroupPostFilter` extension point returns `Success`, no more
      plugins for `PodGroupPostFilter` extension point are run.
-     
-     Even when `PodGroupPostFilter` plugin returns a `Success`, no Pods are bound, but instead,
-     all are returned to the scheduling queue, hoping that the actions taken by `PodGroupPostFilter`
+
+     Even when a `PodGroupPostFilter` plugin returns `Success`, no Pods are bound. Instead,
+     all Pods are returned to the scheduling queue so that the actions taken by `PodGroupPostFilter`
      make a PodGroup schedulable in the next scheduling cycle. Standard scheduling backoff logic applies,
      allowing the PodGroup to be retried later.
 
@@ -85,7 +85,7 @@ It iterates over the Pods and performs the following for each:
      Instead it relies on `PodGroupPostFilter` extension point executed for the whole PodGroup.
 
 2. Checks whether the schedulable Pods meet the group's scheduling criteria
-   (e.g., the `minCount` for [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)) by invoking the `PlacementFeasible` extension point after evaluating each Pod in the group against the cumulative scheduling results.
+   (for example, the `minCount` for [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/)) by invoking the `PlacementFeasible` extension point after evaluating each Pod in the group against the cumulative scheduling results.
    If it returns a `Success` status for any Pod, the PodGroup is deemed feasible.
    If the algorithm processes all Pods without achieving a `Success` status, or if no Pods are scheduled during this cycle, the PodGroup is considered unschedulable.
 
@@ -94,7 +94,7 @@ It iterates over the Pods and performs the following for each:
 
 Placement scheduling algorithm is an alternative PodGroup scheduling algorithm, which uses
 [scheduling plugins](/docs/reference/scheduling/config/#scheduling-plugins) to find the optimal
-placement for the considered PodGroup. Users can accommodate the algorithm to their specific needs
+placement for a PodGroup. You can adapt the algorithm to your specific needs
 by using and configuring plugins.
 
 The algorithm proceeds in three main phases for a given PodGroup:
@@ -123,7 +123,7 @@ This phase executes as extension point: `PlacementScorePlugin`.
 The PodGroup scheduling algorithm relies on specific Pod sorting and may fail to find a valid placement
 that could have been discovered by processing the group's Pods in a different order. In particular:
 
-* For basic **homogeneous** Pod groups (i.e., those where all Pods have identical scheduling requirements
+* For basic **homogeneous** Pod groups (that is, those where all Pods have identical scheduling requirements
   and lack inter-Pod dependencies like affinity, anti-affinity, or topology spread constraints),
   the algorithm is expected to find a placement if one exists.
 
@@ -132,14 +132,14 @@ that could have been discovered by processing the group's Pods in a different or
 * For Pod groups with **inter-Pod dependencies**, finding a valid placement is not guaranteed.
 
 In addition to the above, for cases involving **intra-group dependencies**
-(e.g., when the schedulability of one Pod depends on another group member via inter-Pod affinity),
+(for example, when the schedulability of one Pod depends on another group member via inter-Pod affinity),
 this algorithm may fail to find a placement regardless of cluster state due to its deterministic processing order.
 
 For consistent behavior throughout the entire cycle, the algorithm requires that all Pods belonging to a single PodGroup
 share the same `.spec.schedulerName`. This requirement is validated before the cycle starts,
 and the PodGroup is rejected if the constraint is not met.
 
-## Hierarchical scheduling with CompositePodGroups
+## Hierarchical scheduling with CompositePodGroup objects
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
@@ -148,43 +148,43 @@ feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API
 are enabled, the scheduler extends the PodGroup scheduling cycle to support multi-level group
 hierarchies.
 
-In a hierarchical workload, Pods belong to leaf `PodGroup` objects, which in turn specify parent
-`CompositePodGroup` resources up to the root `CompositePodGroup`. The scheduler evaluates the entire
+In a hierarchical workload, Pods belong to leaf PodGroup objects, which in turn specify parent
+CompositePodGroup resources up to the root CompositePodGroup. The scheduler evaluates the entire
 hierarchy of groups as a single, unified scheduling unit.
 
 ### Hierarchical scheduling cycle execution
 
-After observing a root `CompositePodGroup`, the scheduler places it in the scheduling queue as long
+After observing a root CompositePodGroup, the scheduler places it in the scheduling queue as long
 as there is at least one pending Pod that belongs to that root's group hierarchy.
 
-Once the root `CompositePodGroup` satisfies the
-[hierarchical quorum](/docs/concepts/scheduling-eviction/gang-scheduling/#Hierarchical-quorum), it
+Once the root CompositePodGroup satisfies the
+[hierarchical quorum](/docs/concepts/scheduling-eviction/gang-scheduling/#hierarchical-quorum), it
 enters the active scheduling queue from which it can be popped by the scheduling cycle. The flow of
-the scheduling cycle for `CompositePodGroups` is as follows:
+the scheduling cycle for CompositePodGroup objects is as follows:
 
 1. **Unified cluster snapshot and validation**: The scheduler takes a snapshot of cluster resources
    to mirror the latest observed cluster state. It verifies that the shape of the group hierarchy
    popped from the queue matches the snapshotted hierarchy and validates the configuration
    consistency of the hierarchy (such as identical `.spec.schedulerName` and priority across member
    Pods).
-   
+
    If the hierarchy shape changed concurrently or fails the validation, the cycle halts and requeues
-   the root `CompositePodGroup`.
+   the root CompositePodGroup.
 
 2. **Top-down candidate placement generation**: At each level of the hierarchy, before evaluating
    child groups, the scheduler invokes `PlacementGeneratePlugin` plugins to generate candidate
    placements (subsets of nodes) for the group being evaluated.
-   
-   Candidate placements for a child `CompositePodGroup` or leaf `PodGroup` are generated exclusively
+
+   Candidate placements for a child CompositePodGroup or leaf PodGroup are generated exclusively
    from the subset of nodes belonging to the parent group's currently evaluated placement. For the
-   root `CompositePodGroup`, candidate placements are generated across all available cluster nodes.
+   root CompositePodGroup, candidate placements are generated across all available cluster nodes.
 
 3. **Recursive subtree simulation and feasibility check**: The scheduler evaluates each candidate
-   placement for a `CompositePodGroup` by temporarily assuming that placement in the cluster
+   placement for a CompositePodGroup by temporarily assuming that placement in the cluster
    snapshot and recursively scheduling its child groups:
    * **Recursive traversal**: The scheduler traverses child groups in a pre-sorted order, invoking
-     itself recursively from the `CompositePodGroup` down to leaf `PodGroup` objects. For each leaf
-     `PodGroup`, the scheduler runs the placement scheduling algorithm scoped to the parent's
+     itself recursively from the CompositePodGroup down to leaf PodGroup objects. For each leaf
+     PodGroup, the scheduler runs the placement scheduling algorithm scoped to the parent's
      candidate placement to make tentative Pod assignments in memory.
    * **Feasibility checks**: After evaluating each child group, the scheduler invokes
      `PlacementFeasible` plugins to determine whether the parent group's scheduling policy can
@@ -192,42 +192,42 @@ the scheduling cycle for `CompositePodGroups` is as follows:
      * If the policy constraints remain achievable (or are already satisfied), the scheduler continues
        evaluating subsequent sibling groups.
      * If the policy constraints can no longer be satisfied, the scheduler immediately aborts the evaluation
-       of that `CompositePodGroup` and reverts all tentative in-memory Pod assignments made for that group.
+       of that CompositePodGroup and reverts all tentative in-memory Pod assignments made for that group.
    * **Simulation rollback**: After simulating a candidate placement (regardless of success or failure),
      the scheduler reverts the tentative node reservations made during that simulation before
      evaluating the next candidate placement.
 
 4. **Placement scoring and subtree commitment**: Once all candidate placements for a
-   `CompositePodGroup` have been evaluated:
+   CompositePodGroup have been evaluated:
    * **Scoring**: If one or more candidate placements are feasible, the scheduler invokes
      `PlacementScorePlugin` plugins to score all feasible candidate placements. The scoring plugins
-     evaluate the combined proposed Pod assignments across all descendant leaf `PodGroup` objects in
+     evaluate the combined proposed Pod assignments across all descendant leaf PodGroup objects in
      the subtree and select the placement with the highest overall score.
    * **Commitment**: After selecting the winning placement, the scheduler commits (assumes) the
      tentative Pod assignments corresponding to that optimal placement in memory. This ensures that
      subsequent sibling group evaluations or parent-level evaluations observe consistent, optimal
      scheduling decisions for that subtree.
-     
-     If no feasible placement is found among all generated candidates, the entire `CompositePodGroup`
+
+     If no feasible placement is found among all generated candidates, the entire CompositePodGroup
      is considered unschedulable.
 
 5. **Atomic binding**: If the root-level recursive evaluation succeeds and at least one Pod was
    successfully scheduled, the scheduler commits the Pod assignments by proceeding to the binding
    cycle.
 
-   Otherwise, the entire `CompositePodGroup` is considered unschedulable.
+   Otherwise, the entire CompositePodGroup is considered unschedulable.
 
 ### Limitations
 
 Similar to how the PodGroup scheduling algorithm relies on specific Pod sorting, the hierarchical
-scheduling algorithm relies on a specific sorting of child groups within every `CompositePodGroup`
+scheduling algorithm relies on a specific sorting of child groups within every CompositePodGroup
 hierarchy. As a result, it may fail to find a valid placement that could have been discovered by
 processing the child groups in a different order.
 
 In addition, because the scheduler evaluates group hierarchies using a greedy approach:
 
 * Finding a valid placement is not guaranteed in all cases, even if one exists in the cluster.
-* Even when the scheduler successfully finds a valid placement for a `CompositePodGroup` hierarchy,
+* Even when the scheduler successfully finds a valid placement for a CompositePodGroup hierarchy,
   that placement is not guaranteed to be optimal across the cluster.
 
 ## PodGroup conditions
@@ -272,5 +272,5 @@ In v1.37, the scheduler does not populate this field, however.
 * Learn about the [Workload API](/docs/concepts/workloads/workload-api/).
 * Read about the [CompositePodGroup API](/docs/concepts/workloads/compositepodgroup-api/) and its [lifecycle](/docs/concepts/workloads/compositepodgroup-api/lifecycle/).
 * Learn about [Topology-aware workload scheduling](/docs/concepts/workloads/workload-api/topology-aware-scheduling/).
-* See how to [reference a Workload](/docs/concepts/workloads/pods/workload-reference/) in a Pod.
+* See how to [specify a scheduling group](/docs/concepts/workloads/pods/scheduling-group/) for a Pod.
 * Read about [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/).

--- a/content/en/docs/concepts/scheduling-eviction/topology-aware-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-aware-scheduling.md
@@ -8,9 +8,9 @@ weight: 10
 {{< feature-state feature_gate_name="TopologyAwareWorkloadScheduling" >}}
 
 *Topology-Aware Scheduling* (TAS) is a [placement scheduling algorithm](/docs/concepts/scheduling-eviction/podgroup-scheduling/#placement-scheduling-algorithm)
-that allows finding the optimal placement for the considered PodGroup, guaranteeing that all pods
-will be collocated within the same topology domain. Users can adapt TAS to their specific
-needs by changing TAS plugins configuration.
+that finds the optimal placement for a PodGroup, ensuring that all Pods are co-located within the
+same topology domain. You can adapt TAS to your specific
+needs by changing the TAS plugin configuration.
 
 ## Scheduling framework: TAS plugins configuration
 
@@ -27,13 +27,13 @@ utilization within a placement, and it inherits resource weights from the standa
 plugin settings.
 
 *   `PodGroupPodsCount`: Implements the `PlacementScorePlugin` interface. It scores candidate
-placements based on the total number of pods in the PodGroup that you can successfully schedule. 
+placements based on the total number of pods in the PodGroup that you can successfully schedule.
 
 ### Customizing plugin weights and bin-packing resource weights
 
 By default, the `NodeResourcesFit` and `PodGroupPodsCount` plugins are configured with equal
 weights (both default to 1) to maintain a good balance between bin-packing logic and scheduling as
-many pods as possible. 
+many pods as possible.
 
 You can adjust these weights, or the resource weights in the bin-packing strategy in your
 KubeSchedulerConfiguration. Here is an example snippet showing how to change the weights for both
@@ -77,18 +77,18 @@ profiles:
 When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
 are enabled, the Topology-Aware Scheduling plugins extend their support to multi-level
-`CompositePodGroup` hierarchies. These plugins are called for `CompositePodGroups` during
+CompositePodGroup hierarchies. These plugins are called for CompositePodGroup objects during
 [hierarchical scheduling](/docs/concepts/scheduling-eviction/podgroup-scheduling).
 
 ### Candidate placement generation
 
-For workloads defined with a `CompositePodGroup` hierarchy, the `TopologyPlacement` plugin generates
+For workloads defined with a CompositePodGroup hierarchy, the `TopologyPlacement` plugin generates
 candidate placements top-down across the group hierarchy by successive subdivision:
 
-* For a root `CompositePodGroup`, `TopologyPlacement` generates candidate placements across all
+* For a root CompositePodGroup, `TopologyPlacement` generates candidate placements across all
   available cluster nodes by grouping nodes based on the distinct values of the requested topology
   `key`.
-* For a child `CompositePodGroup` or leaf `PodGroup`, `TopologyPlacement` generates candidate
+* For a child CompositePodGroup or leaf PodGroup, `TopologyPlacement` generates candidate
   placements confined in the placement assumed by the parent group. It subdivides the set of nodes
   from the parent group's placement by grouping those nodes based on the child group's requested
   topology `key`.
@@ -99,21 +99,21 @@ candidate placement equivalent to the parent placement.
 
 Similarly, if the root group does not specify any topology constraint, the plugin generates a single
 candidate placement corresponding to all available nodes in the cluster. This is also true for
-single-level workloads using the `PodGroup` API where no topology constraint is specified.
+single-level workloads using the PodGroup API where no topology constraint is specified.
 {{< /note >}}
 
 ### Placement scoring
 
-When scoring a candidate placement for a `CompositePodGroup`, the scoring plugins apply similar
-logic to the single-level `PodGroup` case:
+When scoring a candidate placement for a CompositePodGroup, the scoring plugins apply similar
+logic to the single-level PodGroup case:
 
 * `PodGroupPodsCount`: Scores candidate placements based on the total number of Pods (both
-  already scheduled and newly assumed) across all descendant leaf `PodGroups` of that
-  `CompositePodGroup`. Candidate placements capable of accommodating a higher total number of Pods
-  across the subhierarchy receive higher scores.
+  already scheduled and newly assumed) across all descendant leaf PodGroup objects of that
+  CompositePodGroup. Candidate placements capable of accommodating a higher total number of Pods
+  across the subtree receive higher scores.
 * `NodeResourcesFit`: Aggregates the resource requests of all proposed Pods across all descendant
-  `PodGroups` of that `CompositePodGroup` and evaluates resource utilization across all nodes within
-  the candidate placement's domain.
+  PodGroup objects of that CompositePodGroup and evaluates resource utilization across all nodes
+  within the candidate placement's domain.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/scheduling-eviction/workload-aware-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/workload-aware-preemption.md
@@ -55,21 +55,21 @@ with a few differences:
    [priority and disruption mode](/docs/concepts/workloads/workload-api/disruption-and-priority/) of a PodGroup
    to evaluate if and how its pods can be preempted during preemption events.
 
-4. Performance and optimality considerations: For the performance reasons,
-   the workload-aware preemption first simulates removal all potential victims and 
-   runs the scheduling once. It then tries to reprieve as many victims as possible
-   for selected placement. This trade off means that there may exists an alternative placement
-   causing less preemptions, but it is not selected by the scheduler due to performance reasons.
+4. Performance and optimality considerations: For performance reasons,
+   workload-aware preemption first simulates the removal of all potential victims and
+   runs scheduling once. It then tries to reprieve as many victims as possible
+   for the selected placement. This trade-off means that there might be an alternative placement
+   that causes fewer preemptions, but the scheduler does not select it due to performance reasons.
 
 {{< note >}}
 When scheduling a single Pod, the default pod preemption applies.
 In v1.36, when the scheduler performs a default preemption for a single Pod
 and it attempts to preempt a Pod belonging to a PodGroup, it does **not**
-respect the `priority` or `disruptionMode` fields of that PodGroup. 
+respect the `priority` or `disruptionMode` fields of that PodGroup.
 This limitation no longer applies in v1.37.
 {{< /note >}}
 
-### Reprieval algorithm
+### Reprieve algorithm
 
 When running workload-aware preemption, the scheduler runs the simulation where it removes potential preemption victims
 and runs the pod group scheduling algorithm. It then tries to reprieve as many victims as possible for returned placement.
@@ -86,38 +86,38 @@ If for each pod, the Filtering passes, the victim pods are kept on their nodes.
 If filtering fails for at least one pod, victim pods are removed from CycleStates and node.
 
 In both cases the scheduler preemptor pods are removed from their nodes and their Unreserve is called,
-so the next reprieval attempt can validate scheduling of PodGroup. The scheduler then proceeds with
+so the next reprieve attempt can validate scheduling of PodGroup. The scheduler then proceeds with
 another potential victim until all victims are processed.
 
-### Preemption for CompositePodGroups
+### Preemption for CompositePodGroup objects
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
 When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
-are enabled, workload-aware preemption provides support for `CompositePodGroups` as well.
+are enabled, workload-aware preemption provides support for CompositePodGroup objects as well.
 
-The underlying preemption mechanism is the same as for `PodGroups` - if the scheduler needs to free
-up capacity to place the root `CompositePodGroup`, it evaluates preemption for the entire group
+The underlying preemption mechanism is the same as for PodGroup objects: if the scheduler needs to
+free up capacity to place the root CompositePodGroup, it evaluates preemption for the entire group
 hierarchy, rather than for individual pods.
 
-`CompositePodGroups` can be selected as preemption victims as well. The victim selection process is
-adjusted to take `CompositePodGroups` into account in the following way:
+CompositePodGroup objects can be selected as preemption victims as well. The victim selection
+process is adjusted to take CompositePodGroup objects into account in the following way:
 
 1. Victim importance hierarchy:
-   - `CompositePodGroups` are considered more important than standalone `PodGroups` of the same
+   - CompositePodGroup objects are considered more important than standalone PodGroup objects of the same
      priority.
-   - For two `CompositePodGroups` of the same priority, the one with more members (larger size) is
+   - For two CompositePodGroup objects of the same priority, the one with more members (larger size) is
      considered more important.
 
-2. Disruption mode: Similar to `PodGroups`, `CompositePodGroups` specify
+2. Disruption mode: Similar to PodGroup objects, CompositePodGroup objects specify a
    [disruption mode](/docs/concepts/workloads/workload-api/disruption-and-priority/) that determines
-   how its child groups should be treated during preemption.
+   how their child groups should be treated during preemption.
 
-Besides workload-aware preemption, `CompositePodGroups` can be selected as preemption victims by
-default Pod preemption during Pod scheduling cycle, alongside `PodGroups` and Pods. Default Pod
+Besides workload-aware preemption, CompositePodGroup objects can be selected as preemption victims by
+default Pod preemption during the Pod scheduling cycle, alongside PodGroup objects and Pods. Default Pod
 preemption shares the victim importance hierarchy logic with the workload-aware preemption and
-respects the `disruptionMode` field of `CompositePodGroups`.
+respects the `disruptionMode` field of CompositePodGroup objects.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/workloads/compositepodgroup-api/_index.md
+++ b/content/en/docs/concepts/workloads/compositepodgroup-api/_index.md
@@ -7,38 +7,38 @@ no_list: true
 <!-- overview -->
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-A `CompositePodGroup` is a runtime object that represents a non-leaf node in a multi-level workload
+A CompositePodGroup is a runtime object that represents a non-leaf node in a multi-level workload
 hierarchy. While the [Workload API](/docs/concepts/workloads/workload-api/) defines static scheduling
-policy templates, `CompositePodGroup` and `PodGroup` objects are the runtime counterparts that
+policy templates, CompositePodGroup and PodGroup objects are the runtime counterparts that
 carry policies and hierarchy references for a specific workload instance.
 
 <!-- body -->
 
 ## What is a CompositePodGroup?
 
-The `CompositePodGroup` API resource is part of the `scheduling.k8s.io/v1alpha3`
+The CompositePodGroup API resource is part of the `scheduling.k8s.io/v1alpha3`
 {{< glossary_tooltip text="API group" term_id="api-group" >}}. Your cluster must have that API
 group enabled, as well as the `CompositePodGroup`
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
 before you can use this API.
 
-A `CompositePodGroup` represents a grouping of child groups (which can be `CompositePodGroup` or
-`PodGroup` objects). It carries scheduling policies, disruption modes, priority
+A CompositePodGroup represents a grouping of child groups (which can be CompositePodGroup or
+PodGroup objects). It carries scheduling policies, disruption modes, priority
 settings, and optional topology constraints that apply collectively across its child groups.
 
 ## API structure
 
-A `CompositePodGroup` consists of a `spec` that defines the desired scheduling behavior
+A CompositePodGroup consists of a `spec` that defines the desired scheduling behavior
 for its child groups, and a `status` subresource.
 
 ### Scheduling policy
 
-Each `CompositePodGroup` carries a [scheduling policy](/docs/concepts/workloads/workload-api/policies/)
+Each CompositePodGroup carries a [scheduling policy](/docs/concepts/workloads/workload-api/policies/)
 (`basic` or `gang`) in `spec.schedulingPolicy`. When a workload controller creates a
-`CompositePodGroup`, this policy is copied from the `Workload`'s `CompositePodGroupTemplate`
+CompositePodGroup, this policy is copied from the Workload's CompositePodGroupTemplate
 at creation time.
 
-For a `gang` policy on a `CompositePodGroup`, the `minGroupCount` field specifies the
+For a `gang` policy on a CompositePodGroup, the `minGroupCount` field specifies the
 minimum number of child groups that must be schedulable simultaneously:
 
 ```yaml
@@ -50,8 +50,8 @@ spec:
 
 ### Parent group reference
 
-Non-root `CompositePodGroup` resources specify their parent group using
-`spec.parentCompositePodGroupName`. Root `CompositePodGroup` objects leave this field unset.
+Non-root CompositePodGroup resources specify their parent group using
+`spec.parentCompositePodGroupName`. Root CompositePodGroup objects leave this field unset.
 
 ```yaml
 spec:
@@ -60,8 +60,8 @@ spec:
 
 ### Workload reference
 
-The `spec.workloadRef` field links the `CompositePodGroup` back to the
-`CompositePodGroupTemplate` in the `Workload` object it was derived from.
+The `spec.workloadRef` field links the CompositePodGroup back to the
+CompositePodGroupTemplate in the Workload object it was derived from.
 
 ```yaml
 spec:
@@ -72,17 +72,17 @@ spec:
 
 ### Status
 
-The `CompositePodGroup` API schema includes a `status` subresource. In the alpha release,
+The CompositePodGroup API schema includes a `status` subresource. In the alpha release,
 the `status` field is present in the API type, but `kube-scheduler` does not update or
-populate status conditions for `CompositePodGroup` objects. Status tracking for composite
-groups will be implemented in future releases.
+populate status conditions for CompositePodGroup objects. Status tracking for composite
+groups is not implemented in this release.
 
 ## Creating a CompositePodGroup
 
-Workload controllers create `CompositePodGroup` objects automatically from `Workload`
+Workload controllers create CompositePodGroup objects automatically from Workload
 templates at runtime.
 
-The following manifest creates a root `CompositePodGroup` with a gang scheduling policy
+The following manifest creates a root CompositePodGroup with a gang scheduling policy
 that requires at least 2 child groups to be schedulable simultaneously:
 
 ```yaml
@@ -100,7 +100,7 @@ spec:
       minGroupCount: 2
 ```
 
-You can inspect `CompositePodGroup` resources in your cluster:
+You can inspect CompositePodGroup resources in your cluster:
 
 ```shell
 kubectl get compositepodgroups
@@ -117,11 +117,11 @@ kubectl describe compositepodgroup root-group-0
 The relationship between controllers, Workloads, CompositePodGroups, PodGroups, and
 Pods follows this pattern:
 
-1. The workload controller creates a `Workload` defining a tree of
-   `CompositePodGroupTemplates` and leaf `PodGroupTemplates`.
-2. For each runtime instance, the controller creates a root `CompositePodGroup`,
-   descendant `CompositePodGroup` objects, and leaf `PodGroup` objects in a top-down manner.
-3. The controller creates `Pods` that reference their leaf `PodGroup` via
+1. The workload controller creates a Workload defining a tree of
+   CompositePodGroupTemplate and leaf PodGroupTemplate objects.
+2. For each runtime instance, the controller creates a root CompositePodGroup,
+   descendant CompositePodGroup objects, and leaf PodGroup objects in a top-down manner.
+3. The controller creates Pods that reference their leaf PodGroup via
    `spec.schedulingGroup.podGroupName`.
 
 The following example illustrates a complete manifest hierarchy for a two-level workload:
@@ -202,8 +202,8 @@ spec:
     image: registry.k8s.io/pause:3.9
 ```
 
-The `Workload` acts as a long-lived policy template, while `CompositePodGroup` and
-`PodGroup` resources handle per-instance runtime scheduling state.
+The Workload acts as a long-lived policy template, while CompositePodGroup and
+PodGroup resources handle per-instance runtime scheduling state.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
+++ b/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
@@ -7,10 +7,10 @@ weight: 10
 <!-- overview -->
 {{< feature-state feature_gate_name="GenericWorkload" >}}
 
-PodGroup can declare a disruption mode. This mode dictates how
+A PodGroup can declare a disruption mode. This mode dictates how
 the scheduler can disrupt a running PodGroup, for example to accommodate
 a higher priority PodGroup. A PodGroup also has a priority,
-which overrides the priority of the individual pods from the group
+which overrides the priority of the individual Pods from the group
 for [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) events.
 
 <!-- body -->
@@ -18,7 +18,7 @@ for [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-awar
 ## Disruption mode types
 
 {{< note >}}
-In v1.36, the `priority` or `disruptionMode` fields of the PodGroup are only respected
+In v1.36, the `priority` and `disruptionMode` fields of the PodGroup are only respected
 by [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/).
 During the pod scheduling phase, the scheduler does not take into account
 the `priority` or `disruptionMode` fields of the PodGroup. This limitation no longer
@@ -31,26 +31,26 @@ The default one is `Single`.
 ### Single
 
 The `Single` mode instructs the scheduler to treat all Pods in the group as separate entities,
-allowing independent disruption of a single pod from a PodGroup.
+allowing independent disruption of a single Pod from a PodGroup.
 
 ### All
 
 The `All` mode emphasizes "all-or-nothing" semantics for disruption.
-It instructs the scheduler that all pods from the PodGroup have to be disrupted together.
+It instructs the scheduler that all Pods from the PodGroup have to be disrupted together.
 
 ## CompositePodGroup
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-A `CompositePodGroup` can also declare a `disruptionMode` in its specification, which controls
+A CompositePodGroup can also declare a `disruptionMode` in its specification, which controls
 how the scheduler disrupts child groups within the composite group during preemption events.
 
-The API supports two disruption modes for `CompositePodGroups`:
+The API supports two disruption modes for CompositePodGroup objects:
 
-- **`Single`**: Allows individual child groups within the `CompositePodGroup` to be disrupted
+- **`Single`**: Allows individual child groups within the CompositePodGroup to be disrupted
   independently during preemption.
-- **`All`**: Enforces all-or-nothing disruption semantics across the `CompositePodGroup` hierarchy.
-  If any Pod contained in the hierarchy below this `CompositePodGroup` has to be preempted, all of
+- **`All`**: Enforces all-or-nothing disruption semantics across the CompositePodGroup hierarchy.
+  If any Pod contained in the hierarchy below this CompositePodGroup has to be preempted, all of
   the Pods from the entire hierarchy must be preempted.
 
 If not specified, the mode defaults to `Single`.
@@ -64,27 +64,27 @@ This configuration is discouraged due to unclear semantics.
 
 ## Pod group priority
 
-PodGroup uses the same concept of [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) as single Pods.
+A PodGroup uses the same concept of [PriorityClass](/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) as individual Pods.
 Once you have created one or more PriorityClasses,
 you can create a PodGroup that specifies one of those PriorityClass names in its specification.
 The priority admission controller uses the `priorityClassName` field and populates the integer value of the priority.
 If the priority class is not found, the PodGroup is rejected.
-When `priorityClassName` is not set for a PodGroup, Kubernetes looks for a default (a PriorityClass with `globalDefault` set true)
+When `priorityClassName` is not set for a PodGroup, Kubernetes looks for a default (a PriorityClass with `globalDefault` set to true).
 If there is no PriorityClass with `globalDefault` set true, a PodGroup with no `priorityClassName` has priority zero.
 
 The priority of the PodGroup is an authoritative priority for all pods in the group during [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) events.
 This value is also used for the ordering of PodGroups in the scheduling queue.
-When the priorities of individual pods forming this PodGroup differ from PodGroup priority
+When the priorities of individual Pods forming this PodGroup differ from the PodGroup priority,
 the PodGroup will not be scheduled with `all pods in a single pod group should have the same priority as the pod group` error.
 
 When the [PodGroupPreemptionPolicy](/docs/reference/command-line-tools-reference/feature-gates/podgroup-preemption-policy/)
-feature gate is enabled, PodGroup has also `preemptionPolicy` field. This field is also taken from the PriorirtyClass.
-It is an authoratitive field for all pods in the group and it decides whether the PodGroup can perform a preemption of
-lower priority pods and pod groups to accomodate a place for itself.  When the feature gate is enabled all pods in the PodGroup
+feature gate is enabled, a PodGroup also has a `preemptionPolicy` field. This field is also taken from the PriorityClass.
+It is an authoritative field for all Pods in the group, and it decides whether the PodGroup can preempt
+lower priority Pods and PodGroup objects to make room for itself. When the feature gate is enabled, all Pods in the PodGroup
 must have the same `preemptionPolicy` as PodGroup. Otherwise the PodGroup will not be scheduled with
 `all pods in a single pod group should have the same preemption policy as the pod group's preemption policy` error.
-When PodGroup has `preemptionPolicy: Never` it will not perform workload aware preemption.
-If the feature flag is disabled, all pods forming PodGroup must have the same `preemptionPolicy`.
+When a PodGroup has `preemptionPolicy: Never`, it does not perform workload-aware preemption.
+If the feature gate is disabled, all Pods forming a PodGroup must have the same `preemptionPolicy`.
 Otherwise the PodGroup will not be scheduled with
 `all pods in a single pod group should have the same preemption policy` error.
 
@@ -106,46 +106,45 @@ spec:
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-`CompositePodGroup` API has `priorityClassName` and `priority` fields as well and their resolution
-is performed in the same way as for the `PodGroups`, through the priority admission controller.
+The CompositePodGroup API has `priorityClassName` and `priority` fields as well, and their resolution
+is performed in the same way as for PodGroup objects, through the priority admission controller.
 
-The priority of a root `CompositePodGroup` acts as the authoritative priority for all child groups
+The priority of a root CompositePodGroup acts as the authoritative priority for all child groups
 and Pods within its hierarchy during
 [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) events.
 All Pods within a single group hierarchy must share the exact same priority and must be equal to the
-priority of the root `CompositePodGroup`.
+priority of the root CompositePodGroup.
 
-The value of priority is also used for the ordering of root `CompositePodGroups` in the scheduling
-active queue.
+The priority value is also used to order root CompositePodGroup objects in the active scheduling queue.
 
 {{< note >}}
-In v1.37, the scheduler doesn't validate if the non-root groups have priority value that is equal to
-the priority of the root `CompositePodGroup`.
+In v1.37, the scheduler does not validate whether non-root groups have a priority value equal to the
+priority of the root CompositePodGroup.
 {{< /note >}}
 
-### PreemptionPolicy in CompositePodGroup
+### Preemption policy for CompositePodGroup
 
 {{< feature-state feature_gate_name="PodGroupPreemptionPolicy" >}}
 
-The `CompositePodGroup` API has the `preemptionPolicy` field as well and its resolution is performed
-in the exact same way as for the `PodGroup` API.
+The CompositePodGroup API has the `preemptionPolicy` field as well, and its resolution is performed
+in the exact same way as for the PodGroup API.
 
-The value of `preemptionPolicy` of the root `CompositePodGroup` determines whether
+The value of `preemptionPolicy` of the root CompositePodGroup determines whether
 [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) can be
 invoked to fit its Pods during scheduling if needed:
 
-- `PreemptLowerPriority` policy allows preempting victims with lower priority,
-- `Never` policy disables workload-aware preemption for that root `CompositePodGroup`.
+- `PreemptLowerPriority` policy allows preempting victims with lower priority.
+- `Never` policy disables workload-aware preemption for that root CompositePodGroup.
 
 All Pods within a single group hierarchy must share the exact same preemption policy which must be
-equal to the preemption policy of the root `CompositePodGroup`.
+equal to the preemption policy of the root CompositePodGroup.
 
-If the feature flag is disabled, the root `CompositePodGroup` will be allowed to perform preemption
+If the feature gate is disabled, the root CompositePodGroup can perform preemption
 unless one of the Pods that belongs to the group hierarchy has `preemptionPolicy` set to `Never`.
 
 {{< note >}}
-In v1.37, when the feature gate is enabled, the scheduler doesn't validate if the non-root groups
-have preemption policy that is equal to the preemption policy of the root `CompositePodGroup`.
+In v1.37, when the feature gate is enabled, the scheduler does not validate whether non-root groups
+have a preemption policy equal to the preemption policy of the root CompositePodGroup.
 {{< /note >}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/workloads/workload-api/policies.md
+++ b/content/en/docs/concepts/workloads/workload-api/policies.md
@@ -59,34 +59,34 @@ schedulingPolicy:
 ## Setting policies via PodGroupTemplates
 
 When using the [Workload API](/docs/concepts/workloads/workload-api/), you define scheduling
-policies inside `PodGroupTemplates`. The workload controller copies the policy from the
+policies inside PodGroupTemplate objects. The workload controller copies the policy from the
 template into each PodGroup it creates, making the PodGroup self-contained. Changes to the
 Workload's templates only affect newly created PodGroups, not existing ones.
 
 For standalone PodGroups (created without a Workload), you set `spec.schedulingPolicy`
 directly on the PodGroup itself.
 
-## Policies in CompositePodGroups
+## Policies in CompositePodGroup objects
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
 When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
-are enabled, `CompositePodGroupTemplates` in a Workload and the `CompositePodGroup` objects also
+are enabled, CompositePodGroupTemplate objects in a Workload and the CompositePodGroup objects also
 declare a scheduling policy.
 
-While a scheduling policy in a `PodGroup` governs a collection of individual Pods, a
-`CompositePodGroup` scheduling policy governs its direct **child groups** (which can be both
-`CompositePodGroup` and `PodGroup` objects).
+While a scheduling policy in a PodGroup governs a collection of individual Pods, a
+CompositePodGroup scheduling policy governs its direct **child groups** (which can be both
+CompositePodGroup and PodGroup objects).
 
-### Policy types for CompositePodGroups
+### Policy types for CompositePodGroup objects
 
-Similar to `PodGroups`, the `spec.schedulingPolicy` field of a `CompositePodGroup` supports two
+Similar to PodGroup objects, the `spec.schedulingPolicy` field of a CompositePodGroup supports two
 types:
 
-- **`basic`**: Child groups within the `CompositePodGroup` are evaluated and admitted independently.
+- **`basic`**: Child groups within the CompositePodGroup are evaluated and admitted independently.
 - **`gang`**: Enforces multi-level all-or-nothing scheduling across child groups. The
-  `CompositePodGroup` is schedulable only if at least `minGroupCount` child groups can be scheduled
+  CompositePodGroup is schedulable only if at least `minGroupCount` child groups can be scheduled
   simultaneously.
 
 ```yaml
@@ -100,10 +100,10 @@ schedulingPolicy:
 ### Setting composite policies via templates
 
 When using the [Workload API](/docs/concepts/workloads/workload-api/), scheduling policies for
-`CompositePodGroups` are defined inside `CompositePodGroupTemplates`. Workload controllers copy the
-`schedulingPolicy` specified in the templates into each `CompositePodGroup` created at runtime.
-Unlike leaf `PodGroupTemplates` where `minCount` can be updated, `minGroupCount` in a
-`CompositePodGroupTemplate` is immutable.
+CompositePodGroup objects are defined inside CompositePodGroupTemplate objects. Workload controllers
+copy the `schedulingPolicy` specified in the templates into each CompositePodGroup created at runtime.
+Unlike leaf PodGroupTemplate objects where `minCount` can be updated, `minGroupCount` in a
+CompositePodGroupTemplate is immutable.
 
 ## {{% heading "whatsnext" %}}
 


### PR DESCRIPTION
### Description

Align the v1.37 CompositePodGroup documentation with the Kubernetes style guide.

- Use normal text, rather than code formatting, for API object and type names.
- Clarify nearby wording and remove spelling and whitespace issues.
- Repair the outdated scheduling-group documentation link.

Validation:
- YAML front matter and CommonMark parsing for all seven files
- Hugo shortcode and fenced-code balance checks
- misspell v0.3.4
- internal documentation targets checked against the dev-1.37 Git tree
- git diff --check

This was submitted by an AI agent and has not been checked by a human

### Issue

Closes: #56893