### PR TITLE
Fix broken Workload reference link in PodGroup scheduling docs

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
@@ -272,5 +272,5 @@ In v1.37, the scheduler does not populate this field, however.
 * Learn about the [Workload API](/docs/concepts/workloads/workload-api/).
 * Read about the [CompositePodGroup API](/docs/concepts/workloads/compositepodgroup-api/) and its [lifecycle](/docs/concepts/workloads/compositepodgroup-api/lifecycle/).
 * Learn about [Topology-aware workload scheduling](/docs/concepts/workloads/workload-api/topology-aware-scheduling/).
-* See how to [reference a Workload](/docs/concepts/workloads/pods/workload-reference/) in a Pod.
+* See how to [reference a PodGroup](/docs/concepts/workloads/pods/scheduling-group/) in a Pod.
 * Read about [gang scheduling](/docs/concepts/scheduling-eviction/gang-scheduling/).


### PR DESCRIPTION
The "whatsnext" list on the PodGroup scheduling page links to a page that does not exist:

```
* See how to [reference a Workload](/docs/concepts/workloads/pods/workload-reference/) in a Pod.
```

`https://kubernetes.io/docs/concepts/workloads/pods/workload-reference/` returns **404**.

## Why

The English page appears to have been renamed to `pods/scheduling-group`:

| | `ja/.../pods/workload-reference.md` | `en/.../pods/scheduling-group.md` |
|---|---|---|
| weight | 90 | 90 |
| feature gate | `GenericWorkload` | `GenericWorkload` |
| opening line | link a Pod to a **Workload** | link a `Pod` to a **PodGroup** |

The Japanese localization still carries the original filename, which is why the target looks like it should exist. There is no `workload-reference.md` under `content/en/docs/concepts/workloads/pods/`.

Since the successor page describes referencing a **PodGroup** rather than a Workload, the link text is updated to match the page it now points at, rather than repointing "reference a Workload" at a page about PodGroups.

The line immediately above already links `/docs/concepts/workloads/workload-api/` (which resolves fine), so this is not a duplicate of that entry.

## Verified

```
404  /docs/concepts/workloads/pods/workload-reference/
200  /docs/concepts/workloads/pods/scheduling-group/
200  /docs/concepts/workloads/workload-api/
```

/sig docs
/language en