### PR TITLE
Add API deprecation terminology guidance to style guide

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -691,6 +691,32 @@ An exception to this rule is documentation about announced deprecations
 targeting removal in future versions. One example of documentation like this
 is the [Deprecated API migration guide](/docs/reference/using-api/deprecation-guide/).
 
+### Use precise terms for deprecated and removed APIs
+
+When you write about API changes, use terms that describe the API's current
+state. For API support timelines, see the
+[Kubernetes Deprecation Policy](/docs/reference/using-api/deprecation-policy/).
+
+- Use _deprecated_ for an API version, field, or feature that still works, but
+  that users should stop using because it is planned for removal or replacement.
+- Use _no longer served_ for an API version that the API server no longer
+  accepts in requests. The resource might still be available through a newer API
+  version.
+- Use _removed_ for a field, feature, or behavior that is no longer available in
+  the release you are documenting. For API versions, prefer _no longer served_
+  when you mean that the API server no longer accepts that version.
+
+Avoid using _obsolete_ for Kubernetes APIs. It is less specific than
+_deprecated_, _no longer served_, or _removed_.
+
+{{< table caption = "Do and Don't - Use precise API change terms" >}}
+Do | Don't
+:--| :-----
+The `batch/v1beta1` API version of CronJob is no longer served as of v1.25. | The `batch/v1beta1` API version of CronJob is obsolete in v1.25.
+Migrate manifests and API clients to use the `batch/v1` API version. | Stop using the removed CronJob API.
+The field is deprecated. Use the replacement field instead. | The field is removed in a future release.
+{{< /table >}}
+
 ### Avoid statements that will soon be out of date
 
 Avoid words like "currently" and "new." A feature that is new today might not be


### PR DESCRIPTION
### Description

Adds guidance to the contributor style guide regarding precise terminology for API lifecycle changes, re-implementing the intent of stale PR #55693 as requested by maintainers in #57025:
- Use **_deprecated_** when an API version, field, or feature still works, but users should stop using it because removal or replacement is planned.
- Use **_no longer served_** when an API version is no longer accepted in requests by the API server (even if the resource remains accessible under a newer API version).
- Use **_removed_** for fields, features, or behaviors no longer present in the documented release. For API versions, prefer _no longer served_ when requests are rejected.
- Discourage using **_obsolete_** as an imprecise synonym for these distinct lifecycle states.
- Includes a Do/Don't table with concrete examples (e.g. `batch/v1beta1` CronJob).

### Attribution and AI Disclosure

- **Original implementation**: @p1930n in stale PR #55693.
- **Contributor**: @alexsmolya
- **AI Agent Disclosure**: Implemented and validated using Google Antigravity (AGY), used as a supervised AI coding/documentation assistant per the maintainer's task instructions in #57025.

### Issue

Closes: #57025
Fixes: #28690

### Validation

- Ran `git diff --check` — clean (no whitespace or formatting anomalies).
- Ran `python3 scripts/check-ctrlcode.py content/en md` — clean.
- Verified doc link target `/docs/reference/using-api/deprecation-policy/` is valid.
