### PR TITLE
[ko] Update kubectl Linux package repository instructions

### DIFF
--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -110,7 +110,7 @@ card:
 
    ```shell
    sudo apt-get update
-   sudo apt-get install -y apt-transport-https ca-certificates curl
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
    ```
    Debian 9(stretch) 또는 그 이전 버전을 사용하는 경우 `apt-transport-https`도 설치해야 한다.
    ```shell
@@ -120,13 +120,17 @@ card:
 2. 구글 클라우드 공개 사이닝 키를 다운로드한다.
 
    ```shell
-   sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    ```
 
 3. 쿠버네티스 `apt` 리포지터리를 추가한다.
 
    ```shell
-   echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' \
+  | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
    ```
 
 4. 새 리포지터리의 `apt` 패키지 색인을 업데이트하고 kubectl을 설치한다.
@@ -147,10 +151,10 @@ Debian 12 또는 Ubuntu 22.04 이전 릴리스에서는 기본적으로 `/etc/ap
 cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-\$basearch
+baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
 EOF
 sudo yum install -y kubectl
 ```

--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -1,19 +1,18 @@
 ---
-# reviewers:
-# - mikedanese
+reviewers:
+- mikedanese
 title: 리눅스에 kubectl 설치 및 설정
 content_type: task
 weight: 10
-card:
-  name: tasks
-  weight: 20
-  title: 리눅스에 kubectl 설치하기
 ---
 
 ## {{% heading "prerequisites" %}}
 
-클러스터의 마이너(minor) 버전 차이 내에 있는 kubectl 버전을 사용해야 한다. 예를 들어, v{{< skew currentVersion >}} 클라이언트는 v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersion >}}, v{{< skew currentVersionAddMinor 1 >}}의 컨트롤 플레인과 연동될 수 있다.
-호환되는 최신 버전의 kubectl을 사용하면 예기치 않은 문제를 피할 수 있다.
+클러스터와 마이너 버전 차이가 1 이내인 kubectl 버전을 사용해야 한다.
+예를 들어, v{{< skew currentVersion >}} 클라이언트는
+v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersionAddMinor 0 >}},
+그리고 v{{< skew currentVersionAddMinor 1 >}} 컨트롤 플레인과 통신할 수 있다.
+호환되는 최신 버전의 kubectl을 사용하면 예기치 않은 문제를 방지하는 데 도움이 된다.
 
 ## 리눅스에 kubectl 설치
 
@@ -27,43 +26,61 @@ card:
 
 1. 다음 명령으로 최신 릴리스를 다운로드한다.
 
-   ```bash
+   {{< tabs name="download_binary_linux" >}}
+   {{< tab name="x86-64" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-   ```
+   {{< /tab >}}
+   {{< tab name="ARM64" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+   {{< /tab >}}
+   {{< /tabs >}}
 
    {{< note >}}
-특정 버전을 다운로드하려면, `$(curl -L -s https://dl.k8s.io/release/stable.txt)` 명령 부분을 특정 버전으로 바꾼다.
+   특정 버전을 다운로드하려면, `$(curl -L -s https://dl.k8s.io/release/stable.txt)`
+   명령 부분을 특정 버전으로 바꾼다.
 
-예를 들어, 리눅스에서 버전 {{< skew currentPatchVersion >}}을 다운로드하려면, 다음을 입력한다.
+   예를 들어, 리눅스 x86-64에서 {{< skew currentPatchVersion >}} 버전을 다운로드하려면 다음을 입력한다.
 
    ```bash
    curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/linux/amd64/kubectl
    ```
+
+   Linux ARM64의 경우 다음과 같이 입력한다:
+
+   ```bash
+   curl -LO https://dl.k8s.io/release/v{{< skew currentPatchVersion >}}/bin/linux/arm64/kubectl
+   ```
+
    {{< /note >}}
 
 1. 바이너리를 검증한다. (선택 사항)
 
    kubectl 체크섬(checksum) 파일을 다운로드한다.
 
-   ```bash
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
-   ```
+   {{< tabs name="download_checksum_linux" >}}
+   {{< tab name="x86-64" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+   {{< /tab >}}
+   {{< tab name="ARM64" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl.sha256"
+   {{< /tab >}}
+   {{< /tabs >}}
 
-   kubectl 바이너리를 체크섬 파일을 통해 검증한다.
+   kubectl 바이너리를 체크섬 파일과 대조하여 검증한다:
 
    ```bash
    echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
    ```
 
-   검증이 성공한다면, 출력은 다음과 같다.
+   검증에 성공하면 다음과 같이 출력된다:
 
-   ```bash
+   ```console
    kubectl: OK
    ```
 
-   검증이 실패한다면, `shasum`이 0이 아닌 상태로 종료되며 다음과 유사한 결과를 출력한다.
+   검증이 실패한다면, `shasum`이 0이 아닌 상태로 종료되며 다음과 유사한 결과를 출력한다:
 
-   ```bash
+   ```console
    kubectl: FAILED
    sha256sum: WARNING: 1 computed checksum did NOT match
    ```
@@ -79,7 +96,8 @@ card:
    ```
 
    {{< note >}}
-   대상 시스템에 root 접근 권한을 가지고 있지 않더라도, `~/.local/bin` 디렉터리에 kubectl을 설치할 수 있다.
+   대상 시스템에 root 접근 권한을 가지고 있지 않더라도, 
+   `~/.local/bin` 디렉터리에 kubectl을 설치할 수 있다.
 
    ```bash
    chmod +x kubectl
@@ -95,13 +113,14 @@ card:
    ```bash
    kubectl version --client
    ```
+
    또는 다음을 실행하여 버전에 대한 더 자세한 정보를 본다.
 
    ```cmd
    kubectl version --client --output=yaml    
    ```
 
-### 기본 패키지 관리 도구를 사용하여 설치 {#install-using-native-package-management}
+### 기본 패키지 관리 도구를 사용하여 설치
 
 {{< tabs name="kubectl_install" >}}
 {{% tab name="데비안 기반의 배포판" %}}
@@ -110,63 +129,146 @@ card:
 
    ```shell
    sudo apt-get update
+   # apt-transport-https는 더미 패키지일 수 있다. 이 경우, 해당 패키지는 생략할 수 있다.
    sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
    ```
-   Debian 9(stretch) 또는 그 이전 버전을 사용하는 경우 `apt-transport-https`도 설치해야 한다.
-   ```shell
-   sudo apt-get install -y apt-transport-https
-   ```
 
-2. 구글 클라우드 공개 사이닝 키를 다운로드한다.
+2. 쿠버네티스 패키지 리포지터리용 공개 서명 키를 다운로드한다. 동일한 서명 키는 모든 리포지터리에 사용되므로 URL에 있는 버전은 무시해도 된다.
 
    ```shell
-   curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key \
-  | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      # `/etc/apt/keyrings` 디렉터리가 존재하지 않는다면 curl 명령을 실행하기 전에 생성해야 한다. 아래 note를 참고한다.
+   # sudo mkdir -p -m 755 /etc/apt/keyrings
+   curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+   sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # 권한이 없는 APT 프로그램이 이 키링을 읽을 수 있도록 한다.
    ```
 
-3. 쿠버네티스 `apt` 리포지터리를 추가한다.
+{{< note >}}
+Debian 12 및 Ubuntu 22.04 이전 릴리스에서는 `/etc/apt/keyrings` 디렉터리가 기본적으로 존재하지 않으므로 curl 명령을 실행하기 전에 생성해야 한다.
+{{< /note >}}
+
+3. 쿠버네티스 `apt` 리포지터리를 추가한다. {{< param "version" >}}과 다른 쿠버네티스 버전을 사용하려면 
+아래 명령에서 {{< param "version" >}}을 원하는 마이너 버전으로 바꾼다.
 
    ```shell
-   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' \
-  | sudo tee /etc/apt/sources.list.d/kubernetes.list
-sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
+   # /etc/apt/sources.list.d/kubernetes.list의 기존 설정을 모두 덮어쓴다.
+   echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+   sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list   # command-not-found 같은 도구가 올바르게 작동하도록 한다.
    ```
 
-4. 새 리포지터리의 `apt` 패키지 색인을 업데이트하고 kubectl을 설치한다.
+{{< note >}}
+다른 마이너 릴리스의 kubectl로 업그레이드하려면 `apt-get update`와 `apt-get upgrade`를 실행하기 전에 `/etc/apt/sources.list.d/kubernetes.list`의 버전을 올려야 한다. 이 절차에 대한 자세한 내용은 [쿠버네티스 패키지 리포지터리 변경하기](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)에서 확인할 수 있다.
+{{< note >}}
+
+4. `apt` 패키지 색인을 업데이트하고 kubectl을 설치한다.
 
    ```shell
    sudo apt-get update
    sudo apt-get install -y kubectl
    ```
-{{< note >}}
-Debian 12 또는 Ubuntu 22.04 이전 릴리스에서는 기본적으로 `/etc/apt/keyrings` 파일이 존재하지 않는다.
-필요할 경우, 읽기 권한은 모두에게 부여되지만 쓰기 권한은 관리자만 갖도록 해당 디렉토리를 생성한다.
-{{< /note >}}
 
 {{% /tab %}}
 
 {{% tab name="레드햇 기반의 배포판" %}}
-```bash
-cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
-enabled=1
-gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
-EOF
-sudo yum install -y kubectl
-```
+
+1. 쿠버네티스 `yum` 리포지터리를 추가한다. {{< param "version" >}}과 다른 쿠버네티스 버전을
+   사용하려면, 아래 명령에서 {{< param "version" >}}을 원하는
+   마이너 버전으로 바꾼다.
+
+   ```bash
+   # /etc/yum.repos.d/kubernetes.repo의 기존 설정을 모두 덮어쓴다.
+   cat <<EOF | sudo tee /etc/yum.repos.d/kubernetes.repo
+   [kubernetes]
+   name=Kubernetes
+   baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
+   enabled=1
+   gpgcheck=1
+   gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
+   EOF
+   ```
+
+{{< note >}}
+다른 마이너 릴리스의 kubectl로 업그레이드하려면 `yum update`를 실행하기 전에 `/etc/yum.repos.d/kubernetes.repo`의 버전을 올려야 한다. 이 절차에 대한 자세한 내용은 [쿠버네티스 패키지 리포지터리 변경하기](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)에서 확인할 수 있다.
+{{< /note >}}
+
+2. yum을 사용하여 kubectl을 설치한다:
+
+   ```bash
+   sudo yum install -y kubectl
+   ```
+
+{{% /tab %}}
+
+{{% tab name="SUSE-based distributions" %}}
+
+1. 쿠버네티스 `zypper` 리포지터리를 추가한다. {{< param "version" >}}과 다른 쿠버네티스 버전을
+사용하려면, 아래 명령에서 {{< param "version" >}}을 원하는
+마이너 버전으로 바꾼다.
+
+   ```bash
+   # /etc/zypp/repos.d/kubernetes.repo의 기존 설정을 모두 덮어쓴다.
+   cat <<EOF | sudo tee /etc/zypp/repos.d/kubernetes.repo
+   [kubernetes]
+   name=Kubernetes
+   baseurl=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/
+   enabled=1
+   gpgcheck=1
+   gpgkey=https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/rpm/repodata/repomd.xml.key
+   EOF
+   ```
+
+{{< note >}}
+다른 마이너 릴리스의 kubectl로 업그레이드하려면 `/etc/zypp/repos.d/kubernetes.repo`의 버전을 올린 뒤
+`zypper update`를 실행해야 한다. 이 절차에 대한 자세한 내용은
+[쿠버네티스 패키지 리포지터리 변경하기](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)에서 확인할 수 있다.
+{{< /note >}}
+
+2. zypper를 업데이트하고 새 리포지터리가 추가되었는지 확인한다:
+
+   ```bash
+   sudo zypper update
+   ```
+
+   다음 메시지가 나타나면 't' 또는 'a'를 누른다:
+
+   ```
+   New repository or package signing key received:
+
+   Repository:       Kubernetes
+   Key Fingerprint:  1111 2222 3333 4444 5555 6666 7777 8888 9999 AAAA
+   Key Name:         isv:kubernetes OBS Project <isv:kubernetes@build.opensuse.org>
+   Key Algorithm:    RSA 2048
+   Key Created:      Thu 25 Aug 2022 01:21:11 PM -03
+   Key Expires:      Sat 02 Nov 2024 01:21:11 PM -03 (expires in 85 days)
+   Rpm Name:         gpg-pubkey-9a296436-6307a177
+
+   Note: Signing data enables the recipient to verify that no modifications occurred after the data
+   were signed. Accepting data with no, wrong or unknown signature can lead to a corrupted system
+   and in extreme cases even to a system compromise.
+
+   Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
+   you are not sure whether the presented key is authentic, ask the repository provider or check
+   their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
+   are using.
+
+   Do you want to reject the key, trust temporarily, or trust always? [r/t/a/?] (r): a
+   ```
+
+3. `zypper`를 사용하여 kubectl을 설치한다:
+
+   ```bash
+   sudo zypper install -y kubectl
+   ```
 
 {{% /tab %}}
 {{< /tabs >}}
 
-### 다른 패키지 관리 도구를 사용하여 설치 {#install-using-other-package-management}
+### 다른 패키지 관리 도구를 사용하여 설치 
 
 {{< tabs name="other_kubectl_install" >}}
 {{% tab name="Snap" %}}
-[snap](https://snapcraft.io/docs/core/install) 패키지 관리자를 지원하는 Ubuntu 또는 다른 리눅스 배포판을 사용하는 경우, kubectl을 [snap](https://snapcraft.io/) 애플리케이션으로 설치할 수 있다.
+[snap](https://snapcraft.io/docs/core/install) 패키지 관리자를 지원하는 
+Ubuntu 또는 다른 리눅스 배포판을 사용하는 경우, 
+kubectl을 [snap](https://snapcraft.io/) 애플리케이션으로 설치할 수 있다.
 
 ```shell
 snap install kubectl --classic
@@ -176,7 +278,8 @@ kubectl version --client
 {{% /tab %}}
 
 {{% tab name="Homebrew" %}}
-리눅스 상에서 [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) 패키지 관리자를 사용한다면, [설치](https://docs.brew.sh/Homebrew-on-Linux#install)를 통해 kubectl을 사용할 수 있다.
+리눅스 상에서 [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) 패키지 관리자를 사용한다면, 
+[설치](https://docs.brew.sh/Homebrew-on-Linux#install)를 통해 kubectl을 사용할 수 있다.
 
 ```shell
 brew install kubectl
@@ -195,7 +298,8 @@ kubectl version --client
 
 ### 셸 자동 완성 활성화
 
-kubectl은 Bash, Zsh, Fish, 및 PowerShell에 대한 자동 완성 지원을 제공하므로 입력을 위한 타이핑을 많이 절약할 수 있다.
+kubectl은 Bash, Zsh, Fish, 및 PowerShell에 대한 자동 완성 지원을 제공하므로 
+입력을 위한 타이핑을 많이 절약할 수 있다.
 
 다음은 Bash, Fish, 및 Zsh에 대한 자동 완성을 설정하는 절차이다.
 
@@ -205,23 +309,37 @@ kubectl은 Bash, Zsh, Fish, 및 PowerShell에 대한 자동 완성 지원을 제
 {{< tab name="Zsh" include="included/optional-kubectl-configs-zsh.md" />}}
 {{< /tabs >}}
 
+### kuberc 구성
+
+자세한 내용은 [kuberc](/docs/reference/kubectl/kuberc)를 참조하십시오.
+
 ### `kubectl convert` 플러그인 설치
 
 {{< include "included/kubectl-convert-overview.md" >}}
 
 1. 다음 명령으로 최신 릴리스를 다운로드한다.
 
-   ```bash
+   {{< tabs name="download_convert_binary_linux" >}}
+   {{< tab name="x86-64" codelang="bash" >}}
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl-convert"
-   ```
+   {{< /tab >}}
+   {{< tab name="ARM64" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl-convert"
+   {{< /tab >}}
+   {{< /tabs >}}
 
 1. 바이너리를 검증한다. (선택 사항)
 
    kubectl-convert 체크섬(checksum) 파일을 다운로드한다.
 
-   ```bash
-   curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl-convert.sha256"
-   ```
+   {{< tabs name="download_convert_checksum_linux" >}}
+   {{< tab name="x86-64" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl-convert.sha256"
+   {{< /tab >}}
+   {{< tab name="ARM64" codelang="bash" >}}
+   curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl-convert.sha256"
+   {{< /tab >}}
+   {{< /tabs >}}
 
    kubectl-convert 바이너리를 체크섬 파일을 통해 검증한다.
 
@@ -237,7 +355,7 @@ kubectl은 Bash, Zsh, Fish, 및 PowerShell에 대한 자동 완성 지원을 제
 
    검증이 실패한다면, `sha256`이 0이 아닌 상태로 종료되며 다음과 유사한 결과를 출력한다.
 
-   ```bash
+   ```console
    kubectl-convert: FAILED
    sha256sum: WARNING: 1 computed checksum did NOT match
    ```
@@ -259,6 +377,12 @@ kubectl은 Bash, Zsh, Fish, 및 PowerShell에 대한 자동 완성 지원을 제
    ```
 
    에러가 출력되지 않는다면, 플러그인이 정상적으로 설치된 것이다.
+
+1. 플러그인을 설치한 후 설치 파일을 정리한다: 
+
+   ```bash
+   rm kubectl-convert kubectl-convert.sha256
+   ```
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/ko/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/ko/docs/tasks/tools/install-kubectl-linux.md
@@ -136,7 +136,7 @@ v{{< skew currentVersionAddMinor -1 >}}, v{{< skew currentVersionAddMinor 0 >}},
 2. 쿠버네티스 패키지 리포지터리용 공개 서명 키를 다운로드한다. 동일한 서명 키는 모든 리포지터리에 사용되므로 URL에 있는 버전은 무시해도 된다.
 
    ```shell
-      # `/etc/apt/keyrings` 디렉터리가 존재하지 않는다면 curl 명령을 실행하기 전에 생성해야 한다. 아래 note를 참고한다.
+   # `/etc/apt/keyrings` 디렉터리가 존재하지 않는다면 curl 명령을 실행하기 전에 생성해야 한다. 아래 note를 참고한다.
    # sudo mkdir -p -m 755 /etc/apt/keyrings
    curl -fsSL https://pkgs.k8s.io/core:/stable:/{{< param "version" >}}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
    sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg # 권한이 없는 APT 프로그램이 이 키링을 읽을 수 있도록 한다.
@@ -157,7 +157,7 @@ Debian 12 및 Ubuntu 22.04 이전 릴리스에서는 `/etc/apt/keyrings` 디렉�
 
 {{< note >}}
 다른 마이너 릴리스의 kubectl로 업그레이드하려면 `apt-get update`와 `apt-get upgrade`를 실행하기 전에 `/etc/apt/sources.list.d/kubernetes.list`의 버전을 올려야 한다. 이 절차에 대한 자세한 내용은 [쿠버네티스 패키지 리포지터리 변경하기](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)에서 확인할 수 있다.
-{{< note >}}
+{{< /note >}}
 
 4. `apt` 패키지 색인을 업데이트하고 kubectl을 설치한다.
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

Updates the Korean translation of `content/ko/docs/tasks/tools/install-kubectl-linux.md`
to use the current `pkgs.k8s.io` package repositories for Debian-based and
Red Hat-based distributions.

This updates the outdated `apt.kubernetes.io` and `packages.cloud.google.com`
references to match the latest English documentation.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #56888

/area localization
/language ko

This PR was written in part with the assistance of generative AI.