### PR TITLE
Fix Service selector example in Debug Pods

### DIFF
--- a/content/en/docs/tasks/debug/debug-application/debug-pods.md
+++ b/content/en/docs/tasks/debug/debug-application/debug-pods.md
@@ -162,15 +162,15 @@ IP addresses in the Service's endpoint slices.
 
 #### My service is missing endpoints
 
-If you are missing endpoints, try listing pods using the labels that Service uses.
-Imagine that you have a Service where the labels are:
+If you are missing endpoints, try listing Pods using the labels in the Service selector.
+For example, that you have a Service with the following selector:
 
 ```yaml
 ...
 spec:
-  - selector:
-     name: nginx
-     type: frontend
+  selector:
+    name: nginx
+    type: frontend
 ```
 
 You can use:
@@ -180,7 +180,7 @@ kubectl get pods --selector=name=nginx,type=frontend
 ```
 
 to list pods that match this selector. Verify that the list matches the Pods that you expect to provide your Service.
-Verify that the pod's `containerPort` matches up with the Service's `targetPort`
+Verify that the pod's `containerPort` matches the Service's `targetPort`
 
 #### Network traffic is not forwarded
 


### PR DESCRIPTION
### Description

The Service selector example under "My service is missing endpoints"
currently represents `spec` as a sequence instead of an object.

This change fixes the selector structure and related wording so that the
example matches the Service API and the label-selector command that follows.

/kind bug
/language en
/sig docs
/sig network