### PR TITLE
[ko] Update API access control reference index

### DIFF
--- a/content/ko/docs/reference/access-authn-authz/_index.md
+++ b/content/ko/docs/reference/access-authn-authz/_index.md
@@ -5,16 +5,16 @@ no_list: true
 ---
 
 쿠버네티스가 API 접근을 구현 및 제어하는 방법에 대한 자세한 내용은
-[쿠버네티스 API에 대한 접근 제어](/ko/docs/concepts/security/controlling-access/)를 참고한다.
+[쿠버네티스 API에 대한 접근 제어](/docs/concepts/security/controlling-access/)를 참고한다.
 
 참조 문헌
 
 - [인증](/docs/reference/access-authn-authz/authentication/)
-   - [부트스트랩 토큰 인증](/ko/docs/reference/access-authn-authz/bootstrap-tokens/)
+   - [부트스트랩 토큰 인증](/docs/reference/access-authn-authz/bootstrap-tokens/)
 - [승인 컨트롤러](/docs/reference/access-authn-authz/admission-controllers/)
    - [동적 승인 제어](/docs/reference/access-authn-authz/extensible-admission-controllers/)
    - [매니페스트 기반 어드미션 컨트롤](/docs/reference/access-authn-authz/manifest-admission-control/)
-- [인가](/ko/docs/reference/access-authn-authz/authorization/)
+- [인가](/docs/reference/access-authn-authz/authorization/)
    - [역할 기반 접근 제어](/docs/reference/access-authn-authz/rbac/)
    - [속성 기반 접근 제어](/docs/reference/access-authn-authz/abac/)
    - [노드 인가](/docs/reference/access-authn-authz/node/)
@@ -25,5 +25,6 @@ no_list: true
 - 서비스 어카운트
   - [개발자 가이드](/docs/tasks/configure-pod-container/configure-service-account/)
   - [관리](/ko/docs/reference/access-authn-authz/service-accounts-admin/)
-- [kubelet 인증과 인가](/ko/docs/reference/access-authn-authz/kubelet-authn-authz/)
+  - [관리](/docs/reference/access-authn-authz/service-accounts-admin/)
+- [kubelet 인증과 인가](/docs/reference/access-authn-authz/kubelet-authn-authz/)
   - kubelet [TLS 부트스트래핑](/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)을 포함함

--- a/content/ko/docs/reference/access-authn-authz/_index.md
+++ b/content/ko/docs/reference/access-authn-authz/_index.md
@@ -13,6 +13,7 @@ no_list: true
    - [부트스트랩 토큰 인증](/ko/docs/reference/access-authn-authz/bootstrap-tokens/)
 - [승인 컨트롤러](/docs/reference/access-authn-authz/admission-controllers/)
    - [동적 승인 제어](/docs/reference/access-authn-authz/extensible-admission-controllers/)
+   - [매니페스트 기반 어드미션 컨트롤](/docs/reference/access-authn-authz/manifest-admission-control/)
 - [인가](/ko/docs/reference/access-authn-authz/authorization/)
    - [역할 기반 접근 제어](/docs/reference/access-authn-authz/rbac/)
    - [속성 기반 접근 제어](/docs/reference/access-authn-authz/abac/)


### PR DESCRIPTION
### Description

Adds the missing Manifest-Based Admission Control entry to the Korean API access control reference index.

The entry is translated as `매니페스트 기반 어드미션 컨트롤`, following the current Korean localization glossary and the terminology used in the Kubernetes v1.36 Korean release documentation.

### Issue

None.

### Validation

- `git diff --check`
- Confirmed that the entry and link match the English source.
- Confirmed that the linked English source document exists.

/area localization
/language ko
