### PR TITLE
Add API deprecation terminology guidance to the style guide

### DIFF
--- a/content/en/docs/contribute/style/style-guide.md
+++ b/content/en/docs/contribute/style/style-guide.md
@@ -691,6 +691,32 @@ An exception to this rule is documentation about announced deprecations
 targeting removal in future versions. One example of documentation like this
 is the [Deprecated API migration guide](/docs/reference/using-api/deprecation-guide/).
 
+### Use precise terms for deprecated and removed APIs
+
+When you write about API changes, use terms that describe the API's current
+state. For API support timelines, see the
+[Kubernetes Deprecation Policy](/docs/reference/using-api/deprecation-policy/).
+
+- Use _deprecated_ for an API version, field, or feature that still works, but
+  that users should stop using because it is planned for removal or replacement.
+- Use _no longer served_ for an API version that the API server no longer
+  accepts in requests. The resource might still be available through a newer API
+  version.
+- Use _removed_ for a field, feature, or behavior that is no longer available in
+  the release you are documenting. For API versions, prefer _no longer served_
+  when you mean that the API server no longer accepts that version.
+
+Avoid using _obsolete_ for Kubernetes APIs. It is less specific than
+_deprecated_, _no longer served_, or _removed_.
+
+{{< table caption = "Do and Don't - Use precise API change terms" >}}
+Do | Don't
+:--| :-----
+The `batch/v1beta1` API version of CronJob is no longer served as of v1.25. | The `batch/v1beta1` API version of CronJob is obsolete in v1.25.
+Migrate manifests and API clients to use the `batch/v1` API version. | Stop using the removed CronJob API.
+The field is deprecated. Use the replacement field instead. | The field is removed in a future release.
+{{< /table >}}
+
 ### Avoid statements that will soon be out of date
 
 Avoid words like "currently" and "new." A feature that is new today might not be


### PR DESCRIPTION
Fixes #28690. Redo of #55693, as requested in #57025.

## Summary

Adds a style guide section under "Avoid making promises or giving hints about the future" that distinguishes the terms used when writing about API changes:

- _deprecated_ — still works, but users should stop using it
- _no longer served_ — the API server no longer accepts that version in requests
- _removed_ — no longer available in the release being documented

It also advises against _obsolete_ for Kubernetes APIs, since it does not say which of the three applies, and adds a Do/Don't table with concrete `batch/v1beta1` CronJob examples.

## Credit

The wording is @p1930n's, from #55693. That PR was reviewed and had `/lgtm`, but went stale after a Netlify deploy failure that maintainers said a rebase would clear, so #57025 asked for it to be redone. I have kept the content equivalent rather than rewriting approved text; the only difference is that this branch is current with `main`.

@p1930n is credited as co-author on the commit.

## How to check this

- The new section renders on the [Documentation Style Guide](/docs/contribute/style/style-guide/) page in the deploy preview, between "Avoid making promises..." and "Avoid statements that will soon be out of date".
- The two links in it resolve: `/docs/reference/using-api/deprecation-policy/` and, in the surrounding text, `/docs/reference/using-api/deprecation-guide/`.
- The `{{< table >}}` shortcode matches the 26 other uses in the same file.
- The diff also adds the missing newline at end of file, as #55693 did.

## AI usage

I used Claude (Anthropic) as an AI assistant while preparing this pull request, alongside my own review. Original authorship of the guidance is @p1930n's. I am R Sai Pranav (@Pranav-error) and I take responsibility for this submission.
