### PR TITLE
Add redirect path : ko/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale

### DIFF
--- a/static/_redirects.base
+++ b/static/_redirects.base
@@ -318,6 +318,7 @@
 /docs/tasks/troubleshoot/debug-init-containers/     /docs/tasks/debug/debug-application/debug-init-containers/ 301
 /docs/tasks/web-ui-dashboard/     /docs/tasks/access-application-cluster/web-ui-dashboard/ 301
 /docs/tasks/run-application/horizontal-pod-autoscale/ /docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/ 301
+/ko/docs/tasks/run-application/horizontal-pod-autoscale/     /ko/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/ 301
 /docs/tasks/debug-application-cluster/troubleshooting/     /docs/tasks/debug/ 301
 /docs/tasks/debug-application-cluster/     /docs/tasks/debug/ 301
 /docs/tasks/debug-application-cluster/debug-init-containers/     /docs/tasks/debug/debug-application/debug-init-containers/ 301


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->
- The English page for Horizontal Pod Autoscaling was moved from
`/docs/tasks/run-application/horizontal-pod-autoscale/` to
`/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/`
- Add a 301 redirect from the old Korean path so existing links keep working
- Related pr : https://github.com/kubernetes/website/pull/55320

### Issue
- https://github.com/kubernetes/website/pull/55320#issuecomment-5319533507
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #