### PR TITLE
Serve example manifests in KYAML and YAML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,13 @@ test-examples:
 	scripts/test_examples.sh install
 	scripts/test_examples.sh run
 
+.PHONY: kyaml verify-kyaml
+kyaml: ## Regenerate the KYAML rendering of the English example manifests.
+	scripts/kyaml.sh generate
+
+verify-kyaml: ## Fail if the generated KYAML examples are stale or do not match their source.
+	scripts/kyaml.sh verify
+
 .PHONY: link-checker-setup
 link-checker-image-pull:
 	$(CONTAINER_ENGINE) pull wjdp/htmltest

--- a/content/en/docs/contribute/style/hugo-shortcodes/index.md
+++ b/content/en/docs/contribute/style/hugo-shortcodes/index.md
@@ -335,6 +335,27 @@ where `<RELATIVE-PATH>` is the path to the sample file to include, relative to t
 The legacy `{{%/* codenew */%}}` shortcode is being replaced by `{{%/* code_sample */%}}`.
 Use `{{%/* code_sample */%}}` (not `{{%/* codenew */%}}` or `{{%/* code */%}}`) in new documentation.
 
+### Both dialects
+
+Example manifests are displayed in YAML, and that is what
+`{{%/* code_sample */%}}` shows and what `https://k8s.io/examples/...` serves.
+
+The manifests listed in `scripts/kyaml_examples.txt` are also rendered as
+[KYAML](/docs/reference/encodings/kyaml/) under `content/<LANG>/examples-kyaml/`.
+For those, the shortcode renders the two dialects as a pair of tabs; anything not
+listed renders in a single pane, exactly as it always has.
+
+The dialects themselves are configured in `hugo.toml`, under
+`[[params.codeSampleDialects]]`.
+
+The tabs are Docsy's, so they behave like every other tab pair on the site:
+choosing a dialect switches every example on the site, not just the one a reader
+clicked, and the choice is remembered across pages. Each tab's filename links to
+the file it shows, so the KYAML tab links to the generated copy.
+
+You do not write the second dialect; `make kyaml` generates it. See
+[Regenerating the KYAML rendering](/docs/contribute/style/write-new-topic/#kyaml-examples).
+
 ## Third party content marker
 
 Running Kubernetes requires third-party software. For example: you

--- a/content/en/docs/contribute/style/write-new-topic.md
+++ b/content/en/docs/contribute/style/write-new-topic.md
@@ -134,6 +134,31 @@ file located at `/content/en/examples/pods/storage/gce-volume.yaml`.
 {{%/* code_sample file="pods/storage/gce-volume.yaml" */%}}
 ```
 
+### Regenerating the KYAML rendering {#kyaml-examples}
+
+Write the sample as YAML. That file is the source of truth: it is what
+`https://k8s.io/examples/...` serves, and so what the `kubectl apply -f`
+commands in the docs fetch.
+
+The manifests listed in `scripts/kyaml_examples.txt` are also rendered in
+[KYAML](/docs/reference/encodings/kyaml/) &mdash; the flow-style dialect of YAML
+that Kubernetes {{< skew currentVersion >}} defines for project-owned examples
+&mdash; so that their pages can offer a reader either. You never write that
+rendering by hand; adding a line to that list is how it grows.
+
+After adding or changing a manifest that is on that list, run:
+
+```shell
+make kyaml
+```
+
+and commit what it writes under `content/en/examples-kyaml/`. `make verify-kyaml`
+fails if you forget, and `scripts/test_examples.sh` runs it whenever a pull
+request touches an examples directory.
+
+`scripts/README.md` covers the rest: why the conventional YAML stays canonical,
+which manifests get no KYAML rendering, and how localizations opt in.
+
 ## Showing how to create an API object from a configuration file
 
 If you need to demonstrate how to create an API object based on a

--- a/content/en/examples-kyaml/controllers/nginx-deployment.yaml
+++ b/content/en/examples-kyaml/controllers/nginx-deployment.yaml
@@ -1,0 +1,35 @@
+---
+{
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: {
+    name: "nginx-deployment",
+    labels: {
+      app: "nginx",
+    },
+  },
+  spec: {
+    replicas: 3,
+    selector: {
+      matchLabels: {
+        app: "nginx",
+      },
+    },
+    template: {
+      metadata: {
+        labels: {
+          app: "nginx",
+        },
+      },
+      spec: {
+        containers: [{
+          name: "nginx",
+          image: "nginx:1.14.2",
+          ports: [{
+            containerPort: 80,
+          }],
+        }],
+      },
+    },
+  },
+}

--- a/content/en/examples-kyaml/pods/config/redis-pod.yaml
+++ b/content/en/examples-kyaml/pods/config/redis-pod.yaml
@@ -1,0 +1,50 @@
+---
+{
+  apiVersion: "v1",
+  kind: "Pod",
+  metadata: {
+    name: "redis",
+  },
+  spec: {
+    containers: [{
+      name: "redis",
+      image: "redis:8.0.2",
+      command: [
+        "redis-server",
+        "/redis-master/redis.conf",
+      ],
+      env: [{
+        name: "MASTER",
+        value: "true",
+      }],
+      ports: [{
+        containerPort: 6379,
+      }],
+      resources: {
+        limits: {
+          cpu: "0.1",
+        },
+      },
+      volumeMounts: [{
+        mountPath: "/redis-master-data",
+        name: "data",
+      }, {
+        mountPath: "/redis-master",
+        name: "config",
+      }],
+    }],
+    volumes: [{
+      name: "data",
+      emptyDir: {},
+    }, {
+      name: "config",
+      configMap: {
+        name: "example-redis-config",
+        items: [{
+          key: "redis-config",
+          path: "redis.conf",
+        }],
+      },
+    }],
+  },
+}

--- a/content/en/examples-kyaml/pods/simple-pod.yaml
+++ b/content/en/examples-kyaml/pods/simple-pod.yaml
@@ -1,0 +1,17 @@
+---
+{
+  apiVersion: "v1",
+  kind: "Pod",
+  metadata: {
+    name: "nginx",
+  },
+  spec: {
+    containers: [{
+      name: "nginx",
+      image: "nginx:1.14.2",
+      ports: [{
+        containerPort: 80,
+      }],
+    }],
+  },
+}

--- a/content/en/examples-kyaml/service/simple-service.yaml
+++ b/content/en/examples-kyaml/service/simple-service.yaml
@@ -1,0 +1,18 @@
+---
+{
+  apiVersion: "v1",
+  kind: "Service",
+  metadata: {
+    name: "my-service",
+  },
+  spec: {
+    selector: {
+      app.kubernetes.io/name: "MyApp",
+    },
+    ports: [{
+      protocol: "TCP",
+      port: 80,
+      targetPort: 9376,
+    }],
+  },
+}

--- a/content/en/examples/examples_test.go
+++ b/content/en/examples/examples_test.go
@@ -155,6 +155,10 @@ var filesIgnore = []string{
 	// NOTE: The following Secret manifest cannot pass because the field values
 	// in it are not BASE64 encoded
 	"secret/tls-auth-secret.yaml",
+	// This fragment uses '...' to stand in for the omitted spec, and '...' is
+	// YAML's document-end marker, so it cannot be decoded. Checking
+	// walkConfigFiles's error below is what surfaced it
+	"validatingadmissionpolicy/failure-policy-ignore.yaml",
 }
 
 // TestGroup contains GroupVersion to uniquely identify the API
@@ -544,7 +548,9 @@ func TestExampleObjectSchemas(t *testing.T) {
 		AllowPrivileged: true,
 	})
 
-	walkConfigFiles(".", t, func(path string, docs [][]byte, kinds []string) {
+	// The error matters: walkConfigFiles stops at the first file it cannot
+	// decode, so ignoring it would silently leave every later file unvalidated.
+	err := walkConfigFiles(".", t, func(path string, docs [][]byte, kinds []string) {
 
 		for i, data := range docs {
 			expectedType := kindObjs[kinds[i]]
@@ -561,4 +567,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 			}
 		}
 	})
+	if err != nil {
+		t.Error(err)
+	}
 }

--- a/hugo.toml
+++ b/hugo.toml
@@ -19,7 +19,7 @@ disableAliases = true
 
 disableKinds = ["taxonomy"]
 
-ignoreFiles = [ "(?:^|/)OWNERS$", "README[-]+[a-z]*\\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
+ignoreFiles = [ "content/[^/]+/examples-[a-z]+","(?:^|/)OWNERS$", "README[-]+[a-z]*\\.md", "^node_modules$", "content/en/docs/doc-contributor-tools" ]
 
 timeout = "600s"
 
@@ -294,6 +294,20 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 	name_key = "community_calendar_name"
 	url = "https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io"
 	icon = "fa-solid fa-calendar-days"
+
+# Dialects that example manifests are offered in besides the conventional YAML
+# they are written as. A generator leaves each one's renderings in
+# content/<lang>/examples-<name>, and the code_sample shortcode offers a tab
+# wherever it finds one, so a dialect listed with nothing generated for it
+# changes no page. scripts/kyaml.sh is the generator for kyaml.
+#
+# The name is both the directory suffix and the tab's persistence key, so keep
+# it lowercase. codelang is the syntax highlighting the tab uses, defaulting to
+# whatever the manifest itself is highlighted as.
+[[params.codeSampleDialects]]
+	name = "kyaml"
+	label = "KYAML"
+	codelang = "yaml"
 
 # Language definitions.
 

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -111,6 +111,9 @@ other = "YouTube"
 [conjunction_1]
 other = "and"
 
+[code_sample_dialect_group]
+other = "Show this example as"
+
 [copy_sample_to_clipboard]
 other = "Copy {{ .filename }} to clipboard"
 

--- a/layouts/partials/code-sample-pane.html
+++ b/layouts/partials/code-sample-pane.html
@@ -1,0 +1,24 @@
+{{- /*
+Renders one example manifest.
+
+Expects a dict with:
+  file      the path passed to the code_sample shortcode, e.g. "pods/simple-pod.yaml"
+  content   the file contents to highlight
+  codelang  highlight language
+  options   highlight options
+  ghlink    raw-file link on GitHub, may be empty
+  id        DOM id for the copy-to-clipboard helper, unique per pane
+*/ -}}
+<div class="highlight code-sample">
+    <div class="copy-code-icon">
+    {{ with .ghlink }}<a href="{{ . | safeURL }}" download="{{ $.file }}">{{ end }}<code>{{ .file }}</code>
+    {{ if .ghlink }}</a>{{ end }}
+    {{- $copyTitle := T "copy_sample_to_clipboard" (dict "filename" .file) -}}
+    {{- with resources.Get "images/copycode.svg" -}}
+    <img src="{{ .RelPermalink }}" class="icon-copycode" onclick="copyCode('{{ $.id }}')" title="{{ $copyTitle }}"></img>
+    {{- end -}}
+    </div>
+    <div class="includecode" id="{{ .id }}">
+       {{- highlight .content .codelang .options -}}
+    </div>
+</div>

--- a/layouts/shortcodes/code_sample.html
+++ b/layouts/shortcodes/code_sample.html
@@ -23,20 +23,75 @@
 {{ if not ($.Scratch.Get "content") }}
 {{ errorf "[%s] %q not found in %q" site.Language.Lang $fileDir.File $bundlePath }}
 {{ end }}
-{{ $filename := printf ($.Scratch.Get "filename") | safeURL }}
-{{ $ghlink := printf "https://%s/%s%s" site.Params.githubwebsiteraw (default "main" site.Params.docsbranch) $filename | safeURL }}
+{{/* The dialects an example can be offered in besides the conventional YAML it
+     is written as, from params.codeSampleDialects in hugo.toml. Configuring one
+     and generating for it are separate: nothing here changes a page until a
+     generator has left renderings in content/<lang>/examples-<name>. */}}
+{{ $alternates := slice }}
+{{ range site.Params.codeSampleDialects }}
+{{/* Whether a rendering exists is the whole question here, so the shortcode and
+     the generator cannot disagree about which examples offer a choice. Deriving
+     the path from the manifest actually read keeps a localized page off a
+     rendering derived from a different translation. */}}
+{{ $altName := replaceRE "^(/content/[^/]+)/examples/" (printf "${1}/examples-%s/" .name) ($.Scratch.Get "filename") }}
+{{ if fileExists $altName }}
+{{ $altContent := readFile $altName }}
+{{/* A reader copies whichever tab is on screen, so every rendering has to
+     describe what the manifest describes. Both sides go through a .yaml-named
+     resource because Unmarshal guesses a bare string's format, and KYAML's
+     leading brace reads as JSON; jsonify then orders the keys, leaving only
+     meaning to compare. */}}
+{{ $sourceObjects := resources.FromString (printf "dialect-check/%s.yaml" ($file | anchorize)) ($.Scratch.Get "content") | transform.Unmarshal | jsonify }}
+{{ $altObjects := resources.FromString (printf "dialect-check/%s-%s.yaml" ($file | anchorize) .name) $altContent | transform.Unmarshal | jsonify }}
+{{ if ne $sourceObjects $altObjects }}
+{{ errorf "%s and its %s rendering in %s describe different objects; regenerate with: make %s" ($.Scratch.Get "filename") .label $altName .name }}
+{{ end }}
+{{ $alternates = $alternates | append (merge . (dict "content" $altContent "path" $altName)) }}
+{{ end }}
+{{ end }}
+{{ $ghbase := printf "https://%s/%s" site.Params.githubwebsiteraw (default "main" site.Params.docsbranch) }}
+{{ $ghlink := printf "%s%s" $ghbase ($.Scratch.Get "filename") }}
 {{ with $.Scratch.Get "content" }}
-<div class="highlight code-sample">
-    <div class="copy-code-icon">
-    {{ with $ghlink }}<a href="{{ . }}" download="{{ $file }}">{{ end }}<code>{{ $file }}</code>
-    {{ if $ghlink }}</a>{{ end }}
-    {{- $copyTitle := T "copy_sample_to_clipboard" (dict "filename" $file) -}}
-    {{- with resources.Get "images/copycode.svg" -}}
-    <img src="{{  .RelPermalink }}" class="icon-copycode" onclick="copyCode('{{ $file | anchorize }}')" title="{{ $copyTitle }}"></img>
-    {{- end -}}
-    </div>
-    <div class="includecode" id="{{ $file | anchorize }}">
-       {{- highlight . $codelang $opts -}}
-    </div>
+{{/* The ordinal keeps the ids apart when one page shows the same example twice:
+     without it both tabs would target the first pane. */}}
+{{ $anchor := printf "%s-%d" ($file | anchorize) $.Ordinal }}
+{{ $yamlPane := dict "file" $file "content" . "codelang" $codelang "options" $opts "ghlink" $ghlink "id" $anchor }}
+{{ if $alternates }}
+{{/* Bootstrap tabs, marked up the way Docsy's own tabpane shortcode marks them
+     up. data-td-tp-persist is what Docsy's js/tabpane-persist.js reads: picking
+     a dialect here picks it for every other example on the site, and the choice
+     survives to the next page. No JavaScript is added for this, because
+     layouts/partials/scripts.html already loads that file on every page.
+     Without JavaScript the first tab, conventional YAML, is the one shown. */}}
+{{ $tabs := slice (dict "name" "yaml" "label" "YAML" "pane" $yamlPane) }}
+{{ range $alternates }}
+{{ $tabs = $tabs | append (dict "name" .name "label" .label "pane" (merge $yamlPane (dict
+     "content" .content
+     "codelang" (default $codelang .codelang)
+     "ghlink" (printf "%s%s" $ghbase .path)
+     "id" (printf "%s-%s" $anchor .name)))) }}
+{{ end }}
+<ul class="nav nav-tabs" role="tablist" aria-label="{{ T "code_sample_dialect_group" }}">
+  {{ range $i, $tab := $tabs }}
+  <li class="nav-item">
+    <button class="nav-link{{ if eq $i 0 }} active{{ end }}" id="tab-{{ $anchor }}-{{ $tab.name }}"
+            data-bs-toggle="tab" data-bs-target="#pane-{{ $anchor }}-{{ $tab.name }}" role="tab"
+            data-td-tp-persist="{{ $tab.name }}" aria-controls="pane-{{ $anchor }}-{{ $tab.name }}"
+            aria-selected="{{ eq $i 0 }}">{{ $tab.label }}</button>
+  </li>
+  {{ end }}
+</ul>
+<div class="tab-content">
+  {{ range $i, $tab := $tabs }}
+  {{/* tabindex, because the manifest inside scrolls sideways and a scrollable
+       region a keyboard cannot reach is a trap. */}}
+  <div class="tab-pane fade{{ if eq $i 0 }} show active{{ end }}" id="pane-{{ $anchor }}-{{ $tab.name }}"
+       role="tabpanel" aria-labelledby="tab-{{ $anchor }}-{{ $tab.name }}" tabindex="0">
+    {{ partial "code-sample-pane.html" $tab.pane }}
+  </div>
+  {{ end }}
 </div>
+{{ else }}
+{{ partial "code-sample-pane.html" $yamlPane }}
+{{ end }}
 {{- end -}}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,7 @@
 | `find_pr.py`            | Find what GitHub pull requests touch a given file.                                                                                    |
 | `upstream_changes.py`   | Find what changes occurred between two versions.                                                                                      |
 | `test_examples.sh`      | This script tests whether a change affects example files bundled in the website.                                                      |
+| `kyaml.sh`              | This script renders a few of a language's example manifests a second time, as KYAML, so their pages can carry both dialects.          |
 | `check-headers-file.sh` | This script checks the headers if you are in a production environment.                                                                |
 | `diff_l10n_branches.py` | This script generates a report of outdated contents in `content/<l10n-lang>` directory by comparing two l10n team milestone branches. |
 | `fetch_kubecon_events.py` | This script fetches upcoming KubeCon events from the Linux Foundation calendar and writes `data/events/kubecon.yaml`.               |
@@ -71,6 +72,94 @@ To install the dependencies:
 To run the examples:
 
     $ ./scripts/test_examples.sh run
+
+## kyaml.sh
+
+Example manifests under `content/<lang>/examples` are conventional YAML. They
+are the source of truth, and they are what `https://k8s.io/examples/...` serves
+to the `kubectl apply -f` commands the docs cite.
+
+This script renders a few of them a second time as
+[KYAML](https://kubernetes.io/docs/reference/encodings/kyaml/) into
+`content/<lang>/examples-kyaml`, so that the `code_sample` shortcode can offer
+those examples in either dialect. The formatter does not carry comments through,
+which is one reason the conventional file stays canonical; both dialects can
+hold comments. The generated tree is not published and should never be edited by
+hand.
+
+Which manifests get a second rendering is `scripts/kyaml_examples.txt`, and it is
+short on purpose. Converting the site is an explicit non-goal of
+[KEP-5295](https://www.kubernetes.dev/resources/keps/5295/): "Require projects
+to migrate to KYAML by default." An example that is not on the list renders in
+one pane, exactly as it always has.
+
+The shortcode does not read that list. It offers a choice when a rendering is
+there for the manifest it is showing, so a rendering cannot exist for a page
+that will not show it, and a page cannot ask for one that was never generated.
+
+Which dialects exist at all is `[[params.codeSampleDialects]]` in `hugo.toml`.
+Each entry names a dialect, its tab label, and the syntax highlighting to use; a
+generator writes that dialect's renderings into `content/<lang>/examples-<name>`,
+which is the path the shortcode looks in and the one `ignoreFiles` keeps
+unpublished. Adding a dialect is an entry there plus a generator for it —
+nothing renders differently until renderings exist.
+
+To regenerate after changing a listed example (`make kyaml` is the same thing):
+
+    $ ./scripts/kyaml.sh generate
+
+To check the committed tree (`make verify-kyaml`):
+
+    $ ./scripts/kyaml.sh verify
+
+`verify` fails if the list names a manifest that is not there, or if the
+generated tree is stale.
+
+It does not check that a rendering still describes what its source describes:
+the `code_sample` shortcode does that, comparing the two with Hugo's
+`transform.Unmarshal` every time the site builds. Neither check subsumes the
+other. The staleness diff compares a freshly rendered tree against the committed
+one, so both sides come from the same formatter and a formatter that changed a
+manifest's meaning would agree with itself. Comparing a manifest against its
+rendering catches that, and it runs on every build rather than only on pull
+requests that touch an examples directory.
+
+`scripts/test_examples.sh run` runs `verify`, and Prow runs that whenever a pull
+request touches `content/<lang>/examples` or `content/<lang>/examples-kyaml`.
+
+### What is in scope
+
+Manifests under `content/<lang>/examples` only, and of those, only the ones in
+`scripts/kyaml_examples.txt`. Not the fenced ` ```yaml ` blocks inside pages: those
+are frequently partial or illustrative rather than manifests a reader applies,
+and KYAML cannot express an elision.
+
+English only, so far. Other languages get no KYAML rendering until their team
+opts in with `./scripts/kyaml.sh generate <lang>`. The shortcode derives the
+rendering's path from the manifest it actually read, so a localized page never
+pairs its own manifest with one derived from a different translation, and a
+manifest on the list that a locale has not translated is simply skipped.
+
+A manifest that embeds a file in a block scalar (`|` or `>`) gets no KYAML
+rendering even when it is listed. KYAML is flow style, block scalars are not
+legal inside flow style, and the embedded file would become one quoted string
+with escaped line breaks. Nor does a manifest holding more than one document:
+the shortcode's check reads one document, so a multi-document file would be
+offered in both dialects and compared in neither. Listing either is not an
+error, but it does nothing, so the script says so on stderr.
+
+### Why the KYAML is a generated tree, and not a .kyaml extension
+
+Every file under `content/<lang>/examples` is published at the matching
+`https://k8s.io/examples` URL, and the English docs cite those URLs in over two
+hundred `kubectl apply -f` commands. Naming the dialect in the extension,
+`simple-pod.kyaml` beside `simple-pod.yaml`, would mean a second published URL
+per manifest and a second file for contributors to keep in step.
+
+Generating into a sibling tree that Hugo does not publish keeps one URL per
+manifest, and keeps the manifest a reader fetches the same as the one the page
+shows. Each pane's filename still links to the exact file it shows, so a reader
+who wants the KYAML can reach it.
 
 ## check-headers-file.sh
 

--- a/scripts/kyaml.sh
+++ b/scripts/kyaml.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Renders the example manifests in scripts/kyaml_examples.txt a second time, as
+# KYAML, into content/<lang>/examples-kyaml. The conventional YAML under
+# content/<lang>/examples stays the source of truth and is never modified; the
+# generated tree is read only by the code_sample shortcode, to fill its second
+# tab. See scripts/README.md for why, and for what is left out.
+#
+#   scripts/kyaml.sh generate [lang...]   (re)write content/<lang>/examples-kyaml
+#   scripts/kyaml.sh verify   [lang...]   fail if that tree is stale
+#
+# Language defaults to "en". Requires Go.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Pinned so the output is reproducible across contributors and CI. This is the
+# formatter that ships with sigs.k8s.io/yaml, as named in KEP-5295.
+YAMLFMT="sigs.k8s.io/yaml/yamlfmt@v1.6.0"
+
+# Renderings go in the sibling of the examples tree named for the dialect, which
+# is the convention params.codeSampleDialects in hugo.toml and the ignoreFiles
+# entry beside it both follow.
+DIALECT="kyaml"
+
+LISTED="scripts/kyaml_examples.txt"
+
+# A block scalar rendered into flow style becomes one quoted string with escaped
+# line breaks, and a multi-document file defeats the shortcode's check, which
+# reads one document. Both render as a single pane instead. A block scalar is
+# introduced either by a mapping key (script: |) or by a sequence item (- |),
+# and the second is the form a container's command usually takes.
+BLOCK_SCALAR='(: *|^[[:space:]]*-[[:space:]]*)[|>][-+0-9]* *$'
+DOCUMENT_BREAK='^---'
+
+usage() {
+    echo "usage: $0 {generate|verify} [lang...]" >&2
+    exit 1
+}
+
+# Echoes the listed manifests, one path per line.
+listed() {
+    sed -e 's/#.*//' -e 's/[[:space:]]*$//' "$LISTED" | grep -v '^$' || true
+}
+
+# Fails if the list names a file that is not there. A typo would otherwise
+# render nothing and say so to no one. This cannot fold into manifests(), which
+# is read from a process substitution and so runs in a subshell, where exiting
+# would exit only that. Only the default language is checked: a listed manifest
+# need not have been translated, and a locale that has not opted in has no
+# generated tree at all.
+check_listed() {
+    local path
+    [ "$1" = en ] || return 0
+    while IFS= read -r path; do
+        [ -f "content/en/examples/$path" ] && continue
+        echo "$LISTED names content/en/examples/$path, which does not exist" >&2
+        exit 1
+    done < <(listed)
+}
+
+# Echoes the listed manifests that get a KYAML rendering for a language,
+# relative to its examples directory, minus the ones left out. A path a language
+# does not have is a manifest it has not translated.
+manifests() {
+    local dir="content/$1/examples" file
+    [ -d "$dir" ] || return 0
+    while IFS= read -r file; do
+        [ -f "$dir/$file" ] || continue
+        if grep -qE "$BLOCK_SCALAR" "$dir/$file"; then
+            echo "$file: no KYAML rendering, it embeds a file in a block scalar" >&2
+            continue
+        fi
+        # The first line may be a document start rather than a separator.
+        if tail -n +2 "$dir/$file" | grep -qE "$DOCUMENT_BREAK"; then
+            echo "$file: no KYAML rendering, it holds more than one document" >&2
+            continue
+        fi
+        echo "$file"
+    done < <(listed)
+}
+
+# Writes the KYAML tree for one language into $2, and leaves the number of
+# manifests it rendered in $RENDERED.
+render() {
+    local lang="$1" out="$2" file
+    RENDERED=0
+    while IFS= read -r file; do
+        mkdir -p "$out/$(dirname "$file")"
+        "$BIN/yamlfmt" -o kyaml "content/$lang/examples/$file" > "$out/$file"
+        RENDERED=$((RENDERED + 1))
+    done < <(manifests "$lang")
+}
+
+[ $# -ge 1 ] || usage
+mode="$1"
+shift
+langs=("${@:-en}")
+case "$mode" in
+    generate | verify) ;;
+    *) usage ;;
+esac
+
+BIN="$(mktemp -d)"
+trap 'rm -rf "$BIN"' EXIT
+GOBIN="$BIN" go install "$YAMLFMT"
+
+for lang in "${langs[@]}"; do
+    generated="content/$lang/examples-$DIALECT"
+    check_listed "$lang"
+
+    if [ "$mode" = "generate" ]; then
+        rm -rf "$generated"
+        render "$lang" "$generated"
+        echo "$lang: rendered $RENDERED manifests as KYAML"
+        continue
+    fi
+
+    staged="$BIN/$lang"
+    render "$lang" "$staged"
+    diff --recursive --unified "$generated" "$staged" || {
+        echo "$generated is stale. Run: scripts/kyaml.sh generate $lang" >&2
+        exit 1
+    }
+    echo "$lang: generated KYAML is up to date"
+done
+
+# Staleness is only half of it: a rendering also has to describe what its source
+# describes. That half is the code_sample shortcode's, which compares the two
+# every time the site builds. See layouts/shortcodes/code_sample.html.

--- a/scripts/kyaml_examples.txt
+++ b/scripts/kyaml_examples.txt
@@ -1,0 +1,7 @@
+# The example manifests offered in both dialects, read by scripts/kyaml.sh.
+# Paths are relative to content/<lang>/examples. See scripts/README.md.
+
+pods/simple-pod.yaml               # docs/concepts/workloads/pods/
+controllers/nginx-deployment.yaml  # docs/concepts/workloads/controllers/deployment.md
+service/simple-service.yaml        # docs/concepts/services-networking/service.md
+pods/config/redis-pod.yaml         # docs/tutorials/configuration/configure-redis-using-configmap.md

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -7,8 +7,10 @@ FILES=($( git diff "$( git merge-base --fork-point master )" --name-only ))
 
 TEST_EXAMPLES=No
 
-# Check if examples folders (all locales) change in this branch
-if printf -- '%s\n' "${FILES[@]}" | grep -qE '^"?content/[^/]+/examples/'; then
+# Check if examples folders (all locales) change in this branch. The generated
+# counterparts under examples-kyaml count too, so that a hand-edit there is
+# caught by scripts/kyaml.sh verify below.
+if printf -- '%s\n' "${FILES[@]}" | grep -qE '^"?content/[^/]+/examples(-kyaml)?/'; then
     TEST_EXAMPLES=Yes
 fi
 
@@ -44,6 +46,9 @@ function run_test() {
     exit 0
   fi
   go test -v k8s.io/website/content/en/examples
+  # The KYAML rendering of each manifest is generated; fail if it is stale or
+  # stopped describing the same objects. See scripts/README.md.
+  scripts/kyaml.sh verify
 }
 
 if [[ $1 == install ]]; then


### PR DESCRIPTION
Part of #57030, per [KEP-5295](https://www.kubernetes.dev/resources/keps/5295/). 

Four example manifests are offered in [KYAML](https://kubernetes.io/docs/reference/encodings/kyaml/): 
1. Pod
2. Deployment
3. Service
4. Redis 
5. ConfigMap 

#56811.

Disclaimer: This PR was assisted with the use of AI 

/sig docs
/language en
