### PR TITLE
docs: say three annotations in the custom metrics exporter post

### DIFF
--- a/content/en/blog/_posts/2026/custom-metrics-exporter-kubernetes.md
+++ b/content/en/blog/_posts/2026/custom-metrics-exporter-kubernetes.md
@@ -347,7 +347,7 @@ need a matching `scrape_config` rule in your Prometheus configuration —
 check with whoever manages your Prometheus installation to confirm it is
 in place.
 
-You can add the following two annotations to the Pod template regardless
+You can add the following three annotations to the Pod template regardless
 of which scraping method you use. They are ignored by the Prometheus
 Operator but picked up automatically by annotation-based setups:
 


### PR DESCRIPTION
the YAML lists scrape, port, and path — that's three, not two.

Fixes #56954

/kind bug
/sig docs
/language en