### PR TITLE
Fix duplicated "type" in ephemeral-container glossary short_description

### DIFF
--- a/content/en/docs/reference/glossary/ephemeral-container.md
+++ b/content/en/docs/reference/glossary/ephemeral-container.md
@@ -3,7 +3,7 @@ title: Ephemeral Container
 id: ephemeral-container
 full_link: /docs/concepts/workloads/pods/ephemeral-containers/
 short_description: >
-  A type of container type that you can temporarily run inside a Pod
+  A type of container that you can temporarily run inside a Pod.
 
 aka:
 tags:


### PR DESCRIPTION
### Description

The `short_description` for the `ephemeral-container` glossary entry currently reads:

> A type of container type that you can temporarily run inside a Pod

The word "type" is duplicated. Comparing with the entry's own body text (`A {{< glossary_tooltip term_id="container" >}} type that you can temporarily run inside a {{< glossary_tooltip term_id="pod" >}}.`), this looks like a copy/paste mistake rather than intentional wording — checked the file history and this line is unchanged since the entry was first added in #15994 (2019).

This PR:
- Removes the duplicated "type": "A type of container type..." -> "A type of container..."
- Adds a trailing period to match the style of sibling glossary entries (e.g. `pod.md`, `container.md`, `node.md`)

This `short_description` is also used as the tooltip text wherever `{{< glossary_tooltip term_id="ephemeral-container" >}}` is referenced elsewhere in the docs, so this also fixes that tooltip text sitewide.

Found while working on the Japanese translation of this glossary entry (#56997), see review discussion: https://github.com/kubernetes/website/pull/56997#discussion_r3789082492

### Issue

None