### PR TITLE
[ja] Translate content/en/docs/reference/glossary/qos-class.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/qos-class.md
+++ b/content/ja/docs/reference/glossary/qos-class.md
@@ -17,6 +17,6 @@ related:
 QoSクラス(Quality of Serviceクラス)は、Kubernetesがクラスター内のPodをいくつかのクラスに分類し、スケジューリングと退避に関する決定を行う方法を提供します。
 
 <!--more-->
-PodのQoSクラスは、そのインフラストラクチャ{{< glossary_tooltip text="リソース" term_id="infrastructure-resource" >}}の要求と制限の設定に基づいて、作成時に設定されます。
+PodのQoSクラスは、その{{< glossary_tooltip text="インフラストラクチャリソース" term_id="infrastructure-resource" >}}の要求と制限の設定に基づいて、作成時に設定されます。
 QoSクラスは、Podのスケジューリングと退避に関する決定を行うために使用されます。
 Kubernetesは、Podに`Guaranteed`、`Burstable`、`BestEffort`のいずれかのQoSクラスを割り当てます。

--- a/content/ja/docs/reference/glossary/qos-class.md
+++ b/content/ja/docs/reference/glossary/qos-class.md
@@ -1,0 +1,22 @@
+---
+title: QoSクラス
+id: qos-class
+full_link: /docs/concepts/workloads/pods/pod-qos/
+short_description: >
+  QoSクラス(Quality of Serviceクラス)は、Kubernetesがクラスター内のPodをいくつかのクラスに分類し、スケジューリングと退避に関する決定を行う方法を提供します。
+
+aka:
+tags:
+- fundamental
+- architecture
+related:
+ - pod
+
+---
+
+QoSクラス(Quality of Serviceクラス)は、Kubernetesがクラスター内のPodをいくつかのクラスに分類し、スケジューリングと退避に関する決定を行う方法を提供します。
+
+<!--more-->
+PodのQoSクラスは、そのインフラストラクチャ{{< glossary_tooltip text="リソース" term_id="infrastructure-resource" >}}の要求と制限の設定に基づいて、作成時に設定されます。
+QoSクラスは、Podのスケジューリングと退避に関する決定を行うために使用されます。
+Kubernetesは、Podに`Guaranteed`、`Burstable`、`BestEffort`のいずれかのQoSクラスを割り当てます。


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/qos-class.md` into Japanese: `content/ja/docs/reference/glossary/qos-class.md`.

Terminology follows the Japanese pages that already cover this concept — `QoSクラス`, `退避`, `スケジューリング`, `要求と制限`, and the class names `Guaranteed` / `Burstable` / `BestEffort` left as-is (see `content/ja/docs/concepts/workloads/pods/pod-qos.md`). `full_link` carries no `/ja` prefix, per the localization style guide. The `infrastructure resource` tooltip links only `リソース`, matching the existing usage in `content/ja/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md` and `content/ja/docs/reference/glossary/pod-disruption.md`; that term is not translated yet (#56854), so it falls back to the English entry, which builds fine.

Checked with a local Hugo 0.144.2 build: the three Japanese pages referencing this term via `glossary_tooltip` — `pod-qos.md`, `pod-priority-preemption.md` and `swap-memory-management.md` — now show the Japanese definition instead of falling back to the English one.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?all=true#term-qos-class

This PR was written in part with the assistance of generative AI. The Japanese wording and every terminology choice were checked against the existing Japanese pages and the localization style guide before submitting, and the rendered output was verified locally.

### Issue

Closes: #56850

/area localization
/language ja
