### PR TITLE
Fix duplicated words in English documentation

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -266,7 +266,7 @@ Installing an Aggregated API server always involves running a new Deployment.
 Custom resources consume storage space in the same way that ConfigMaps do. Creating too many
 custom resources may overload your API server's storage space.
 
-Custom resources are placed into storage based upon the the current storage
+Custom resources are placed into storage based upon the current storage
 version of the resource, defined in the CRD spec. Any update to a custom
 resource will use the currently defined storage version to store the resource.
 All other versions either need to have all the fields of that version or define

--- a/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
+++ b/content/en/docs/concepts/scheduling-eviction/dynamic-resource-allocation.md
@@ -981,7 +981,7 @@ To support tainting a specific hardware instance, CEL selectors can be used in a
 to match a vendor-specific unique ID attribute, if the driver supports one for its hardware.
 
 The taint applies as long as the DeviceTaintRule exists.
-It can be modified and and removed at any time.
+It can be modified and removed at any time.
 Here is one example of a DeviceTaintRule for a fictional DRA driver:
 
 ```yaml

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableKubeletCloudCredentialProviders.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableKubeletCloudCredentialProviders.md
@@ -22,5 +22,5 @@ stages:
 removed: true
 ---
 Enabling the feature gate deactivated the legacy in-tree functionality within the
-kubelet, that allowed the kubelet to to authenticate to a cloud provider container registry
+kubelet, that allowed the kubelet to authenticate to a cloud provider container registry
 for container image pulls.

--- a/content/en/docs/reference/node/kubelet-files.md
+++ b/content/en/docs/reference/node/kubelet-files.md
@@ -197,7 +197,7 @@ AppArmor profiles are loaded via the node operating system rather then reference
 
 A lock file for the kubelet; typically `/var/run/kubelet.lock`. The kubelet uses this to ensure
 that two different kubelets don't try to run in conflict with each other.
-You can configure the path to the lock file using the the `--lock-file` kubelet command line argument.
+You can configure the path to the lock file using the `--lock-file` kubelet command line argument.
 
 If two kubelets on the same node use a different value for the lock file path, they will not be able to
 detect a conflict when both are running.

--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -47,7 +47,7 @@ sudo sysctl --system
 ```
 
 
-You need to have an IPv4 and and IPv6 address range to use. Cluster operators typically
+You need to have an IPv4 and an IPv6 address range to use. Cluster operators typically
 use private address ranges for IPv4. For IPv6, a cluster operator typically chooses a global
 unicast address block from within `2000::/3`, using a range that is assigned to the operator.
 You don't have to route the cluster's IP address ranges to the public internet.

--- a/content/en/docs/tutorials/cluster-management/admission-policies.md
+++ b/content/en/docs/tutorials/cluster-management/admission-policies.md
@@ -121,7 +121,7 @@ the validation failure in both the API response body and the HTTP `Warning:` hea
 
 #### MutatingAdmissionPolicyBinding {#policy-actions-mutating}
 
-For MutatingAdmissionPolicyBinding, the the action is always to mutate the object.
+For MutatingAdmissionPolicyBinding, the action is always to mutate the object.
 
 You can use a JSON Patch or a Kubernetes _apply configuration_.
 


### PR DESCRIPTION
### Description

Fixes six duplicated-word errors in the English documentation, one per file.

| File | Before | After |
|------|--------|-------|
| `concepts/extend-kubernetes/api-extension/custom-resources.md` | based upon **the the** current storage | based upon **the** current storage |
| `concepts/scheduling-eviction/dynamic-resource-allocation.md` | modified **and and** removed | modified **and** removed |
| `reference/command-line-tools-reference/feature-gates/DisableKubeletCloudCredentialProviders.md` | kubelet **to to** authenticate | kubelet **to** authenticate |
| `reference/node/kubelet-files.md` | using **the the** `--lock-file` | using **the** `--lock-file` |
| `setup/production-environment/tools/kubeadm/dual-stack-support.md` | an IPv4 **and and** IPv6 address range | an IPv4 **and an** IPv6 address range |
| `tutorials/cluster-management/admission-policies.md` | **the the** action is always | **the** action is always |

Five of these are straightforward duplicate-word deletions.

The `dual-stack-support.md` change is the one worth a closer look. Simply
deleting the repeated word would give "an IPv4 and IPv6 address range", which
reads as a single range. The surrounding section describes two separate CIDRs,
one IPv4 and one IPv6, so the intended wording is "an IPv4 **and an** IPv6
address range". It is corrected to `and an` rather than by removing a word.

No headings, anchors, links, or code samples are modified, so there is no
impact on rendering or on incoming links.

Repeated words also appear in a few pages under
`content/en/docs/reference/kubernetes-api/`. Those are generated from the
Kubernetes API source, so they are deliberately left out of this PR; they
would need to be fixed upstream in `kubernetes/kubernetes`.