### PR TITLE
docs: note random probe delay after kubelet start

### DIFF
--- a/content/en/docs/concepts/workloads/pods/probes.md
+++ b/content/en/docs/concepts/workloads/pods/probes.md
@@ -250,6 +250,11 @@ spec:
 `periodSeconds`
 : How often (in seconds) to perform the probe. Default to 10 seconds. The minimum value is 1. While a container is not Ready, the readiness probe may be executed at times other than the configured `periodSeconds` interval. This is to make the Pod ready faster.
 
+  When the kubelet starts (or restarts), each probe worker waits a random delay
+  of up to one `periodSeconds` before the first probe run. That stagger avoids
+  thundering-herd probe traffic right after kubelet comes up. It is separate
+  from `initialDelaySeconds`, which always applies after the container starts.
+
 `timeoutSeconds`
 : Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
 

--- a/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md
@@ -32,7 +32,14 @@ In this exercise, you create a Pod that runs a container based on the
 In the configuration file, you can see that the Pod has a single `Container`.
 The `periodSeconds` field specifies that the kubelet should perform a liveness
 probe every 5 seconds. The `initialDelaySeconds` field tells the kubelet that it
-should wait 5 seconds before performing the first probe. To perform a probe, the
+should wait 5 seconds before performing the first probe.
+
+{{< note >}}
+When the kubelet starts or restarts, each probe worker also waits a **random**
+delay of up to one `periodSeconds` before its first probe run. That stagger is
+separate from `initialDelaySeconds` and avoids many probes firing at once after
+kubelet comes up.
+{{< /note >}} To perform a probe, the
 kubelet executes the command `cat /tmp/healthy` in the target container. If the
 command succeeds, it returns 0, and the kubelet considers the container to be alive and
 healthy. If the command returns a non-zero value, the kubelet kills the container


### PR DESCRIPTION
Kubelet staggers the first probe for each worker by a random wait of up to `periodSeconds` when kubelet has just started, so probes don't all fire at once after a restart.

That behavior is easy to miss next to `initialDelaySeconds`. Documented it on the probes concept page and the configure-probes task page.

Related to #52218

---
This PR was written in part with the assistance of generative AI.