### PR TITLE
Fix deprecation policy url

### DIFF
--- a/content/en/docs/reference/deprecation-policy.md
+++ b/content/en/docs/reference/deprecation-policy.md
@@ -6,6 +6,8 @@ reviewers:
 title: Kubernetes Deprecation Policy
 content_type: concept
 weight: 40
+aliases:
+  - /docs/reference/using-api/deprecation-policy/
 ---
 
 <!-- overview -->


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
The Kubernetes deprecation policy covers more than just APIs, but its current URL suggests that it only applies to APIs. This change moves the page to /docs/reference/deprecation-policy/ and keeps the old URL as an alias so existing links continue to work.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #49739

