### PR TITLE
docs: qualify DRA adminAccess namespace-label guarantee

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -654,11 +654,21 @@ spec:
 ```
 
 Admin access is a privileged mode and should not be granted to regular users in
-multi-tenant clusters. Only users authorized to
-create ResourceClaim or ResourceClaimTemplate objects in namespaces labeled with
-`resource.kubernetes.io/admin-access: "true"` (case-sensitive) can use the
-`adminAccess` field. This ensures that non-admin users cannot misuse the
-feature.
+multi-tenant clusters. The API server only accepts the `adminAccess` field on
+ResourceClaim or ResourceClaimTemplate objects in namespaces labeled with
+`resource.kubernetes.io/admin-access: "true"` (case-sensitive).
+
+That label is not itself an admin-only control. Anyone who can `patch` or
+`update` a Namespace — including a self-service Role limited to one namespace
+via `resourceNames` — can set the label and then use `adminAccess` there.
+Treat `resource.kubernetes.io/admin-access` the same way you treat Pod
+Security Admission labels such as `pod-security.kubernetes.io/enforce`:
+restrict who can change namespace labels, and audit existing
+`get`/`patch`/`update` grants on `namespaces`.
+
+For operator guidance, see
+[Restrict who can enable admin access](/docs/concepts/security/hardening-guide/dynamic-resource-allocation/#admin-access)
+in the DRA hardening guide.
 
 Admin access is a *beta feature* and is enabled by default with the
 [`DRAAdminAccess` feature gate](/docs/reference/command-line-tools-reference/feature-gates/#DRAAdminAccess)

--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -658,13 +658,12 @@ multi-tenant clusters. The API server only accepts the `adminAccess` field on
 ResourceClaim or ResourceClaimTemplate objects in namespaces labeled with
 `resource.kubernetes.io/admin-access: "true"` (case-sensitive).
 
-That label is not itself an admin-only control. Anyone who can `patch` or
-`update` a Namespace — including a self-service Role limited to one namespace
-via `resourceNames` — can set the label and then use `adminAccess` there.
+That label is not itself an authorization check. Anyone allowed to
+update the Namespace object can set the label and then use `adminAccess`
+there, regardless of how your cluster authorizes that update.
 Treat `resource.kubernetes.io/admin-access` the same way you treat Pod
 Security Admission labels such as `pod-security.kubernetes.io/enforce`:
-restrict who can change namespace labels, and audit existing
-`get`/`patch`/`update` grants on `namespaces`.
+restrict who can change those labels on Namespace objects.
 
 For operator guidance, see
 [Restrict who can enable admin access](/docs/concepts/security/hardening-guide/dynamic-resource-allocation/#admin-access)

--- a/content/en/docs/concepts/security/hardening-guide/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/security/hardening-guide/dynamic-resource-allocation.md
@@ -107,21 +107,20 @@ rules:
 ## Restrict who can enable admin access {#admin-access}
 
 `adminAccess` on a ResourceClaim is accepted only when the claim's namespace
-has the label `resource.kubernetes.io/admin-access: "true"`. That check is
-**not** an RBAC field-level gate. It is a namespace label.
+has the label `resource.kubernetes.io/admin-access: "true"`. That is a
+namespace-label check in the API server, not a field-level authorization
+rule.
 
-A common self-service pattern is granting a team `get`/`patch` on only their
-own Namespace object (`resourceNames: ["their-ns"]`) so they can manage labels
-without cluster-wide namespace access. That grant is enough to set the
-admin-access label and then create claims with `adminAccess`.
+Anyone who can update that Namespace object can set the label and then
+create claims with `adminAccess`. How they get that permission depends
+on your cluster's authorization configuration.
 
 If you do not want this in a multi-tenant cluster:
 
-- Audit who can `get`, `patch`, or `update` `namespaces`, including
-  `resourceNames`-scoped Roles.
+- Audit who is allowed to get, patch, or update Namespace objects.
 - Treat `resource.kubernetes.io/admin-access` like
-  `pod-security.kubernetes.io/enforce`: only privileged actors should be
-  able to change it.
+  `pod-security.kubernetes.io/enforce`: only privileged actors should
+  be able to change it.
 - Optionally deny changes to that label except from a small set of
   identities, using a ValidatingAdmissionPolicy or webhook.
 

--- a/content/en/docs/concepts/security/hardening-guide/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/security/hardening-guide/dynamic-resource-allocation.md
@@ -104,6 +104,30 @@ rules:
     resourceNames: ["dra.example.com"]
 ```
 
+## Restrict who can enable admin access {#admin-access}
+
+`adminAccess` on a ResourceClaim is accepted only when the claim's namespace
+has the label `resource.kubernetes.io/admin-access: "true"`. That check is
+**not** an RBAC field-level gate. It is a namespace label.
+
+A common self-service pattern is granting a team `get`/`patch` on only their
+own Namespace object (`resourceNames: ["their-ns"]`) so they can manage labels
+without cluster-wide namespace access. That grant is enough to set the
+admin-access label and then create claims with `adminAccess`.
+
+If you do not want this in a multi-tenant cluster:
+
+- Audit who can `get`, `patch`, or `update` `namespaces`, including
+  `resourceNames`-scoped Roles.
+- Treat `resource.kubernetes.io/admin-access` like
+  `pod-security.kubernetes.io/enforce`: only privileged actors should be
+  able to change it.
+- Optionally deny changes to that label except from a small set of
+  identities, using a ValidatingAdmissionPolicy or webhook.
+
+See also
+[Admin access](/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#admin-access).
+
 ## Related cluster administrator task
 
 To apply these patterns in a running cluster, see


### PR DESCRIPTION
the adminAccess section says the namespace label "ensures that non-admin users cannot misuse the feature". that only holds if they also can't label the namespace — and a pretty common self-service Role (`patch` on one Namespace via resourceNames) is enough to set it.

softened that wording and added a short note in the DRA hardening guide.

Fixes #56957

/kind bug
/sig docs
/sig auth
/language en