### PR TITLE
docs: fix grammar in control plane glossary

### DIFF
--- a/content/en/docs/reference/glossary/control-plane.md
+++ b/content/en/docs/reference/glossary/control-plane.md
@@ -13,7 +13,7 @@ tags:
 
  <!--more--> 
  
- This layer is composed of many different components, such as (but not restricted to):
+ This layer is composed of many different components, including, but not limited to:
 
  * {{< glossary_tooltip text="etcd" term_id="etcd" >}}
  * {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}

--- a/content/en/docs/reference/glossary/control-plane.md
+++ b/content/en/docs/reference/glossary/control-plane.md
@@ -13,7 +13,7 @@ tags:
 
  <!--more--> 
  
- This layer is composed by many different components, such as (but not restricted to):
+ This layer is composed of many different components, such as (but not restricted to):
 
  * {{< glossary_tooltip text="etcd" term_id="etcd" >}}
  * {{< glossary_tooltip text="API Server" term_id="kube-apiserver" >}}


### PR DESCRIPTION
### Description

Corrects a grammar issue in the Control Plane glossary entry by changing
"composed by" to "composed of".

This is a documentation-only change and does not affect Kubernetes behavior.

### Issue

N/A

### Special notes for my reviewer

The change is limited to `content/en/docs/reference/glossary/control-plane.md`.

```release-note
NONE