### PR TITLE
[ja] Translate content/en/docs/reference/glossary/resource-quota.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/resource-quota.md
+++ b/content/ja/docs/reference/glossary/resource-quota.md
@@ -1,0 +1,18 @@
+---
+title: リソースクォータ(ResourceQuota)
+id: resource-quota
+full_link: /docs/concepts/policy/resource-quotas/
+short_description: >
+  名前空間ごとの総リソース消費を制限するための制約を提供します。
+
+aka: 
+tags:
+- fundamental
+- operation
+- architecture
+---
+{{< glossary_tooltip text="名前空間" term_id="namespace" >}}ごとの総リソース消費を制限するオブジェクトです。
+<!--more-->
+
+リソースクォータは名前空間内で作成できる{{< glossary_tooltip text="APIリソース" term_id="api-resource" >}}の数を種別ごとに制限したり、その名前空間(およびその中にあるオブジェクト)の代わりに消費される{{< glossary_tooltip text="インフラストラクチャリソース" term_id="infrastructure-resource" >}}の総量に制限を設けることができます。
+

--- a/content/ja/docs/reference/glossary/resource-quota.md
+++ b/content/ja/docs/reference/glossary/resource-quota.md
@@ -14,5 +14,5 @@ tags:
 {{< glossary_tooltip text="名前空間" term_id="namespace" >}}ごとの総リソース消費を制限するオブジェクトです。
 <!--more-->
 
-リソースクォータは名前空間内で作成できる{{< glossary_tooltip text="APIリソース" term_id="api-resource" >}}の数を種別ごとに制限したり、その名前空間(およびその中にあるオブジェクト)の代わりに消費される{{< glossary_tooltip text="インフラストラクチャリソース" term_id="infrastructure-resource" >}}の総量に制限を設けることができます。
+ResourceQuotaは、名前空間内で作成できる{{< glossary_tooltip text="APIリソース" term_id="api-resource" >}}の数を種別ごとに制限したり、その名前空間(の内部にあるオブジェクト)のために消費される{{< glossary_tooltip text="インフラストラクチャリソース" term_id="infrastructure-resource" >}}の総量に制限を設けたりできます。
 


### PR DESCRIPTION
### Description

Translated `content/en/docs/reference/glossary/resource-quota.md` into Japanese: `content/ja/docs/reference/glossary/resource-quota.md`.

#### Website Link:
- English: https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-resource-quota

### Issue

Closes: #56985