### PR TITLE
docs: drop docker CLI pull-by-digest link from image pull policy

### DIFF
--- a/content/en/docs/concepts/containers/images.md
+++ b/content/en/docs/concepts/containers/images.md
@@ -94,7 +94,7 @@ these values have:
   {{< glossary_tooltip text="container runtime" term_id="container-runtime" >}}
   to pull the image. The container runtime contacts the registry, resolves
   the image tag or name to a
-  [digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier),
+  [digest](#image-names),
   and downloads any layers that are not already cached locally.
   If all layers are already present, the container runtime uses the cached
   image without downloading it again. The kubelet itself does not check


### PR DESCRIPTION
The Always pull-policy paragraph linked to the docker CLI pull-by-digest page. That's `docker pull`, not how kubelet or the runtime resolve a tag.

The digest format is already on this page (and the OCI spec). I pointed the word at that section instead.

Fixes #55017

---
This PR was written in part with the assistance of generative AI.