### PR TITLE
Updates v1.34 hugo.toml for release v1.37

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -139,10 +139,10 @@ time_format_default = "January 02, 2006 at 3:04 PM PST"
 description = "Production-Grade Container Orchestration"
 showedit = true
 
-latest = "v1.36"
+latest = "v1.37"
 
 version = "v1.34"
-githubbranch = "1.34.6"
+githubbranch = "v1.34.11"
 docsbranch = "release-1.34"
 # Should be changed to Docsy provided `archived_version` in the future.
 deprecated = true
@@ -182,34 +182,34 @@ js = [
 ]
 
 [[params.versions]]
-version = "v1.36"
-githubbranch = "v1.36.0"
+version = "v1.37"
+githubbranch = "v1.37.0"
 docsbranch = "main"
 url = "https://kubernetes.io"
 
 [[params.versions]]
+version = "v1.36"
+githubbranch = "v1.36.4"
+docsbranch = "release-1.36"
+url = "https://v1-36.docs.kubernetes.io"
+
+[[params.versions]]
 version = "v1.35"
-githubbranch = "v1.35.3"
+githubbranch = "v1.35.8"
 docsbranch = "release-1.35"
 url = "https://v1-35.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.34"
-githubbranch = "v1.34.6"
+githubbranch = "v1.34.11"
 docsbranch = "release-1.34"
 url = "https://v1-34.docs.kubernetes.io"
 
 [[params.versions]]
 version = "v1.33"
-githubbranch = "v1.33.10"
+githubbranch = "v1.33.13"
 docsbranch = "release-1.33"
 url = "https://v1-33.docs.kubernetes.io"
-
-[[params.versions]]
-version = "v1.32"
-githubbranch = "v1.32.13"
-docsbranch = "release-1.32"
-url = "https://v1-32.docs.kubernetes.io"
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
This PR updates the hugo.toml for v1.34 ahead of the v1.37 release.

/hold for v1.37 release day