### PR TITLE
[zh-cn] Sync node reference index

### DIFF
--- a/content/zh-cn/docs/reference/node/_index.md
+++ b/content/zh-cn/docs/reference/node/_index.md
@@ -32,6 +32,8 @@ This section contains the following reference topics about nodes:
 * [Linux Node Swap Behaviors](/docs/reference/node/swap-behavior/)
 
 * [Seccomp information](/docs/reference/node/seccomp/)
+
+* [What happens after a node restart](/docs/reference/node/what-happens-on-restart/)
 -->
 本部分包含以下有关节点的参考主题：
 
@@ -45,6 +47,7 @@ This section contains the following reference topics about nodes:
 * [节点 `.status` 信息](/zh-cn/docs/reference/node/node-status/)
 * [Linux 节点的交换（Swap）行为](/zh-cn/docs/reference/node/swap-behavior/)
 * [Seccomp 信息](/zh-cn/docs/reference/node/seccomp/)
+* [节点重启后会发生什么](/docs/reference/node/what-happens-on-restart/)
 
 <!--
 You can also read node reference details from elsewhere in the


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.

 For overall help on editing and submitting pull requests, visit:
 https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release,
 see https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->

### Description

Sync the Simplified Chinese node reference index with the current English source.

- Add the “What happens after a node restart” reference entry.
- Keep the link pointed at the English page because a Simplified Chinese counterpart is not currently available.
- Update both the embedded English source comment and the Chinese list.

Upstream change: https://github.com/kubernetes/website/commit/fa9e2b43f14e1fa57f556a3a6fc0e2e531dbccf9

Validation:
- Reviewed the complete output of `./scripts/lsync.sh content/zh-cn/docs/reference/node/_index.md`
- `git diff --check`

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR description
 so it will automatically close when the PR is merged. See the GitHub documentation for more
 details and other options:
 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

None
