### PR TITLE
[zh-cn] Sync Gateway TLS guide

### DIFF
--- a/content/zh-cn/docs/concepts/services-networking/gateway.md
+++ b/content/zh-cn/docs/concepts/services-networking/gateway.md
@@ -206,7 +206,8 @@ to the Gateway by the implementation's controller. This address is used as a net
 processing traffic of backend network endpoints defined in routes.
 
 See the [Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.Gateway)
-reference for a full definition of this API kind.
+reference for a full definition of this API kind. For guidance on configuring HTTPS/TLS listeners, see the
+[Gateway API TLS Guide](https://gateway-api.sigs.k8s.io/guides/tls/).
 -->
 在此示例中，流量处理基础设施的实例被编程为监听 80 端口上的 HTTP 流量。
 由于未指定 `addresses` 字段，因此对应实现的控制器负责将地址或主机名设置到 Gateway 之上。
@@ -214,6 +215,8 @@ reference for a full definition of this API kind.
 
 有关此类 API 的完整定义，请参阅
 [Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.Gateway)。
+有关配置 HTTPS/TLS 监听器的指导，请参阅
+[Gateway API TLS 指南](https://gateway-api.sigs.k8s.io/guides/tls/)。
 
 {{< note >}}
 <!--


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.

 For overall help on editing and submitting pull requests, visit:
 https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release,
 see https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->

### Description

Sync the Simplified Chinese Gateway page with the current English source.

- Add the Gateway API TLS Guide link for configuring HTTPS/TLS listeners.
- Update both the embedded English source comment and the Chinese translation.

Upstream change: https://github.com/kubernetes/website/commit/2b952e51edc0fff789c9b7066fe3de5eac7f1e55

Validation:
- Reviewed the complete output of `./scripts/lsync.sh content/zh-cn/docs/concepts/services-networking/gateway.md`
- `git diff --check`

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR description
 so it will automatically close when the PR is merged. See the GitHub documentation for more
 details and other options:
 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

None
