### PR TITLE
docs: fix broken map-crictl link in dockershim FAQ

### DIFF
--- a/content/en/blog/_posts/2020/dockershim-faq.md
+++ b/content/en/blog/_posts/2020/dockershim-faq.md
@@ -155,7 +155,7 @@ runtime where possible.
 
 Another thing to look out for is anything expecting to run for system maintenance
 or nested inside a container when building images will no longer work. For the
-former, you can use the [`crictl`][cr] tool as a drop-in replacement (see [mapping from dockercli to crictl](/docs/reference/tools/map-crictl-dockercli/)) and for the
+former, you can use the [`crictl`][cr] tool as a drop-in replacement (see [debugging nodes with crictl](/docs/tasks/debug/debug-cluster/crictl/)) and for the
 latter you can use newer container build options like [img], [buildah],
 [kaniko], or [buildkit-cli-for-kubectl] that don’t require Docker.
 


### PR DESCRIPTION
The dockershim FAQ still linked to `/docs/reference/tools/map-crictl-dockercli/`, which 404s. Switched that to the current crictl debugging task page.

Fixes #47521

---
This PR was written in part with the assistance of generative AI.