### PR TITLE
docs: use priorityClassName for static Pod eviction priority

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -360,10 +360,18 @@ then the kubelet must choose to evict one of these pods to preserve node stabili
 and to limit the impact of resource starvation on other pods. In this case, it
 will choose to evict pods of lowest Priority first.
 
-If you are running a [static pod](/docs/concepts/workloads/pods/#static-pods)
-and want to avoid having it evicted under resource pressure, set the
-`priority` field for that Pod directly. Static pods do not support the
-`priorityClassName` field.
+If you are running a [static pod](/docs/concepts/workloads/pods/static-pods/)
+and want to avoid having it evicted under resource pressure, set
+`priorityClassName` in the static Pod manifest (for example
+`system-node-critical` or `system-cluster-critical`). The kubelet resolves the
+class to a numeric priority for local eviction decisions.
+
+Do **not** set the integer `priority` field yourself. The Priority admission
+plugin rejects mirror Pods that supply a numeric priority; only
+`priorityClassName` is the supported way to raise priority for static Pods.
+
+See [Pod Priority and Preemption](/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+for how PriorityClasses work.
 
 When the kubelet evicts pods in response to inode or process ID starvation, it uses
 the Pods' relative priority to determine the eviction order, because inodes and PIDs have no

--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -362,9 +362,11 @@ will choose to evict pods of lowest Priority first.
 
 If you are running a [static pod](/docs/concepts/workloads/pods/static-pods/)
 and want to avoid having it evicted under resource pressure, set
-`priorityClassName` in the static Pod manifest (for example
-`system-node-critical` or `system-cluster-critical`). The kubelet resolves the
-class to a numeric priority for local eviction decisions.
+`priorityClassName` in the static Pod manifest to any PriorityClass that
+exists in the cluster. The kubelet resolves that name to a numeric priority
+for local eviction decisions. The built-in `system-node-critical` and
+`system-cluster-critical` classes are the usual way to stay above ordinary
+workloads.
 
 Do **not** set the integer `priority` field yourself. The Priority admission
 plugin rejects mirror Pods that supply a numeric priority; only

--- a/content/en/docs/concepts/workloads/pods/static-pods.md
+++ b/content/en/docs/concepts/workloads/pods/static-pods.md
@@ -51,6 +51,11 @@ such as {{< glossary_tooltip text="ServiceAccount" term_id="service-account" >}}
 
 Static Pods do not support [ephemeral containers](/docs/concepts/workloads/pods/ephemeral-containers/).
 
+To influence kubelet eviction under node resource pressure, set
+`priorityClassName` on the static Pod manifest. Do not set the integer
+`priority` field (mirror Pods reject a bare priority value). See
+[node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction).
+
 ## Static Pods vs DaemonSets {#static-pods-vs-daemonsets}
 
 <!-- Source: tasks/configure-pod-container/static-pod/ -->

--- a/content/en/docs/concepts/workloads/pods/static-pods.md
+++ b/content/en/docs/concepts/workloads/pods/static-pods.md
@@ -52,7 +52,8 @@ such as {{< glossary_tooltip text="ServiceAccount" term_id="service-account" >}}
 Static Pods do not support [ephemeral containers](/docs/concepts/workloads/pods/ephemeral-containers/).
 
 To influence kubelet eviction under node resource pressure, set
-`priorityClassName` on the static Pod manifest. Do not set the integer
+`priorityClassName` on the static Pod manifest to a PriorityClass that exists
+in the cluster (not only the built-in system classes). Do not set the integer
 `priority` field (mirror Pods reject a bare priority value). See
 [node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction).
 


### PR DESCRIPTION
The node-pressure eviction page told people to set integer `priority` and that static Pods do not support `priorityClassName`. Mirror Pods reject a bare priority value; set `priorityClassName` instead. Also noted this on the static Pods concept page.

Fixes #46859

---
This PR was written in part with the assistance of generative AI.