### PR TITLE
docs: fix broken Kyverno policies link

### DIFF
--- a/content/en/docs/concepts/security/pod-security-standards.md
+++ b/content/en/docs/concepts/security/pod-security-standards.md
@@ -511,7 +511,7 @@ of individual policies are not defined here.
 Other alternatives for enforcing policies are being developed in the Kubernetes ecosystem, such as:
 
 - [Kubewarden](https://github.com/kubewarden)
-- [Kyverno](https://kyverno.io/policies/pod-security/)
+- [Kyverno](https://kyverno.io/policies)
 - [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
 
 ## Pod OS field


### PR DESCRIPTION
The Kyverno link under Pod Security Standards → Alternatives was going to `https://kyverno.io/policies/pod-security/`, which 404s. Updated it to `https://kyverno.io/policies`.

Fixes #56734

---
This PR was written in part with the assistance of generative AI.