### PR TITLE
docs: use https for json-schema.org in CRD reference

### DIFF
--- a/content/en/docs/reference/kubernetes-api/apiextensions/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/apiextensions/custom-resource-definition-v1.md
@@ -437,7 +437,7 @@ JSON represents any valid JSON value. These types are supported: bool, int64, fl
 
 ## JSONSchemaProps {#JSONSchemaProps}
 
-JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+JSONSchemaProps is a JSON-Schema following Specification Draft 4 (https://json-schema.org/).
 
 <hr>
 


### PR DESCRIPTION
The CRD v1 reference still points at http://json-schema.org/. Switched it to https.

Related to #53971 (the broken-paren case may already be fixed; this is the remaining http→https cleanup on that string).