### PR TITLE
docs: caution that Weave Net and Romana are unmaintained

### DIFF
--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/_index.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/_index.md
@@ -2,3 +2,7 @@
 title: Install a Network Policy Provider
 weight: 50
 ---
+
+Some NetworkPolicy providers listed under this section are no longer
+maintained. Check each provider page for a caution before installing.
+

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/romana-network-policy.md
@@ -8,6 +8,15 @@ weight: 50
 
 <!-- overview -->
 
+{{< caution >}}
+Romana is no longer actively maintained. Prefer an actively maintained
+NetworkPolicy provider such as
+[Antrea](/docs/tasks/administer-cluster/network-policy-provider/antrea-network-policy/),
+[Calico](/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy/),
+[Cilium](/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/),
+or [Kube-router](/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy/).
+{{< /caution >}}
+
 This page shows how to use Romana for NetworkPolicy.
 
 ## {{% heading "prerequisites" %}}

--- a/content/en/docs/tasks/administer-cluster/network-policy-provider/weave-network-policy.md
+++ b/content/en/docs/tasks/administer-cluster/network-policy-provider/weave-network-policy.md
@@ -8,6 +8,15 @@ weight: 60
 
 <!-- overview -->
 
+{{< caution >}}
+Weave Net is [archived](https://github.com/weaveworks/weave) and no longer
+maintained. Prefer an actively maintained NetworkPolicy provider such as
+[Antrea](/docs/tasks/administer-cluster/network-policy-provider/antrea-network-policy/),
+[Calico](/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy/),
+[Cilium](/docs/tasks/administer-cluster/network-policy-provider/cilium-network-policy/),
+or [Kube-router](/docs/tasks/administer-cluster/network-policy-provider/kube-router-network-policy/).
+{{< /caution >}}
+
 This page shows how to use Weave Net for NetworkPolicy.
 
 ## {{% heading "prerequisites" %}}


### PR DESCRIPTION
The Network Policy Provider section still presents Weave Net and Romana alongside actively maintained options. Weave Net is archived; Romana has not been updated in years.

This adds a short caution on those two pages (and a one-liner on the section index) pointing readers at Antrea / Calico / Cilium / Kube-router instead of deleting the historical pages.

Fixes #56735