### PR TITLE
content: update Kubernetes API glossary definition

### DIFF
--- a/content/en/docs/reference/glossary/kubernetes-api.md
+++ b/content/en/docs/reference/glossary/kubernetes-api.md
@@ -3,14 +3,14 @@ title: Kubernetes API
 id: kubernetes-api
 full_link: /docs/concepts/overview/kubernetes-api/
 short_description: >
-  The application that serves Kubernetes functionality through a RESTful interface and stores the state of the cluster.
+  The HTTP API that lets users, cluster components, and external components communicate with one another and query or manipulate the state of Kubernetes objects.
 
 aka: 
 tags:
 - fundamental
 - architecture
 ---
- The application that serves Kubernetes functionality through a RESTful interface and stores the state of the cluster.
+ The HTTP API that lets users, cluster components, and external components communicate with one another and query or manipulate the state of Kubernetes objects.
 
 <!--more--> 
 


### PR DESCRIPTION
### What this PR does / why we need it 

Updates the Kubernetes API definition in `content/en/docs/reference/glossary/kubernetes-api.md` to state that it  
  is an HTTP API interface rather than an application that stores cluster state. This removes the contradiction       
  between the glossary entry and the concepts overview page.                                                          
                                                                                                                      
 ### Which issue(s) this PR fixes 
Fixes #56930                                                                                                      
                                                                                                                      
### Special notes for your reviewer
None. 