### PR TITLE
Fix two broken links in scheduling docs

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -558,7 +558,7 @@ For details about the `status.devices` field, see the
 Kubernetes provides a mechanism for monitoring and reporting the health of dynamically allocated infrastructure resources.
 For stateful applications running on specialized hardware, it is critical to know when a device has failed or become unhealthy. It is also helpful to find out if the device recovers.
 
-To use this functionality, the `ResourceHealthStatus` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/resource-health-status/) must be enabled (beta and enabled by default since v1.36), and the DRA driver must implement the `DRAResourceHealth` gRPC service.
+To use this functionality, the `ResourceHealthStatus` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#ResourceHealthStatus) must be enabled (beta and enabled by default since v1.36), and the DRA driver must implement the `DRAResourceHealth` gRPC service.
 
 When a DRA driver detects that an allocated device has become unhealthy, it reports this status back to the kubelet. This health information is then exposed directly in the Pod's status. The kubelet populates the `allocatedResourcesStatus` field in the status of each container, detailing the health of each device assigned to that container. Each resource health entry can include an optional `message` field with additional human-readable context about the health status, such as error details or failure reasons.
 

--- a/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
@@ -166,5 +166,5 @@ kubectl get podgroup <name> -o jsonpath='{.status.conditions}'
 ## {{% heading "whatsnext" %}}
 
 * Learn about the [Workload API](/docs/concepts/workloads/workload-api/).
-* See how to [reference a Workload](/docs/concepts/workloads/pods/workload-reference/) in a Pod.
+* See how to [reference a Workload](/docs/concepts/workloads/pods/scheduling-group/) in a Pod.
 * Read about [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/).


### PR DESCRIPTION
Both links below currently return 404 on kubernetes.io.

### 1. `dynamic-resource-allocation.md`

Links to `/docs/reference/command-line-tools-reference/feature-gates/resource-health-status/`.

Feature gate pages set `_build: {list: never, render: false}` in their front matter, so they are not published at their own URL — they are rendered into the feature gates index page. `ResourceHealthStatus.md` exists in the repo, but neither `/feature-gates/ResourceHealthStatus/` nor the kebab-case form resolves.

The index page carries `<dt id=ResourceHealthStatus>`, so the anchor is the correct target. This is the form already used elsewhere in these docs, for example `#GenericWorkload` in `scheduling-group.md` and `#WorkloadAwarePreemption` in `workload-api/_index.md`.

### 2. `podgroup-scheduling.md`

Links to `/docs/concepts/workloads/pods/workload-reference/`, which does not exist and never has.

The page that describes how a Pod references its PodGroup is `/docs/concepts/workloads/pods/scheduling-group/` ("You can link a `Pod` to a `PodGroup`..."). `workload-api/_index.md` already links to `scheduling-group/` for the same purpose. The other two links in that same whatsnext list resolve correctly.

### Notes

- The zh-cn translations of both pages appear to carry the same links; happy to follow up separately, or to fold them in here if preferred.
- Not touching `/docs/reference/config-api/kubelet-stats.v1alpha1/`, which is broken but already has several open PRs and issues.