### PR TITLE
docs: note kubectl label uses equals for PSA labels

### DIFF
--- a/content/en/docs/concepts/security/pod-security-admission.md
+++ b/content/en/docs/concepts/security/pod-security-admission.md
@@ -75,6 +75,13 @@ pod-security.kubernetes.io/<MODE>: <LEVEL>
 pod-security.kubernetes.io/<MODE>-version: <VERSION>
 ```
 
+Those snippets are **namespace labels in YAML** form (`key: value`). If you set the
+same labels with `kubectl label`, use `key=value` instead, for example:
+
+```shell
+kubectl label namespace my-namespace pod-security.kubernetes.io/enforce=baseline
+```
+
 Check out [Enforce Pod Security Standards with Namespace Labels](/docs/tasks/configure-pod-container/enforce-standards-namespace-labels) to see example usage.
 
 ## Workload resources and Pod templates


### PR DESCRIPTION
The PSA concept page only showed YAML `key: value` labels. People pasting that into `kubectl label` hit syntax errors. Clarified YAML vs `key=value` for kubectl.

Fixes #56332

---
This PR was written in part with the assistance of generative AI.