### PR TITLE
Fix missing copy button on StatefulSet Components example

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/statefulset.md
+++ b/content/en/docs/concepts/workloads/controllers/statefulset.md
@@ -66,57 +66,7 @@ that provides a set of stateless replicas.
 
 The example below demonstrates the components of a StatefulSet.
 
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: nginx
-  labels:
-    app: nginx
-spec:
-  ports:
-  - port: 80
-    name: web
-  clusterIP: None
-  selector:
-    app: nginx
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: web
-spec:
-  selector:
-    matchLabels:
-      app: nginx # has to match .spec.template.metadata.labels
-  serviceName: "nginx"
-  replicas: 3 # by default is 1
-  minReadySeconds: 10 # by default is 0
-  template:
-    metadata:
-      labels:
-        app: nginx # has to match .spec.selector.matchLabels
-    spec:
-      terminationGracePeriodSeconds: 10
-      containers:
-      - name: nginx
-        image: registry.k8s.io/nginx-slim:0.24
-        ports:
-        - containerPort: 80
-          name: web
-        volumeMounts:
-        - name: www
-          mountPath: /usr/share/nginx/html
-  volumeClaimTemplates:
-  - metadata:
-      name: www
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "my-storage-class"
-      resources:
-        requests:
-          storage: 1Gi
-```
+{{% code_sample file="controllers/statefulset.yaml" %}}
 
 {{< note >}}
 This example uses the `ReadWriteOnce` access mode, for simplicity. For

--- a/content/en/examples/controllers/statefulset.yaml
+++ b/content/en/examples/controllers/statefulset.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+  - port: 80
+    name: web
+  clusterIP: None
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: nginx # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  replicas: 3 # by default is 1
+  minReadySeconds: 10 # by default is 0
+  template:
+    metadata:
+      labels:
+        app: nginx # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: registry.k8s.io/nginx-slim:0.24
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "my-storage-class"
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
### Description

On the [StatefulSet concept page](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/), the main "Components" YAML example is a plain fenced ` ```yaml ` block, so it renders **without** a copy-to-clipboard button.

Compare with the [Job concept page](https://kubernetes.io/docs/concepts/workloads/controllers/job/), where the main example is included via the `code_sample` shortcode and does get a copy button (plus a download link to the raw example file).

**Root cause:** the copy-to-clipboard icon (`layouts/shortcodes/code_sample.html`) is only rendered for code blocks pulled in via the `code`, `codenew`, or `code_sample` shortcodes, which read the YAML from a file under `content/en/examples/`. A plain inline ` ```yaml ` fence has no such affordance.

**Fix:**
- Added `content/en/examples/controllers/statefulset.yaml`, containing the exact same manifest that was previously inlined in the doc (verified byte-for-byte via diff).
- Replaced the inline fenced block in `statefulset.md` with `{{% code_sample file="controllers/statefulset.yaml" %}}`, matching the pattern already used in `job.md`.

No content changes — only how the example is included, so it now gets the copy/download UI consistent with other controller docs.

### Issue

N/A — found while comparing the StatefulSet and Job concept pages.


### Disclosure
This PR was written in part with the assistance of generative AI, but humanly review every changes and verified myself manually on the UI