### PR TITLE
Update for deprecation of kube-dns

### DIFF
--- a/content/en/docs/concepts/configuration/manage-resources-containers.md
+++ b/content/en/docs/concepts/configuration/manage-resources-containers.md
@@ -611,7 +611,7 @@ Non-terminated Pods:        (5 in total)
   Namespace    Name                                  CPU Requests  CPU Limits  Memory Requests  Memory Limits
   ---------    ----                                  ------------  ----------  ---------------  -------------
   kube-system  fluentd-gcp-v1.38-28bv1               100m (5%)     0 (0%)      200Mi (2%)       200Mi (2%)
-  kube-system  kube-dns-3297075139-61lj3             260m (13%)    0 (0%)      100Mi (1%)       170Mi (2%)
+  kube-system  coredns-3297075139-61lj3              260m (13%)    0 (0%)      100Mi (1%)       170Mi (2%)
   kube-system  kube-proxy-e2e-test-...               100m (5%)     0 (0%)      0 (0%)           0 (0%)
   kube-system  monitoring-influxdb-grafana-v4-z1m12  200m (10%)    200m (10%)  600Mi (8%)       600Mi (8%)
   kube-system  node-problem-detector-v0.1-fj7m3      20m (1%)      200m (10%)  20Mi (0%)        100Mi (1%)

--- a/content/en/docs/reference/access-authn-authz/rbac.md
+++ b/content/en/docs/reference/access-authn-authz/rbac.md
@@ -774,7 +774,7 @@ This is commonly used by add-on API servers for unified authentication and autho
 <tr>
 <td><b>system:kube-dns</b></td>
 <td><b>kube-dns</b> service account in the <b>kube-system</b> namespace</td>
-<td>Role for the <a href="/docs/concepts/services-networking/dns-pod-service/">kube-dns</a> component.</td>
+<td>Role for the deprecated kube-dns component. (<a href="/docs/concepts/services-networking/dns-pod-service/">CoreDNS</a> does not use this role.)</td>
 </tr>
 <tr>
 <td><b>system:kubelet-api-admin</b></td>

--- a/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
+++ b/content/en/docs/reference/kubectl/docker-cli-to-kubectl.md
@@ -360,7 +360,7 @@ kubectl cluster-info
 ```
 ```
 Kubernetes master is running at https://203.0.113.141
-KubeDNS is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/kube-dns/proxy
+CoreDNS is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/kube-dns/proxy
 kubernetes-dashboard is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy
 Grafana is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy
 Heapster is running at https://203.0.113.141/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy

--- a/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/implementation-details.md
@@ -544,9 +544,6 @@ addon.
 
 - The `coredns` ServiceAccount is bound to the privileges in the `system:coredns` ClusterRole
 
-In Kubernetes version 1.21, support for using `kube-dns` with kubeadm was removed.
-You can use CoreDNS with kubeadm even when the related Service is named `kube-dns`.
-
 ## kubeadm join phases internal design
 
 Similarly to `kubeadm init`, also `kubeadm join` internal workflow consists of a sequence of

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -65,12 +65,7 @@ following steps:
    See [kubeadm join](/docs/reference/setup-tools/kubeadm/kubeadm-join/) for additional information.
 
 1. Installs a DNS server (CoreDNS) and the kube-proxy addon components via the API server.
-   In Kubernetes version 1.11 and later CoreDNS is the default DNS server.
    Please note that although the DNS server is deployed, it will not be scheduled until CNI is installed.
-
-   {{< warning >}}
-   kube-dns usage with kubeadm is deprecated as of v1.18 and is removed in v1.21.
-   {{< /warning >}}
 
 ### Using init phases with kubeadm {#init-phases}
 

--- a/content/en/docs/tasks/access-application-cluster/access-cluster-services.md
+++ b/content/en/docs/tasks/access-application-cluster/access-cluster-services.md
@@ -65,7 +65,7 @@ The output is similar to this:
 Kubernetes master is running at https://192.0.2.1
 elasticsearch-logging is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/elasticsearch-logging/proxy
 kibana-logging is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/kibana-logging/proxy
-kube-dns is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/kube-dns/proxy
+coredns is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/kube-dns/proxy
 grafana is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy
 heapster is running at https://192.0.2.1/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy
 ```

--- a/content/en/docs/tasks/administer-cluster/coredns.md
+++ b/content/en/docs/tasks/administer-cluster/coredns.md
@@ -8,7 +8,7 @@ weight: 380
 ---
 
 <!-- overview -->
-This page describes the CoreDNS upgrade process and how to install CoreDNS instead of kube-dns.
+This page describes the CoreDNS upgrade process and how to install CoreDNS.
 
 
 ## {{% heading "prerequisites" %}}
@@ -21,31 +21,14 @@ This page describes the CoreDNS upgrade process and how to install CoreDNS inste
 ## About CoreDNS
 
 [CoreDNS](https://coredns.io) is a flexible, extensible DNS server
-that can serve as the Kubernetes cluster DNS.
+that is the default implementation of Kubernetes cluster DNS.
 Like Kubernetes, the CoreDNS project is hosted by the
 {{< glossary_tooltip text="CNCF" term_id="cncf" >}}.
 
-You can use CoreDNS instead of kube-dns in your cluster by replacing
-kube-dns in an existing deployment, or by using tools like kubeadm
-that will deploy and upgrade the cluster for you.
-
 ## Installing CoreDNS
 
-For manual deployment or replacement of kube-dns, see the documentation at the
+For manual deployment, see the documentation at the
 [CoreDNS website](https://coredns.io/manual/installation/).
-
-## Migrating to CoreDNS
-
-### Upgrading an existing cluster with kubeadm
-
-In Kubernetes version 1.21, kubeadm removed its support for `kube-dns` as a DNS application.
-For `kubeadm` v{{< skew currentVersion >}}, the only supported cluster DNS application
-is CoreDNS.
-
-You can move to CoreDNS when you use `kubeadm` to upgrade a cluster that is
-using `kube-dns`. In this case, `kubeadm` generates the CoreDNS configuration
-("Corefile") based upon the `kube-dns` ConfigMap, preserving configurations for
-stub domains, and upstream name server.
 
 ## Upgrading CoreDNS
 
@@ -72,8 +55,8 @@ configuration of CoreDNS. For more details, check out the
 
 ## {{% heading "whatsnext" %}}
 
-You can configure [CoreDNS](https://coredns.io) to support many more use cases than
-kube-dns does by modifying the CoreDNS configuration ("Corefile").
+You can configure [CoreDNS](https://coredns.io) to support many use cases beyond
+basic service name resolution by modifying the CoreDNS configuration ("Corefile").
 For more information, see the [documentation](https://coredns.io/plugins/kubernetes/)
 for the `kubernetes` CoreDNS plugin, or read the 
 [Custom DNS Entries for Kubernetes](https://coredns.io/2017/05/08/custom-dns-entries-for-kubernetes/).

--- a/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
+++ b/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
@@ -15,8 +15,7 @@ This page provides hints on diagnosing DNS problems.
 
 {{< include "task-tutorial-prereqs.md" >}}  
 Your cluster must be configured to use the CoreDNS
-{{< glossary_tooltip text="addon" term_id="addons" >}} or its precursor,
-kube-dns.  
+{{< glossary_tooltip text="addon" term_id="addons" >}}.
 
 {{% version-check %}}
 
@@ -84,7 +83,7 @@ nameserver 10.0.0.10
 options ndots:5
 ```
 
-Errors such as the following indicate a problem with the CoreDNS (or kube-dns)
+Errors such as the following indicate a problem with the CoreDNS
 add-on or with associated Services:
 
 ```shell
@@ -125,7 +124,8 @@ coredns-7b96bf9f76-mvmmt   1/1       Running   0           1h
 ```
 
 {{< note >}}
-The value for label `k8s-app` is `kube-dns` for both CoreDNS and kube-dns deployments.
+The value for label `k8s-app` for CoreDNS is `kube-dns`, for backward
+compatibility with the original kube-dns.
 {{< /note >}}
 
 
@@ -170,7 +170,8 @@ kube-dns     ClusterIP   10.0.0.10      <none>        53/UDP,53/TCP        1h
 ```
 
 {{< note >}}
-The service name is `kube-dns` for both CoreDNS and kube-dns deployments.
+The Service for CoreDNS is named `kube-dns`, for backward compatibility with the
+original kube-dns.
 {{< /note >}}
 
 
@@ -190,7 +191,7 @@ kubectl get endpointslice -l kubernetes.io/service-name=kube-dns --namespace=kub
 ```
 ```
 NAME             ADDRESSTYPE   PORTS   ENDPOINTS                  AGE
-kube-dns-zxoja   IPv4          53      10.180.3.17,10.180.3.17    1h
+coredns-zxoja    IPv4          53      10.180.3.17,10.180.3.17    1h
 ```
 
 If you do not see the endpoints, see the endpoints section in the

--- a/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
+++ b/content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md
@@ -63,7 +63,7 @@ If you don't see a Deployment for DNS services, you can also look for it by name
 kubectl get deployment --namespace=kube-system
 ```
 
-and look for a deployment named `coredns` or `kube-dns`.
+and look for a deployment named `coredns`.
 
 
 Your scale target is

--- a/content/en/docs/tasks/administer-cluster/nodelocaldns.md
+++ b/content/en/docs/tasks/administer-cluster/nodelocaldns.md
@@ -24,24 +24,24 @@ This page provides an overview of NodeLocal DNSCache feature in Kubernetes.
 
 NodeLocal DNSCache improves Cluster DNS performance by running a DNS caching agent
 on cluster nodes as a DaemonSet. In today's architecture, Pods in 'ClusterFirst' DNS mode
-reach out to a kube-dns `serviceIP` for DNS queries. This is translated to a
-kube-dns/CoreDNS endpoint via iptables rules added by kube-proxy.
+normally reach out to a CoreDNS `clusterIP` for DNS queries. This is translated to a
+CoreDNS endpoint by kube-proxy.
 With this new architecture, Pods will reach out to the DNS caching agent
-running on the same node, thereby avoiding iptables DNAT rules and connection tracking.
-The local caching agent will query kube-dns service for cache misses of cluster
+running on the same node, thereby avoiding DNAT rules and connection tracking.
+The local caching agent will query the CoreDNS service for cache misses of cluster
 hostnames ("`cluster.local`" suffix by default).
 
 ## Motivation
 
 * With the current DNS architecture, it is possible that Pods with the highest DNS QPS
-  have to reach out to a different node, if there is no local kube-dns/CoreDNS instance.
+  have to reach out to a different node, if there is no local CoreDNS instance.
   Having a local cache will help improve the latency in such scenarios.
 
 * Skipping iptables DNAT and connection tracking will help reduce
   [conntrack races](https://github.com/kubernetes/kubernetes/issues/56903)
   and avoid UDP DNS entries filling up conntrack table.
 
-* Connections from the local caching agent to kube-dns service can be upgraded to TCP.
+* Connections from the local caching agent to the CoreDNS service can be upgraded to TCP.
   TCP conntrack entries will be removed on connection close in contrast with
   UDP entries that have to timeout
   ([default](https://www.kernel.org/doc/Documentation/networking/nf_conntrack-sysctl.txt)
@@ -53,7 +53,7 @@ hostnames ("`cluster.local`" suffix by default).
 
 * Metrics & visibility into DNS requests at a node level.
 
-* Negative caching can be re-enabled, thereby reducing the number of queries for the kube-dns service.
+* Negative caching can be re-enabled, thereby reducing the number of queries for the CoreDNS service.
 
 ## Architecture Diagram
 
@@ -87,7 +87,8 @@ This feature can be enabled using the following steps:
 * Substitute the variables in the manifest with the right values:
 
   ```shell
-  kubedns=`kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}`
+  # For historical reasons, the Service for CoreDNS is called "kube-dns"
+  coredns=`kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}`
   domain=<cluster-domain>
   localdns=<node-local-address>
   ```
@@ -98,22 +99,22 @@ This feature can be enabled using the following steps:
   * If kube-proxy is running in IPTABLES mode:
 
     ``` bash
-    sed -i "s/__PILLAR__LOCAL__DNS__/$localdns/g; s/__PILLAR__DNS__DOMAIN__/$domain/g; s/__PILLAR__DNS__SERVER__/$kubedns/g" nodelocaldns.yaml
+    sed -i "s/__PILLAR__LOCAL__DNS__/$localdns/g; s/__PILLAR__DNS__DOMAIN__/$domain/g; s/__PILLAR__DNS__SERVER__/$coredns/g" nodelocaldns.yaml
     ```
 
     `__PILLAR__CLUSTER__DNS__` and `__PILLAR__UPSTREAM__SERVERS__` will be populated by
     the `node-local-dns` pods.
-    In this mode, the `node-local-dns` pods listen on both the kube-dns service IP
+    In this mode, the `node-local-dns` pods listen on both the CoreDNS service IP
     as well as `<node-local-address>`, so pods can look up DNS records using either IP address.
 
   * If kube-proxy is running in IPVS mode:
 
     ``` bash
-    sed -i "s/__PILLAR__LOCAL__DNS__/$localdns/g; s/__PILLAR__DNS__DOMAIN__/$domain/g; s/,__PILLAR__DNS__SERVER__//g; s/__PILLAR__CLUSTER__DNS__/$kubedns/g" nodelocaldns.yaml
+    sed -i "s/__PILLAR__LOCAL__DNS__/$localdns/g; s/__PILLAR__DNS__DOMAIN__/$domain/g; s/,__PILLAR__DNS__SERVER__//g; s/__PILLAR__CLUSTER__DNS__/$coredns/g" nodelocaldns.yaml
     ```
 
     In this mode, the `node-local-dns` pods listen only on `<node-local-address>`.
-    The `node-local-dns` interface cannot bind the kube-dns cluster IP since the
+    The `node-local-dns` interface cannot bind the CoreDNS cluster IP since the
     interface used for IPVS loadbalancing already uses this address.
     `__PILLAR__UPSTREAM__SERVERS__` will be populated by the node-local-dns pods.
 
@@ -122,7 +123,7 @@ This feature can be enabled using the following steps:
 * If using kube-proxy in IPVS mode, `--cluster-dns` flag to kubelet needs to be modified
   to use `<node-local-address>` that NodeLocal DNSCache is listening on.
   Otherwise, there is no need to modify the value of the `--cluster-dns` flag,
-  since NodeLocal DNSCache listens on both the kube-dns service IP as well as
+  since NodeLocal DNSCache listens on both the CoreDNS service IP as well as
   `<node-local-address>`.
 
 Once enabled, the `node-local-dns` Pods will run in the `kube-system` namespace
@@ -133,14 +134,23 @@ be available on a per-node basis.
 You can disable this feature by removing the DaemonSet, using `kubectl delete -f <manifest>`.
 You should also revert any changes you made to the kubelet configuration.
 
-## StubDomains and Upstream server Configuration
+## Stub domain configuration
 
-StubDomains and upstream servers specified in the `kube-dns` ConfigMap in the `kube-system` namespace
-are automatically picked up by `node-local-dns` pods. The ConfigMap contents need to follow the format
-shown in [the example](/docs/tasks/administer-cluster/dns-custom-nameservers/#example-1).
-The `node-local-dns` ConfigMap can also be modified directly with the stubDomain configuration
-in the Corefile format. Some cloud providers might not allow modifying `node-local-dns` ConfigMap directly.
-In those cases, the `kube-dns` ConfigMap can be updated.
+The Corefile in the `node-local-dns` ConfigMap can be modified with the
+stubDomain configuration. Some cloud providers might not allow modifying the
+`node-local-dns` ConfigMap directly; in that case, a `kube-dns` ConfigMap in the
+format traditionally used by `kube-dns` can be used instead:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: kube-system
+  name: kube-dns
+data:
+  stubDomains: |
+    {"abc.com" : ["1.2.3.4"], "my.cluster.local" : ["2.3.4.5"]}
+```
 
 ## Setting memory limits
 

--- a/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
+++ b/content/en/docs/tasks/job/coarse-parallel-processing-work-queue.md
@@ -105,7 +105,7 @@ Address: 10.0.147.152
 ```
 (the IP addresses will vary)
 
-If the kube-dns addon is not set up correctly, the previous step may not work for you.
+If the cluster DNS addon is not set up correctly, the previous step may not work for you.
 You can also find the IP address for that Service in an environment variable:
 
 ```shell

--- a/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
+++ b/content/en/docs/tutorials/kubernetes-basics/expose/expose-intro.md
@@ -60,8 +60,7 @@ and assigns a fixed, external IP to the Service. Superset of NodePort.
 
 * _ExternalName_ - Maps the Service to the contents of the `externalName` field
 (e.g. `foo.bar.example.com`), by returning a `CNAME` record with its value.
-No proxying of any kind is set up. This type requires v1.7 or higher of `kube-dns`,
-or CoreDNS version 0.0.8 or higher.
+No proxying of any kind is set up.
 
 More information about the different types of Services can be found in the
 [Using Source IP](/docs/tutorials/services/source-ip/) tutorial. Also see

--- a/content/en/examples/admin/dns/dns-horizontal-autoscaler.yaml
+++ b/content/en/examples/admin/dns/dns-horizontal-autoscaler.yaml
@@ -74,7 +74,7 @@ spec:
           - /cluster-proportional-autoscaler
           - --namespace=kube-system
           - --configmap=kube-dns-autoscaler
-          # Should keep target in sync with cluster/addons/dns/kube-dns.yaml.base
+          # Should keep target in sync with cluster/addons/dns/coredns/coredns.yaml.base
           - --target=<SCALE_TARGET>
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
           # If using small nodes, "nodesPerReplica" should dominate.

--- a/content/en/examples/application/job/redis/worker.py
+++ b/content/en/examples/application/job/redis/worker.py
@@ -4,7 +4,7 @@ import time
 import rediswq
 
 host="redis"
-# Uncomment next two lines if you do not have Kube-DNS working.
+# Uncomment next two lines if you do not have CoreDNS working.
 # import os
 # host = os.getenv("REDIS_SERVICE_HOST")
 


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/issues/137556. Not strongly tied to 1.37; could merge either before or after.

There are still many instances of the string `kube-dns` in the docs, mostly because [the default CoreDNS install is still called "kube-dns" for backward compatibility](https://github.com/kubernetes/kubernetes/blob/v1.37.0-rc.0/cluster/addons/dns/coredns/coredns.yaml.base#L193). Beyond that:

- `content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md` still says "`` `coredns` (or `kube-dns`) ``" in 2 places, since people may still be troubleshooting clusters that use kube-dns.
- `content/en/docs/tasks/administer-cluster/nodelocaldns.md` still refers to a "`kube-dns`" ConfigMap, since that's the name it uses.
- `content/en/docs/tasks/administer-cluster/dns-horizontal-autoscaling.md` (and `content/end/examples/admin/dns/dns-horizontal-autoscaler.yaml`) still create a "`kube-dns-autoscaler`", but referencing CoreDNS.
- `content/en/docs/tasks/administer-cluster/dns-custom-nameservers.md` references a CoreDNS option that is set "`` for backward compatibility with `kube-dns` ``".
- `content/en/docs/reference/access-authn-authz/rbac.md` still lists the old `kube-dns` RBAC Role, which [we continue to create for now](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go#L512-L518).

/cc @aojea