### PR TITLE
Update "deleted" to "inaccessible" in ConfigMap task

### DIFF
--- a/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md
@@ -720,7 +720,7 @@ very
 ```
 
 {{< caution >}}
-Like before, all previous files in the `/etc/config/` directory will be deleted.
+Like before, all previous files in the `/etc/config/` directory will be inaccessible.
 {{< /caution >}}
 
 Delete that Pod:


### PR DESCRIPTION
### Description

[The text above it is referring to](https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/configure-pod-container/configure-pod-configmap.md?plain=1#L693-L696) says:

> If there are any files in the `/etc/config` directory of that container image, the volume
mount will make those files from the image inaccessible.

"Inaccessible" is a more accurate and less alarming word than "deleted". The files are still present in the image if you rerun without the volume mount, hence they cannot be described as "deleted".

