### PR TITLE
fix incorrect spec.pod.os field in the Windows user guide

### DIFF
--- a/content/en/docs/concepts/windows/user-guide.md
+++ b/content/en/docs/concepts/windows/user-guide.md
@@ -170,7 +170,7 @@ to `windows`.
 {{< note >}}
 If you are running a version of Kubernetes older than 1.24, you may need to enable
 the `IdentifyPodOS` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-to be able to set a value for `.spec.pod.os`.
+to be able to set a value for `.spec.os.name`.
 {{< /note >}}
 
 The scheduler does not use the value of `.spec.os.name` when assigning Pods to nodes. You should


### PR DESCRIPTION
### Description

Changes `.spec.pod.os` to `.spec.os.name` in the `IdentifyPodOS` note in the Windows user guide.

### Issue

Closes: #57150 

### Comments

The note can be removed entirely if necessary, since it only applies to versions older than v1.24.