### PR TITLE
[ja] Translate content/en/docs/reference/glossary/cel.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/cel.md
+++ b/content/ja/docs/reference/glossary/cel.md
@@ -1,0 +1,18 @@
+---
+title: Common Expression Language
+id: cel
+full_link: https://cel.dev
+short_description: >
+  ユーザーのコードを安全に実行できるように設計された式言語。
+tags:
+- extension
+- fundamental
+aka:
+- CEL
+---
+高速かつポータブルで、安全に実行できるように設計された汎用の式言語です。
+
+<!--more-->
+
+Kubernetesでは、CELを使用してクエリを実行したり、きめ細かなフィルタリングを行ったりできます。
+例えば、[動的アドミッションコントロール](/docs/reference/access-authn-authz/extensible-admission-controllers/)でCEL式を使用してリクエスト内の特定のフィールドをフィルタリングしたり、[動的リソース割り当て(DRA)](/docs/concepts/scheduling-eviction/dynamic-resource-allocation)で特定の属性に基づいてリソースを選択したりできます。


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/cel.md` into Japanese: `content/ja/docs/reference/glossary/cel.md`.

Terminology follows existing ja pages: 動的アドミッションコントロール (`concepts/security/controlling-access.md`) and 動的リソース割り当て (the DRA concept page title). Verified locally with hugo 0.144.2 — the CEL term renders on the ja glossary page and the DRA link resolves to the translated page.

**Website Link**:

- English: https://kubernetes.io/docs/reference/glossary/?all=true#term-cel

### Issue

Closes: #57019

/area localization
/language ja

This PR was written in part with the assistance of generative AI; the translation has been checked by a human and verified with a local Hugo build.

<!-- oss-radar:idempotency=auto-20260817-151234.w1.kubernetes_website.57019 -->
