### PR TITLE
[zh-cn] Sync cluster intro

### DIFF
--- a/content/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
+++ b/content/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md
@@ -135,18 +135,14 @@ applications._
 cluster.** Each node has a Kubelet, which is an agent for managing the node and
 communicating with the Kubernetes control plane. The node should also have tools for
 handling container operations, such as {{< glossary_tooltip text="containerd" term_id="containerd" >}}
-or {{< glossary_tooltip term_id="cri-o" >}}. A Kubernetes cluster that handles production
-traffic should have a minimum of three nodes because if one node goes down, both an
-[etcd](/docs/concepts/architecture/#etcd) member and a control plane instance are lost,
-and redundancy is compromised. You can mitigate this risk by adding more control plane nodes.
+or {{< glossary_tooltip term_id="cri-o" >}}. A common and supported deployment
+model runs Kubernetes control plane components on dedicated control plane nodes.
 -->
 **节点是一个虚拟机或者物理机，它在 Kubernetes 集群中充当工作机器的角色。**
 每个节点都有 Kubelet，它管理节点而且是节点与控制面通信的代理。
 节点还应该具有用于处理容器操作的工具，例如 {{< glossary_tooltip text="containerd" term_id="containerd" >}}
 或 {{< glossary_tooltip term_id="cri-o" >}}。
-处理生产级流量的 Kubernetes 集群至少应具有三个节点，因为如果只有一个节点，出现故障时其对应的
-[etcd](/zh-cn/docs/concepts/architecture/#etcd) 成员和控制面实例都会丢失，
-并且冗余会受到影响。你可以通过添加更多控制面节点来降低这种风险。
+一种常见且受支持的部署模型是在专用控制面节点上运行 Kubernetes 控制面组件。
 
 <!--
 When you deploy applications on Kubernetes, you tell the control plane to start


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.

 For overall help on editing and submitting pull requests, visit:
 https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release,
 see https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->

### Description

Sync the Simplified Chinese cluster introduction with the current English source.

- Replace the outdated minimum-three-nodes explanation.
- Clarify that a common supported deployment model runs control plane components on dedicated control plane nodes.
- Update the embedded English source comment and the Chinese translation together.

Upstream change: https://github.com/kubernetes/website/commit/3a1cad81997002ce29496ef304d6d31e98aa90fe

Validation:
- Reviewed the complete output of `./scripts/lsync.sh content/zh-cn/docs/tutorials/kubernetes-basics/create-cluster/cluster-intro.md`
- `git diff --check`

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR description
 so it will automatically close when the PR is merged. See the GitHub documentation for more
 details and other options:
 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

None
