### PR TITLE
Fix ResourceSlice glossary full_link to the GA API page

### DIFF
--- a/content/en/docs/reference/glossary/resourceslice.md
+++ b/content/en/docs/reference/glossary/resourceslice.md
@@ -1,7 +1,7 @@
 ---
 title: ResourceSlice
 id: resourceslice
-full_link: /docs/reference/kubernetes-api/workload-resources/resource-slice-v1beta1/
+full_link: /docs/reference/kubernetes-api/resource/resource-slice-v1/
 short_description: >
   Represents one or more infrastructure resources, like devices, in a pool of
   similar resources.

--- a/content/fr/docs/reference/glossary/resourceslice.md
+++ b/content/fr/docs/reference/glossary/resourceslice.md
@@ -1,7 +1,7 @@
 ---
 title: ResourceSlice
 id: resourceslice
-full_link: /docs/reference/kubernetes-api/workload-resources/resource-slice-v1beta1/
+full_link: /docs/reference/kubernetes-api/resource/resource-slice-v1/
 short_description: >
   Représente une ou plusieurs ressources d'infrastructure, comme des dispositifs, dans un pool de ressources similaires.
 

--- a/content/zh-cn/docs/reference/glossary/resourceslice.md
+++ b/content/zh-cn/docs/reference/glossary/resourceslice.md
@@ -1,7 +1,7 @@
 ---
 title: ResourceSlice
 id: resourceslice
-full_link: /zh-cn/docs/reference/kubernetes-api/workload-resources/resource-slice-v1beta1/
+full_link: /zh-cn/docs/reference/kubernetes-api/resource/resource-slice-v1/
 short_description: >
   用一个相似资源所构成的池来表示一个或多个基础设施资源（如设备）。
 
@@ -11,7 +11,7 @@ tags:
 <!--
 title: ResourceSlice
 id: resourceslice
-full_link: /docs/reference/kubernetes-api/workload-resources/resource-slice-v1beta1/
+full_link: /docs/reference/kubernetes-api/resource/resource-slice-v1/
 short_description: >
   Represents one or more infrastructure resources, like devices, in a pool of
   similar resources.


### PR DESCRIPTION
## Summary

The `ResourceSlice` glossary's `full_link` points at the removed `workload-resources/resource-slice-v1beta1` API page, so the tutorial's "Install Drivers and Allocate Devices with DRA" renders a broken link (gh #56966). The GA page lives under `/docs/reference/kubernetes-api/resource/resource-slice-v1/`.

## Changes

- `content/en/docs/reference/glossary/resourceslice.md` — `full_link` now targets the GA `resource-slice-v1` API page
- `content/fr/docs/reference/glossary/resourceslice.md` — same fix (English target, matching the fr glossary convention)
- `content/zh-cn/docs/reference/glossary/resourceslice.md` — both the localized and English fallback `full_link`s now target the v1 page

## Validation

- Confirmed the old `workload-resources/resource-slice-v1beta1.md` page no longer exists in the tree and `content/en/docs/reference/kubernetes-api/resource/resource-slice-v1.md` does
- `git diff --check` — clean
