### PR TITLE
docs: rank node-pressure eviction by usage vs requests, not QoS

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -336,12 +336,14 @@ The kubelet uses the following parameters to determine the pod eviction order:
 
 As a result, kubelet ranks and evicts pods in the following order:
 
-1. `BestEffort` or `Burstable` pods where the usage exceeds requests. These pods
-   are evicted based on their Priority and then by how much their usage level
-   exceeds the request.
+1. Pods whose usage exceeds requests. That includes every `BestEffort` pod
+   (they request nothing) and any `Burstable` pod that is over its request.
+   Within this group, lower Priority goes first, then pods that exceed
+   requests by more.
 
-1. `Guaranteed` pods and `Burstable` pods where the usage is less than requests
-   are evicted last, based on their Priority.
+1. Pods whose usage is at or below requests (`Guaranteed` pods, and
+   `Burstable` pods still under request) are evicted last, based on
+   their Priority.
 
 {{<note>}}
 The kubelet does not use the pod's [QoS class](/docs/concepts/workloads/pods/pod-qos/) to determine the eviction order.

--- a/content/en/docs/concepts/workloads/pods/pod-qos.md
+++ b/content/en/docs/concepts/workloads/pods/pod-qos.md
@@ -8,9 +8,10 @@ weight: 85
 
 This page introduces _Quality of Service (QoS) classes_ in Kubernetes, and explains
 how Kubernetes assigns a QoS class to each Pod as a consequence of the resource
-constraints that you specify for the containers in that Pod. Kubernetes relies on this
-classification to make decisions about which Pods to evict when there are not enough
-available resources on a Node.
+constraints that you specify for the containers in that Pod. QoS is a useful
+hint for how likely a Pod is to be evicted under memory pressure, but
+[node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/)
+ranks by usage versus requests and by Priority, not by QoS class itself.
 
 <!-- body -->
 
@@ -24,13 +25,13 @@ of the {{< glossary_tooltip text="Containers" term_id="container" >}} in that Po
 how those requests relate to resource limits.
 This is known as {{< glossary_tooltip text="Quality of Service" term_id="qos-class" >}}
 (QoS) class. Kubernetes assigns every Pod a QoS class based on the resource requests
-and limits of its component Containers. QoS classes are used by Kubernetes to decide
-which Pods to evict from a Node experiencing
-[Node Pressure](/docs/concepts/scheduling-eviction/node-pressure-eviction/). The possible
-QoS classes are `Guaranteed`, `Burstable`, and `BestEffort`. When a Node runs out of resources,
-Kubernetes will first evict `BestEffort` Pods running on that Node, followed by `Burstable` and
-finally `Guaranteed` Pods. When this eviction is due to resource pressure, only Pods exceeding
-resource requests are candidates for eviction.
+and limits of its component Containers. The possible QoS classes are
+`Guaranteed`, `Burstable`, and `BestEffort`. For
+[node-pressure eviction](/docs/concepts/scheduling-eviction/node-pressure-eviction/),
+the kubelet ranks pods by whether usage exceeds requests, then by Priority.
+`BestEffort` pods request nothing, so they usually come first when they
+use any of the starved resource — that is a consequence of requests, not
+a separate QoS sort.
 
 ### Guaranteed
 


### PR DESCRIPTION
the ranking list read like a QoS sort, then the note said it isn't. restated it as usage-vs-requests (BestEffort just happens to request nothing).

also toned down the QoS page, which said Kubernetes evicts by QoS class.

see kubernetes/kubernetes#129759

/kind documentation
/language en
/sig node