### PR TITLE
Document DRA admin-access as a namespace-modification risk

### DIFF
--- a/content/en/docs/concepts/security/rbac-good-practices.md
+++ b/content/en/docs/concepts/security/rbac-good-practices.md
@@ -197,6 +197,9 @@ labels on that namespace. In clusters where Pod Security Admission is used, this
 for a more permissive policy than intended by the administrators.
 For clusters where NetworkPolicy is used, users may be set labels that indirectly allow
 access to services that an administrator did not intend to allow.
+For clusters using Dynamic Resource Allocation, labeling a namespace with
+`resource.kubernetes.io/admin-access: "true"` allows any user who can create ResourceClaims in that namespace
+to request admin access to devices already allocated to any other claim in any namespace.
 
 ## Kubernetes RBAC - denial of service risks {#denial-of-service-risks}
 


### PR DESCRIPTION
### Description

Adds Dynamic Resource Allocation's `adminAccess` field as a third example in the "Namespace modification"
section of the RBAC good practices page, alongside the existing Pod Security Admission and NetworkPolicy
examples. Same pattern: labeling a namespace (`resource.kubernetes.io/admin-access: "true"`) — not any RBAC
verb on the field itself — is what gates whether `adminAccess` can be requested by claims in that namespace.
Once granted, it can bypass the exclusivity of devices already allocated to claims in any namespace — the
same shape of risk as the existing PSA/NetworkPolicy examples here.

Follow-up to the discussion on #56957: @lmktfy triaged the issue and raised the idea of a short dedicated page covering this risk. @smarticu5 (who added this "Namespace modification" section originally, after raising it with SIG Security) pointed out it already covers this exact pattern for PSA/NetworkPolicy, and offered to support a PR adding DRA as a third example here.

### Issue

Related to #56957 (not closing it — that issue's core claim is addressed separately in #56972, which rewords
the DRA concept page's `adminAccess` statement and adds a new hardening-guide section, substantially covering
what was originally requested there). This PR is a smaller, complementary addition to the general RBAC good
practices page, not a replacement for that fix.
