### PR TITLE
[pl] Fix typo in documentation page title

### DIFF
--- a/content/pl/docs/concepts/overview/working-with-objects/_index.md
+++ b/content/pl/docs/concepts/overview/working-with-objects/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Objekty w Kubernetesie
+title: Obiekty w Kubernetesie
 content_type: concept
 weight: 30
 description: >


### PR DESCRIPTION
### Description
Fixes a typo in the title of the Polish documentation page.
