### PR TITLE
docs: fix broken json-schema.org link in CRD API ref

### DIFF
--- a/content/en/docs/reference/kubernetes-api/apiextensions/custom-resource-definition-v1.md
+++ b/content/en/docs/reference/kubernetes-api/apiextensions/custom-resource-definition-v1.md
@@ -437,7 +437,7 @@ JSON represents any valid JSON value. These types are supported: bool, int64, fl
 
 ## JSONSchemaProps {#JSONSchemaProps}
 
-JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+JSONSchemaProps is a JSON-Schema following Specification Draft 4 ([https://json-schema.org/](https://json-schema.org/)).
 
 <hr>
 


### PR DESCRIPTION
The JSONSchemaProps description used `(http://json-schema.org/).`, which auto-linked with the trailing `)` stuck in the href.

Switched to an explicit https markdown link.

Fixes #53971

Note: this page is auto-generated from the Go API comments; the same wording still lives upstream in `types_jsonschema.go` and would need a follow-up there to stick across regenerations.

---
This PR was written in part with the assistance of generative AI.