### PR TITLE
Update patch release schedule for July 2026

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -7,10 +7,13 @@ schedules:
 - endOfLifeDate: "2027-06-28"
   maintenanceModeStartDate: "2027-04-28"
   next:
-    cherryPickDeadline: "2026-07-10"
+    cherryPickDeadline: "2026-08-07"
+    release: 1.36.4
+    targetDate: "2026-08-11"
+  previousPatches:
+  - cherryPickDeadline: "2026-07-10"
     release: 1.36.3
     targetDate: "2026-07-14"
-  previousPatches:
   - cherryPickDeadline: "2026-06-05"
     release: 1.36.2
     targetDate: "2026-06-09"
@@ -22,10 +25,13 @@ schedules:
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:
-    cherryPickDeadline: "2026-07-10"
+    cherryPickDeadline: "2026-08-07"
+    release: 1.35.8
+    targetDate: "2026-08-11"
+  previousPatches:
+  - cherryPickDeadline: "2026-07-10"
     release: 1.35.7
     targetDate: "2026-07-14"
-  previousPatches:
   - cherryPickDeadline: "2026-06-05"
     release: 1.35.6
     targetDate: "2026-06-09"
@@ -53,10 +59,13 @@ schedules:
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
   next:
-    cherryPickDeadline: "2026-07-10"
+    cherryPickDeadline: "2026-08-07"
+    release: 1.34.11
+    targetDate: "2026-08-11"
+  previousPatches:
+  - cherryPickDeadline: "2026-07-10"
     release: 1.34.10
     targetDate: "2026-07-14"
-  previousPatches:
   - cherryPickDeadline: "2026-06-05"
     release: 1.34.9
     targetDate: "2026-06-09"
@@ -141,9 +150,9 @@ schedules:
   release: "1.33"
   releaseDate: "2025-04-23"
 upcoming_releases:
-- cherryPickDeadline: "2026-07-10"
-  targetDate: "2026-07-14"
 - cherryPickDeadline: "2026-08-07"
   targetDate: "2026-08-11"
 - cherryPickDeadline: "2026-09-11"
   targetDate: "2026-09-15"
+- cherryPickDeadline: "2026-10-09"
+  targetDate: "2026-10-13"


### PR DESCRIPTION
### What this PR does / why we need it
Updates the patch release schedule in `data/releases/schedule.yaml` to move v1.36.3 (along with v1.35.7 and v1.34.
  10) to `previousPatches` and set v1.36.4 as the next scheduled patch release for August 2026. This ensures the      
  Kubernetes release pages accurately display v1.36.3 and upcoming patch release schedules.                                                                                                             
### Which issue(s) this PR fixes

Fixes #56947                                                                                                      
                                                                                                                      
### Special notes for your reviewer                                                                                                                       
None.                                                                                                             

