### PR TITLE
[zh-cn] Fix broken feature gate links

### DIFF
--- a/content/zh-cn/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/zh-cn/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -760,7 +760,7 @@ As an alpha feature, Kubernetes provides a mechanism for monitoring and reportin
 For stateful applications running on specialized hardware, it is critical to know when a device has failed or become unhealthy.
 It is also helpful to find out if the device recovers.
 
-To enable this functionality, the `ResourceHealthStatus` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/ResourceHealthStatus/)
+To enable this functionality, the `ResourceHealthStatus` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/#ResourceHealthStatus)
 must be enabled, and the DRA driver must implement the `DRAResourceHealth` gRPC service.
 -->
 作为一种 Alpha 特性，Kubernetes 提供了一种机制用于监控和上报动态分配的基础设施资源的健康状况。
@@ -768,7 +768,7 @@ must be enabled, and the DRA driver must implement the `DRAResourceHealth` gRPC 
 同时，获知设备是否恢复也同样有助于维护应用的稳定性。
 
 要开启这个功能，`ResourceHealthStatus`
-[特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ResourceHealthStatus/)必须启用的同时，
+[特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/#ResourceHealthStatus)必须启用的同时，
 设备驱动程序必须实现了 `DRAResourceHealth` gRPC 服务。
 
 <!--

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md
@@ -23,7 +23,7 @@ The results are compared, and any discrepancies are reported via the `declarativ
 Only the hand-written validation result is returned to the user (eg: actually validates in the request path).
 The original hand-written validation are still the authoritative validations
 when this is enabled but this can be changed if the
-[DeclarativeValidationBeta feature gate](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/)
+[DeclarativeValidationBeta feature gate](/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidationBeta)
 is enabled in addition to this gate.
 This feature gate only operates on the `kube-apiserver` component.
 -->
@@ -32,5 +32,5 @@ API 将同时执行所生成的声明式验证代码和原来手工编写的验�
 `declarative_validation_mismatch_total` 指标进行报告。
 返回给用户的仅是手工编写验证的结果（也就是说，实际在请求路径中起到验证作用者）。
 在启用此特性门控时，原来手工编写的验证逻辑仍然是权威的验证方式，但如果同时启用了
-[DeclarativeValidationBeta 特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/)，
+[DeclarativeValidationBeta 特性门控](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidationBeta)，
 将发生变化。此特性门控仅作用于 kube-apiserver 组件。

--- a/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
+++ b/content/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md
@@ -16,14 +16,14 @@ stages:
 ---
 
 <!--
-Deprecated: in favor of [DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/).
+Deprecated: in favor of [DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidationBeta).
 -->
 已弃用：由
-[DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidationBeta/)
+[DeclarativeValidationBeta](/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidationBeta)
 取代。
 
 <!--
-When enabled, along with the [DeclarativeValidation](/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation/)
+When enabled, along with the [DeclarativeValidation](/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidation)
 feature gate, declarative validation errors are returned directly to the caller,
 replacing hand-written validation errors for rules that have declarative implementations.
 When disabled (and `DeclarativeValidation` is enabled), hand-written validation errors are always returned,
@@ -37,7 +37,7 @@ Note: Although declarative validation aims for functional equivalence with hand-
 the exact description of error messages may differ between the two approaches.
 -->
 启用此特性门控后，若同时启用了
-[DeclarativeValidation](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/DeclarativeValidation)
+[DeclarativeValidation](/zh-cn/docs/reference/command-line-tools-reference/feature-gates/#DeclarativeValidation)
 特性门控，具有声明式实现的验证规则将直接返回声明式验证错误，替代手工编写的验证错误。
 若此特性门控被禁用（但启用了 `DeclarativeValidation`），则始终返回手工编写的验证错误，
 这实际上将声明式验证置于一种**不匹配验证模式（mismatch validation mode）**，


### PR DESCRIPTION
The Chinese pages link to feature gates by path, for example `/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ResourceHealthStatus/`. Those URLs return **404**:

```
$ curl -o /dev/null -w '%{http_code}' -L https://kubernetes.io/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ResourceHealthStatus/
404
$ curl -o /dev/null -w '%{http_code}' -L https://kubernetes.io/zh-cn/docs/reference/command-line-tools-reference/feature-gates/
200
```

Feature gate pages set `_build: {list: never, render: false}`, so they are not published at their own URL — their content is rendered into the feature gates index page. The anchor on that index is the correct target, and it exists in the Chinese build as well:

```
$ curl -s https://kubernetes.io/zh-cn/docs/reference/command-line-tools-reference/feature-gates/ | grep -o 'id=ResourceHealthStatus>'
id=ResourceHealthStatus>
```

Affected files (8 links):

- `concepts/scheduling-eviction/dynamic-resource-allocation.md` — `ResourceHealthStatus`
- `reference/command-line-tools-reference/feature-gates/DeclarativeValidation.md` — `DeclarativeValidationBeta`
- `reference/command-line-tools-reference/feature-gates/DeclarativeValidationTakeover.md` — `DeclarativeValidation`, `DeclarativeValidationBeta`

The commented-out English source lines are updated alongside the translated text so they continue to match the English pages.

Related English PRs: #57063 and #57064.

/language zh