### PR TITLE
Fix feature gate cross-reference links in DeclarativeValidation gates

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md
@@ -21,6 +21,6 @@ The results are compared, and any discrepancies are reported via the `declarativ
 Only the hand-written validation result is returned to the user (eg: actually validates in the request path).
 The original hand-written validation are still the authoritative validations
 when this is enabled but this can be changed if the
-[DeclarativeValidationBeta feature gate](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/)
+[DeclarativeValidationBeta feature gate](/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidationBeta)
 is enabled in addition to this gate.
 This feature gate only operates on the `kube-apiserver` component.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
@@ -14,9 +14,9 @@ stages:
     defaultValue: false
     fromVersion: "1.36"
 ---
-Deprecated: in favor of [DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/).
+Deprecated: in favor of [DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidationBeta).
 
-When enabled, along with the [DeclarativeValidation](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation/)
+When enabled, along with the [DeclarativeValidation](/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidation)
 feature gate, declarative validation errors are returned directly to the caller,
 replacing hand-written validation errors for rules that have declarative implementations.
 When disabled (and `DeclarativeValidation` is enabled), hand-written validation errors are always returned,


### PR DESCRIPTION
The `DeclarativeValidation` and `DeclarativeValidationTakeover` gate descriptions link to other feature gates by path:

- `/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/` (x2)
- `/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation/` (x1)

Both return **404** on kubernetes.io.

Feature gate pages set `_build: {list: never, render: false}` in their front matter, so they are not published at their own URL — their content is rendered into the feature gates index page. The anchor on that index is the correct target:

```
$ curl -s .../docs/reference/command-line-tools-reference/feature-gates/ | grep -o 'id=DeclarativeValidationBeta>'
id=DeclarativeValidationBeta>
```

This is the form already used elsewhere in these docs, for example `#GenericWorkload` in `scheduling-group.md` and `#WorkloadAwarePreemption` in `workload-api/_index.md`.

Related: #57063 fixes the same class of link in `dynamic-resource-allocation.md`. The zh-cn equivalents will follow in a separate PR.