### PR TITLE
remove recommendation to add cluster-admin rights to the default service account in kube-system

### DIFF
--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -1116,22 +1116,6 @@ In order from most secure to least secure, the approaches are:
      --namespace=my-namespace
    ```
 
-   Many [add-ons](/docs/concepts/cluster-administration/addons/) run as the
-   "default" service account in the `kube-system` namespace.
-   To allow those add-ons to run with super-user access, grant cluster-admin
-   permissions to the "default" service account in the `kube-system` namespace.
-
-   {{< caution >}}
-   Enabling this means the `kube-system` namespace contains Secrets
-   that grant super-user access to your cluster's API.
-   {{< /caution >}}
-
-   ```shell
-   kubectl create clusterrolebinding add-on-cluster-admin \
-     --clusterrole=cluster-admin \
-     --serviceaccount=kube-system:default
-   ```
-
 3. Grant a role to all service accounts in a namespace
 
    If you want all applications in a namespace to have a role, no matter what service account they use,


### PR DESCRIPTION
### Description

Following a discussion at last week's SIG-Security, this change modifies the ServiceAccount permissions section of the RBAC documentation, to remove a recommendation that `cluster-admin` rights are bound to the `default` service account in the `kube-system` namespace. 

Granting of `cluster-admin` to applications running in Kubernetes is not recommended from a security standpoint as all applications should only be provided with the least privilege rights needed to achieve their function. Any add-ons for Kubernetes clusters should ship with manifests detailing their required rights and a specific named service account for their operation.


Also removes an outdated note in that section related to secret creation for service accounts which hasn't been the case since the TokenRequest changes went live some years back.
