### PR TITLE
docs: fix ResourceSlice glossary entry API reference link

### DIFF
--- a/content/en/docs/reference/glossary/resourceslice.md
+++ b/content/en/docs/reference/glossary/resourceslice.md
@@ -1,7 +1,7 @@
 ---
 title: ResourceSlice
 id: resourceslice
-full_link: /docs/reference/kubernetes-api/workload-resources/resource-slice-v1beta1/
+full_link: /docs/reference/kubernetes-api/resource/resource-slice-v1/
 short_description: >
   Represents one or more infrastructure resources, like devices, in a pool of
   similar resources.


### PR DESCRIPTION
#### What type of PR is this?

 /kind bug                                                                                                         
    /language en                                                                                                      
    /sig docs                                                                                                         
 #### What this PR does / why we need it:
 Fixes a broken documentation link in the `ResourceSlice` glossary definition.                                     
    Previously, `full_link` pointed to `/docs/reference/kubernetes-api/workload-resources/resource-slice-v1beta1/`    
  which results in a 404. This updates the link to the valid canonical API reference path `/docs/reference/kubernetes-
  api/resource/resource-slice-v1/`.                                                                                   
                                                                                                                      
#### Which issue(s) this PR fixes: 
Fixes #56966                                                                                                      
#### Special notes for your reviewer:
None  