### PR TITLE
Prefer a new name when replacing an immutable ConfigMap

### DIFF
--- a/content/en/docs/concepts/configuration/configmap.md
+++ b/content/en/docs/concepts/configuration/configmap.md
@@ -324,8 +324,12 @@ immutable: true
 
 Once a ConfigMap is marked as immutable, it is _not_ possible to revert this change
 nor to mutate the contents of the `data` or the `binaryData` field. You can
-only delete and recreate the ConfigMap. Because existing Pods maintain a mount point
-to the deleted ConfigMap, it is recommended to recreate these pods.
+only delete and recreate the ConfigMap.
+
+If you need different data, prefer a new name and point new Pods at that object.
+Reusing the same name is only safe after every existing reference to the old
+object (not only Pods) has gone away. Existing Pods keep a mount to the deleted
+ConfigMap; recreate those Pods as well.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -634,8 +634,11 @@ You can also update any existing mutable Secret to make it immutable.
 {{< note >}}
 Once a Secret or ConfigMap is marked as immutable, it is _not_ possible to revert this change
 nor to mutate the contents of the `data` field. You can only delete and recreate the Secret.
-Existing Pods maintain a mount point to the deleted Secret - it is recommended to recreate
-these pods.
+
+If you need different data, prefer a new name and point new Pods at that object.
+Reusing the same name is only safe after every existing reference to the old
+object (not only Pods) has gone away. Existing Pods keep a mount to the deleted
+Secret; recreate those Pods as well.
 {{< /note >}}
 
 ## Information security for Secrets


### PR DESCRIPTION
The immutable ConfigMap / Secret pages said delete, recreate, restart Pods. That undersells it — same name is only safe after every reference to the old object is gone.

I used a new name as the default advice, same wording on both pages.

Fixes #42359

---
This PR was written in part with the assistance of generative AI.