### PR TITLE
docs: note kubeadm inherits -v from the parent command

### DIFF
--- a/content/en/docs/reference/setup-tools/kubeadm/_index.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/_index.md
@@ -19,6 +19,14 @@ Instead, we expect higher-level and more tailored tooling to be built on top of 
 
 To install kubeadm, see the [installation guide](/docs/setup/production-environment/tools/kubeadm/install-kubeadm).
 
+## Global flags
+
+`-v` / `--v` (klog verbosity) and `--rootfs` are flags on the parent
+`kubeadm` command. They apply to every subcommand. The generated options
+tables on the subcommand pages omit them. `--v=5` is usually enough for
+troubleshooting; `--v=10` prints each API client request and its body.
+Run `kubeadm --help` to list them.
+
 ## {{% heading "whatsnext" %}}
 
 * [kubeadm init](/docs/reference/setup-tools/kubeadm/kubeadm-init) to bootstrap a Kubernetes control-plane node

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-certs.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-certs.md
@@ -8,6 +8,8 @@ weight: 90
 For more details on how these commands can be used, see
 [Certificate Management with kubeadm](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/).
 
+{{< include "kubeadm-inherited-global-flags.md" >}}
+
 ## kubeadm certs {#cmd-certs}
 
 A collection of operations for operating Kubernetes certificates.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-config.md
@@ -37,6 +37,8 @@ API version to a newer, supported API version.
 that kubeadm requires.
 
 <!-- body -->
+{{< include "kubeadm-inherited-global-flags.md" >}}
+
 ## kubeadm config print {#cmd-config-print}
 
 {{< include "generated/kubeadm_config/kubeadm_config_print.md" >}}

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -12,16 +12,7 @@ This command initializes a Kubernetes control plane node.
 
 {{< include "generated/kubeadm_init/_index.md" >}}
 
-### Inherited global flags {#inherited-global-flags}
-
-The generated options table for `kubeadm init` lists only the flags that
-belong to that subcommand. The parent `kubeadm` command also accepts
-global flags that apply to every subcommand, including `init`.
-
-Use `-v` / `--v` to set log verbosity. `--v=5` is usually enough for
-troubleshooting; `--v=10` prints each API client request and its body.
-`--rootfs` is inherited as well. Run `kubeadm --help` to see the full
-list.
+{{< include "kubeadm-inherited-global-flags.md" >}}
 
 ### Init workflow {#init-workflow}
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -12,6 +12,17 @@ This command initializes a Kubernetes control plane node.
 
 {{< include "generated/kubeadm_init/_index.md" >}}
 
+### Inherited global flags {#inherited-global-flags}
+
+The generated options table for `kubeadm init` lists only the flags that
+belong to that subcommand. The parent `kubeadm` command also accepts
+global flags that apply to every subcommand, including `init`.
+
+Use `-v` / `--v` to set log verbosity. `--v=5` is usually enough for
+troubleshooting; `--v=10` prints each API client request and its body.
+`--rootfs` is inherited as well. Run `kubeadm --help` to see the full
+list.
+
 ### Init workflow {#init-workflow}
 
 `kubeadm init` bootstraps a Kubernetes control plane node by executing the

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -12,6 +12,8 @@ This command initializes a new Kubernetes node and joins it to the existing clus
 <!-- body -->
 {{< include "generated/kubeadm_join/_index.md" >}}
 
+{{< include "kubeadm-inherited-global-flags.md" >}}
+
 ### The join workflow {#join-workflow}
 
 `kubeadm join` bootstraps a Kubernetes worker node or a control-plane node and adds it to the cluster.

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-kubeconfig.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-kubeconfig.md
@@ -6,6 +6,8 @@ weight: 90
 
 `kubeadm kubeconfig` provides utilities for managing kubeconfig files.
 
+{{< include "kubeadm-inherited-global-flags.md" >}}
+
 For examples on how to use `kubeadm kubeconfig user` see
 [Generating kubeconfig files for additional users](/docs/tasks/administer-cluster/kubeadm/kubeadm-certs#kubeconfig-additional-users).
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-reset.md
@@ -12,6 +12,8 @@ Performs a best effort revert of changes made by `kubeadm init` or `kubeadm join
 <!-- body -->
 {{< include "generated/kubeadm_reset/_index.md" >}}
 
+{{< include "kubeadm-inherited-global-flags.md" >}}
+
 ### Reset workflow {#reset-workflow}
 
 `kubeadm reset` is responsible for cleaning up a node local file system from files that were created using

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-token.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-token.md
@@ -15,6 +15,8 @@ the cluster and a control-plane node, as described in [authenticating with boots
 such a token and also to create and manage new ones.
 
 <!-- body -->
+{{< include "kubeadm-inherited-global-flags.md" >}}
+
 ## kubeadm token create {#cmd-token-create}
 {{< include "generated/kubeadm_token/kubeadm_token_create.md" >}}
 

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-upgrade.md
@@ -13,6 +13,8 @@ behind one command, with support for both planning an upgrade and actually perfo
 
 <!-- body -->
 
+{{< include "kubeadm-inherited-global-flags.md" >}}
+
 ## kubeadm upgrade guidance
 
 The steps for performing an upgrade using kubeadm are outlined in [this document](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).

--- a/content/en/docs/reference/setup-tools/kubeadm/kubeadm-version.md
+++ b/content/en/docs/reference/setup-tools/kubeadm/kubeadm-version.md
@@ -11,3 +11,5 @@ This command prints the version of kubeadm.
 
 <!-- body -->
 {{< include "generated/kubeadm_version/_index.md" >}}
+
+{{< include "kubeadm-inherited-global-flags.md" >}}

--- a/content/en/includes/kubeadm-inherited-global-flags.md
+++ b/content/en/includes/kubeadm-inherited-global-flags.md
@@ -1,0 +1,11 @@
+### Inherited global flags {#inherited-global-flags}
+
+The generated options table on each `kubeadm` subcommand page lists
+flags for that subcommand only. The parent `kubeadm` command also
+accepts global flags that apply to **every** subcommand (`init`,
+`join`, `upgrade`, `reset`, `token`, and the rest).
+
+Use `-v` / `--v` to set log verbosity. `--v=5` is usually enough for
+troubleshooting; `--v=10` prints each API client request and its body.
+`--rootfs` is inherited as well. Run `kubeadm --help` to see the full
+list.


### PR DESCRIPTION
The generated options table on the kubeadm init page only lists init-specific flags. People look there for a verbosity switch and miss `-v`, which lives on the parent `kubeadm` command.

Added a short note after the table. `--v=10` is what neolit123 suggested for API traces; `--rootfs` is mentioned because it's the other inherited flag.

Fixes #48717

---
This PR was written in part with the assistance of generative AI.