### PR TITLE
docs: say mixed patch versions on the same minor are supported

### DIFF
--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -40,6 +40,12 @@ For more information, see the Kubernetes [patch releases](/releases/patch-releas
 
 ## Supported version skew
 
+The rules below are about **minor** versions (`x.y`). Mixed **patch**
+versions of control-plane components on the same minor release (for
+example `kube-apiserver` at 1.37.1 and `kube-scheduler` at 1.37.3) are
+supported. Matching patches is still a good idea so you pick up the
+same fixes, but the skew policy does not forbid mixing them.
+
 ### kube-apiserver
 
 In [highly-available (HA) clusters](/docs/setup/production-environment/tools/kubeadm/high-availability/),

--- a/content/en/releases/version-skew-policy.md
+++ b/content/en/releases/version-skew-policy.md
@@ -40,11 +40,10 @@ For more information, see the Kubernetes [patch releases](/releases/patch-releas
 
 ## Supported version skew
 
-The rules below are about **minor** versions (`x.y`). Mixed **patch**
-versions of control-plane components on the same minor release (for
-example `kube-apiserver` at 1.37.1 and `kube-scheduler` at 1.37.3) are
-supported. Matching patches is still a good idea so you pick up the
-same fixes, but the skew policy does not forbid mixing them.
+The rules below are about **minor** versions (`x.y`). They do not
+constrain **patch** versions (`x.y.z`). Two instances of the same
+component on {{< skew currentVersion >}} may run different patches.
+Matching patches is still a good idea so you pick up the same fixes.
 
 ### kube-apiserver
 


### PR DESCRIPTION
the skew policy only talks about minor versions. mixed patches on the same minor (1.37.1 apiserver + 1.37.3 scheduler) are fine.

see kubernetes/kubernetes#141240

/kind documentation
/language en
/sig architecture
/sig cluster-lifecycle

This PR was written in part with the assistance of generative AI.