### PR TITLE
Use tables for the cidr and isCIDR examples on the CEL page

### DIFF
--- a/content/en/docs/reference/using-api/cel.md
+++ b/content/en/docs/reference/using-api/cel.md
@@ -553,11 +553,37 @@ IPv4-mapped IPv6 addresses (e.g. `::ffff:1.2.3.4/24`) are not allowed.
 
 Examples:
 
-<tt>cidr('192.168.0.0/16')</tt> // returns an IPv4 address with a CIDR mask
-<tt>cidr('::1/128')</tt> // returns an IPv6 address with a CIDR mask
-<tt>cidr('192.168.0.0/33')</tt> // error
-<tt>cidr('::1/129')</tt> // error
-<tt>cidr('192.168.0.1/16')</tt> // error, because there are non-0 bits after the prefix
+<table>
+<caption>Examples of CEL expressions using the cidr function</caption>
+<thead>
+<tr>
+  <th>CEL Expression</th>
+  <th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>cidr('192.168.0.0/16')</tt></td>
+  <td>Returns an IPv4 address with a CIDR mask.</td>
+</tr>
+<tr>
+  <td><tt>cidr('::1/128')</tt></td>
+  <td>Returns an IPv6 address with a CIDR mask.</td>
+</tr>
+<tr>
+  <td><tt>cidr('192.168.0.0/33')</tt></td>
+  <td>Error, because the prefix length exceeds the IPv4 address size.</td>
+</tr>
+<tr>
+  <td><tt>cidr('::1/129')</tt></td>
+  <td>Error, because the prefix length exceeds the IPv6 address size.</td>
+</tr>
+<tr>
+  <td><tt>cidr('192.168.0.1/16')</tt></td>
+  <td>Error, because there are non-0 bits after the prefix.</td>
+</tr>
+</tbody>
+</table>
 
 #### `isCIDR`
 
@@ -570,10 +596,33 @@ IPv4-mapped IPv6 addresses (e.g. `::ffff:1.2.3.4/24`) are not allowed.
 
 Examples:
 
-<tt>isCIDR('192.168.0.0/16')</tt> // returns true
-<tt>isCIDR('::1/128')</tt> // returns true
-<tt>isCIDR('192.168.0.0/33')</tt> // returns false
-<tt>isCIDR('::1/129')</tt> // returns false
+<table>
+<caption>Examples of CEL expressions using the isCIDR function</caption>
+<thead>
+<tr>
+  <th>CEL Expression</th>
+  <th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><tt>isCIDR('192.168.0.0/16')</tt></td>
+  <td>Returns true for a valid IPv4 CIDR.</td>
+</tr>
+<tr>
+  <td><tt>isCIDR('::1/128')</tt></td>
+  <td>Returns true for a valid IPv6 CIDR.</td>
+</tr>
+<tr>
+  <td><tt>isCIDR('192.168.0.0/33')</tt></td>
+  <td>Returns false, because the prefix length exceeds the IPv4 address size.</td>
+</tr>
+<tr>
+  <td><tt>isCIDR('::1/129')</tt></td>
+  <td>Returns false, because the prefix length exceeds the IPv6 address size.</td>
+</tr>
+</tbody>
+</table>
 
 #### `containsIP` / `containsCIDR` / `ip` / `masked` / `prefixLength`
 


### PR DESCRIPTION
The examples under `cidr` and `isCIDR` in the Kubernetes CIDR library section
are written as consecutive `<tt>` lines with `//` comments:

```markdown
Examples:

<tt>cidr('192.168.0.0/16')</tt> // returns an IPv4 address with a CIDR mask
<tt>cidr('::1/128')</tt> // returns an IPv6 address with a CIDR mask
<tt>cidr('192.168.0.0/33')</tt> // error
```

Markdown joins consecutive lines into a single paragraph, and the site does not
enable `hardWraps`, so these render as one run-on line. On the live page today,
https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-cidr-library
produces:

```html
<p><tt>cidr('192.168.0.0/16')</tt> // returns an IPv4 address with a CIDR mask<tt>cidr('::1/128')</tt> // returns an IPv6 address with a CIDR mask<tt>cidr('192.168.0.0/33')</tt> // error<tt>cidr('::1/129')</tt> // error<tt>cidr('192.168.0.1/16')</tt> // error, because there are non-0 bits after the prefix</p>
```

The newlines are stripped, so the reader sees `...with a CIDR maskcidr('::1/128')...`
with no separation between one example and the next.

Every other example block on this page uses an HTML table — there are eleven of
them. The rework in 9e578ee7ae ("Rework CEL page to use HTML table rather than
Markdown table") did not change any line mentioning `cidr(`, so these two blocks
were left behind when the rest of the page was converted.

This change converts both to the same two-column `CEL Expression` / `Purpose`
table used by the Kubernetes IP address library section directly above. The
captions are `...using the cidr function` and `...using the isCIDR function` so
they do not collide with the existing `...using CIDR library functions` caption
further down the same section.

No wording outside the two example blocks is touched.

Surfaced during review of #56778 by @windsonsea, who asked for the English table
style to be fixed upstream first.
