### PR TITLE
Write API kinds without backticks in the CompositePodGroup docs

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/gang-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/gang-scheduling.md
@@ -54,16 +54,16 @@ The process follows these steps for each PodGroup:
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+When the [CompositePodGroup](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
-are enabled, gang scheduling extends its support to `CompositePodGroups`.
+are enabled, gang scheduling extends its support to CompositePodGroups.
 
-Contrary to `PodGroups` that group Pods, `CompositePodGroups` group child groups together - either
-`PodGroups` or other `CompositePodGroups`. `CompositePodGroup` specifies a scheduling policy that
+Contrary to PodGroups that group Pods, CompositePodGroups group child groups together - either
+PodGroups or other CompositePodGroups. CompositePodGroup specifies a scheduling policy that
 applies to its child groups during scheduling:
 
 * `gang` policy with a `minGroupCount` field, specifying the minimum number of child groups (either
-  `CompositePodGroup` or `PodGroup` objects) that must be scheduled together as a single unit
+  CompositePodGroup or PodGroup objects) that must be scheduled together as a single unit
   atomically.
 * `basic` policy which indicates that child groups can be scheduled independently.
 
@@ -76,35 +76,35 @@ scheduled as an independent gang, e.g. for AI inference workloads.
 
 ### Hierarchical quorum
 
-The `GangScheduling` plugin holds the root `CompositePodGroup` from entering the active scheduling
+The `GangScheduling` plugin holds the root CompositePodGroup from entering the active scheduling
 queue in the `PreEnqueue` phase until it satisfies the **hierarchical quorum**. This quorum is
-evaluated bottom-up, from leaf `PodGroup` objects up to the root `CompositePodGroup`:
+evaluated bottom-up, from leaf PodGroup objects up to the root CompositePodGroup:
 
-- A leaf `PodGroup` **satisfies quorum** if and only if the `PodGroup` object exists and can
+- A leaf PodGroup **satisfies quorum** if and only if the PodGroup object exists and can
   potentially meet its scheduling policy criteria:
   - For a `gang` policy: at least `minCount` of its constituent Pods have been created.
   - For a `basic` policy: at least one of its constituent Pods has been created.
-- A `CompositePodGroup` **satisfies quorum** if and only if the `CompositePodGroup` object exists
+- A CompositePodGroup **satisfies quorum** if and only if the CompositePodGroup object exists
   and can potentially meet its scheduling policy criteria:
   - For a `gang` policy: at least `minGroupCount` of its direct child groups satisfy quorum.
   - For a `basic` policy: at least one of its direct child groups satisfies quorum.
-- The overall **hierarchical quorum** is satisfied if and only if the root `CompositePodGroup`
+- The overall **hierarchical quorum** is satisfied if and only if the root CompositePodGroup
   satisfies the quorum.
 
-Ultimately, a root `CompositePodGroup` is admitted into the active scheduling queue if and only if
+Ultimately, a root CompositePodGroup is admitted into the active scheduling queue if and only if
 it satisfies the hierarchical quorum and there is at least one pending Pod that belongs to one of
-its descendant `PodGroups`.
+its descendant PodGroups.
 
 ### Placement feasibility
 
 The `GangScheduling` plugin's `PlacementFeasible` method supports evaluation for both
-`PodGroups` and `CompositePodGroups`. It is invoked by the scheduling cycle before starting child
-evaluation and after evaluating each child group of a `CompositePodGroup`.
+PodGroups and CompositePodGroups. It is invoked by the scheduling cycle before starting child
+evaluation and after evaluating each child group of a CompositePodGroup.
 
 By taking into account the number of child groups that were successfully scheduled and the child
 groups that were not evaluated in the scheduling cycle just yet, `PlacementFeasible` determines
 whether the group's policy constraint is still achievable, allowing the scheduling cycle to abort
-the evaluation of the `CompositePodGroup` early if its underlying scheduling policy cannot be
+the evaluation of the CompositePodGroup early if its underlying scheduling policy cannot be
 satisfied anymore.
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/podgroup-scheduling.md
@@ -143,24 +143,24 @@ and the PodGroup is rejected if the constraint is not met.
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+When the [CompositePodGroup](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
 are enabled, the scheduler extends the PodGroup scheduling cycle to support multi-level group
 hierarchies.
 
-In a hierarchical workload, Pods belong to leaf `PodGroup` objects, which in turn specify parent
-`CompositePodGroup` resources up to the root `CompositePodGroup`. The scheduler evaluates the entire
+In a hierarchical workload, Pods belong to leaf PodGroup objects, which in turn specify parent
+CompositePodGroup resources up to the root CompositePodGroup. The scheduler evaluates the entire
 hierarchy of groups as a single, unified scheduling unit.
 
 ### Hierarchical scheduling cycle execution
 
-After observing a root `CompositePodGroup`, the scheduler places it in the scheduling queue as long
+After observing a root CompositePodGroup, the scheduler places it in the scheduling queue as long
 as there is at least one pending Pod that belongs to that root's group hierarchy.
 
-Once the root `CompositePodGroup` satisfies the
+Once the root CompositePodGroup satisfies the
 [hierarchical quorum](/docs/concepts/scheduling-eviction/gang-scheduling/#Hierarchical-quorum), it
 enters the active scheduling queue from which it can be popped by the scheduling cycle. The flow of
-the scheduling cycle for `CompositePodGroups` is as follows:
+the scheduling cycle for CompositePodGroups is as follows:
 
 1. **Unified cluster snapshot and validation**: The scheduler takes a snapshot of cluster resources
    to mirror the latest observed cluster state. It verifies that the shape of the group hierarchy
@@ -169,22 +169,22 @@ the scheduling cycle for `CompositePodGroups` is as follows:
    Pods).
    
    If the hierarchy shape changed concurrently or fails the validation, the cycle halts and requeues
-   the root `CompositePodGroup`.
+   the root CompositePodGroup.
 
 2. **Top-down candidate placement generation**: At each level of the hierarchy, before evaluating
    child groups, the scheduler invokes `PlacementGeneratePlugin` plugins to generate candidate
    placements (subsets of nodes) for the group being evaluated.
    
-   Candidate placements for a child `CompositePodGroup` or leaf `PodGroup` are generated exclusively
+   Candidate placements for a child CompositePodGroup or leaf PodGroup are generated exclusively
    from the subset of nodes belonging to the parent group's currently evaluated placement. For the
-   root `CompositePodGroup`, candidate placements are generated across all available cluster nodes.
+   root CompositePodGroup, candidate placements are generated across all available cluster nodes.
 
 3. **Recursive subtree simulation and feasibility check**: The scheduler evaluates each candidate
-   placement for a `CompositePodGroup` by temporarily assuming that placement in the cluster
+   placement for a CompositePodGroup by temporarily assuming that placement in the cluster
    snapshot and recursively scheduling its child groups:
    * **Recursive traversal**: The scheduler traverses child groups in a pre-sorted order, invoking
-     itself recursively from the `CompositePodGroup` down to leaf `PodGroup` objects. For each leaf
-     `PodGroup`, the scheduler runs the placement scheduling algorithm scoped to the parent's
+     itself recursively from the CompositePodGroup down to leaf PodGroup objects. For each leaf
+     PodGroup, the scheduler runs the placement scheduling algorithm scoped to the parent's
      candidate placement to make tentative Pod assignments in memory.
    * **Feasibility checks**: After evaluating each child group, the scheduler invokes
      `PlacementFeasible` plugins to determine whether the parent group's scheduling policy can
@@ -192,42 +192,42 @@ the scheduling cycle for `CompositePodGroups` is as follows:
      * If the policy constraints remain achievable (or are already satisfied), the scheduler continues
        evaluating subsequent sibling groups.
      * If the policy constraints can no longer be satisfied, the scheduler immediately aborts the evaluation
-       of that `CompositePodGroup` and reverts all tentative in-memory Pod assignments made for that group.
+       of that CompositePodGroup and reverts all tentative in-memory Pod assignments made for that group.
    * **Simulation rollback**: After simulating a candidate placement (regardless of success or failure),
      the scheduler reverts the tentative node reservations made during that simulation before
      evaluating the next candidate placement.
 
 4. **Placement scoring and subtree commitment**: Once all candidate placements for a
-   `CompositePodGroup` have been evaluated:
+   CompositePodGroup have been evaluated:
    * **Scoring**: If one or more candidate placements are feasible, the scheduler invokes
      `PlacementScorePlugin` plugins to score all feasible candidate placements. The scoring plugins
-     evaluate the combined proposed Pod assignments across all descendant leaf `PodGroup` objects in
+     evaluate the combined proposed Pod assignments across all descendant leaf PodGroup objects in
      the subtree and select the placement with the highest overall score.
    * **Commitment**: After selecting the winning placement, the scheduler commits (assumes) the
      tentative Pod assignments corresponding to that optimal placement in memory. This ensures that
      subsequent sibling group evaluations or parent-level evaluations observe consistent, optimal
      scheduling decisions for that subtree.
      
-     If no feasible placement is found among all generated candidates, the entire `CompositePodGroup`
+     If no feasible placement is found among all generated candidates, the entire CompositePodGroup
      is considered unschedulable.
 
 5. **Atomic binding**: If the root-level recursive evaluation succeeds and at least one Pod was
    successfully scheduled, the scheduler commits the Pod assignments by proceeding to the binding
    cycle.
 
-   Otherwise, the entire `CompositePodGroup` is considered unschedulable.
+   Otherwise, the entire CompositePodGroup is considered unschedulable.
 
 ### Limitations
 
 Similar to how the PodGroup scheduling algorithm relies on specific Pod sorting, the hierarchical
-scheduling algorithm relies on a specific sorting of child groups within every `CompositePodGroup`
+scheduling algorithm relies on a specific sorting of child groups within every CompositePodGroup
 hierarchy. As a result, it may fail to find a valid placement that could have been discovered by
 processing the child groups in a different order.
 
 In addition, because the scheduler evaluates group hierarchies using a greedy approach:
 
 * Finding a valid placement is not guaranteed in all cases, even if one exists in the cluster.
-* Even when the scheduler successfully finds a valid placement for a `CompositePodGroup` hierarchy,
+* Even when the scheduler successfully finds a valid placement for a CompositePodGroup hierarchy,
   that placement is not guaranteed to be optimal across the cluster.
 
 ## PodGroup conditions

--- a/content/en/docs/concepts/scheduling-eviction/topology-aware-scheduling.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-aware-scheduling.md
@@ -74,21 +74,21 @@ profiles:
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+When the [CompositePodGroup](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
 are enabled, the Topology-Aware Scheduling plugins extend their support to multi-level
-`CompositePodGroup` hierarchies. These plugins are called for `CompositePodGroups` during
+CompositePodGroup hierarchies. These plugins are called for CompositePodGroups during
 [hierarchical scheduling](/docs/concepts/scheduling-eviction/podgroup-scheduling).
 
 ### Candidate placement generation
 
-For workloads defined with a `CompositePodGroup` hierarchy, the `TopologyPlacement` plugin generates
+For workloads defined with a CompositePodGroup hierarchy, the `TopologyPlacement` plugin generates
 candidate placements top-down across the group hierarchy by successive subdivision:
 
-* For a root `CompositePodGroup`, `TopologyPlacement` generates candidate placements across all
+* For a root CompositePodGroup, `TopologyPlacement` generates candidate placements across all
   available cluster nodes by grouping nodes based on the distinct values of the requested topology
   `key`.
-* For a child `CompositePodGroup` or leaf `PodGroup`, `TopologyPlacement` generates candidate
+* For a child CompositePodGroup or leaf PodGroup, `TopologyPlacement` generates candidate
   placements confined in the placement assumed by the parent group. It subdivides the set of nodes
   from the parent group's placement by grouping those nodes based on the child group's requested
   topology `key`.
@@ -99,20 +99,20 @@ candidate placement equivalent to the parent placement.
 
 Similarly, if the root group does not specify any topology constraint, the plugin generates a single
 candidate placement corresponding to all available nodes in the cluster. This is also true for
-single-level workloads using the `PodGroup` API where no topology constraint is specified.
+single-level workloads using the PodGroup API where no topology constraint is specified.
 {{< /note >}}
 
 ### Placement scoring
 
-When scoring a candidate placement for a `CompositePodGroup`, the scoring plugins apply similar
-logic to the single-level `PodGroup` case:
+When scoring a candidate placement for a CompositePodGroup, the scoring plugins apply similar
+logic to the single-level PodGroup case:
 
 * `PodGroupPodsCount`: Scores candidate placements based on the total number of Pods (both
-  already scheduled and newly assumed) across all descendant leaf `PodGroups` of that
-  `CompositePodGroup`. Candidate placements capable of accommodating a higher total number of Pods
+  already scheduled and newly assumed) across all descendant leaf PodGroups of that
+  CompositePodGroup. Candidate placements capable of accommodating a higher total number of Pods
   across the subhierarchy receive higher scores.
 * `NodeResourcesFit`: Aggregates the resource requests of all proposed Pods across all descendant
-  `PodGroups` of that `CompositePodGroup` and evaluates resource utilization across all nodes within
+  PodGroups of that CompositePodGroup and evaluates resource utilization across all nodes within
   the candidate placement's domain.
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/scheduling-eviction/workload-aware-preemption.md
+++ b/content/en/docs/concepts/scheduling-eviction/workload-aware-preemption.md
@@ -93,31 +93,31 @@ another potential victim until all victims are processed.
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+When the [CompositePodGroup](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
-are enabled, workload-aware preemption provides support for `CompositePodGroups` as well.
+are enabled, workload-aware preemption provides support for CompositePodGroups as well.
 
-The underlying preemption mechanism is the same as for `PodGroups` - if the scheduler needs to free
-up capacity to place the root `CompositePodGroup`, it evaluates preemption for the entire group
+The underlying preemption mechanism is the same as for PodGroups - if the scheduler needs to free
+up capacity to place the root CompositePodGroup, it evaluates preemption for the entire group
 hierarchy, rather than for individual pods.
 
-`CompositePodGroups` can be selected as preemption victims as well. The victim selection process is
-adjusted to take `CompositePodGroups` into account in the following way:
+CompositePodGroups can be selected as preemption victims as well. The victim selection process is
+adjusted to take CompositePodGroups into account in the following way:
 
 1. Victim importance hierarchy:
-   - `CompositePodGroups` are considered more important than standalone `PodGroups` of the same
+   - CompositePodGroups are considered more important than standalone PodGroups of the same
      priority.
-   - For two `CompositePodGroups` of the same priority, the one with more members (larger size) is
+   - For two CompositePodGroups of the same priority, the one with more members (larger size) is
      considered more important.
 
-2. Disruption mode: Similar to `PodGroups`, `CompositePodGroups` specify
+2. Disruption mode: Similar to PodGroups, CompositePodGroups specify
    [disruption mode](/docs/concepts/workloads/workload-api/disruption-and-priority/) that determines
    how its child groups should be treated during preemption.
 
-Besides workload-aware preemption, `CompositePodGroups` can be selected as preemption victims by
-default Pod preemption during Pod scheduling cycle, alongside `PodGroups` and Pods. Default Pod
+Besides workload-aware preemption, CompositePodGroups can be selected as preemption victims by
+default Pod preemption during Pod scheduling cycle, alongside PodGroups and Pods. Default Pod
 preemption shares the victim importance hierarchy logic with the workload-aware preemption and
-respects the `disruptionMode` field of `CompositePodGroups`.
+respects the `disruptionMode` field of CompositePodGroups.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/workloads/compositepodgroup-api/_index.md
+++ b/content/en/docs/concepts/workloads/compositepodgroup-api/_index.md
@@ -7,38 +7,38 @@ no_list: true
 <!-- overview -->
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-A `CompositePodGroup` is a runtime object that represents a non-leaf node in a multi-level workload
+A CompositePodGroup is a runtime object that represents a non-leaf node in a multi-level workload
 hierarchy. While the [Workload API](/docs/concepts/workloads/workload-api/) defines static scheduling
-policy templates, `CompositePodGroup` and `PodGroup` objects are the runtime counterparts that
+policy templates, CompositePodGroup and PodGroup objects are the runtime counterparts that
 carry policies and hierarchy references for a specific workload instance.
 
 <!-- body -->
 
 ## What is a CompositePodGroup?
 
-The `CompositePodGroup` API resource is part of the `scheduling.k8s.io/v1alpha3`
+The CompositePodGroup API resource is part of the `scheduling.k8s.io/v1alpha3`
 {{< glossary_tooltip text="API group" term_id="api-group" >}}. Your cluster must have that API
-group enabled, as well as the `CompositePodGroup`
+group enabled, as well as the CompositePodGroup
 [feature gate](/docs/reference/command-line-tools-reference/feature-gates/),
 before you can use this API.
 
-A `CompositePodGroup` represents a grouping of child groups (which can be `CompositePodGroup` or
-`PodGroup` objects). It carries scheduling policies, disruption modes, priority
+A CompositePodGroup represents a grouping of child groups (which can be CompositePodGroup or
+PodGroup objects). It carries scheduling policies, disruption modes, priority
 settings, and optional topology constraints that apply collectively across its child groups.
 
 ## API structure
 
-A `CompositePodGroup` consists of a `spec` that defines the desired scheduling behavior
+A CompositePodGroup consists of a `spec` that defines the desired scheduling behavior
 for its child groups, and a `status` subresource.
 
 ### Scheduling policy
 
-Each `CompositePodGroup` carries a [scheduling policy](/docs/concepts/workloads/workload-api/policies/)
+Each CompositePodGroup carries a [scheduling policy](/docs/concepts/workloads/workload-api/policies/)
 (`basic` or `gang`) in `spec.schedulingPolicy`. When a workload controller creates a
-`CompositePodGroup`, this policy is copied from the `Workload`'s `CompositePodGroupTemplate`
+CompositePodGroup, this policy is copied from the Workload's `CompositePodGroupTemplate`
 at creation time.
 
-For a `gang` policy on a `CompositePodGroup`, the `minGroupCount` field specifies the
+For a `gang` policy on a CompositePodGroup, the `minGroupCount` field specifies the
 minimum number of child groups that must be schedulable simultaneously:
 
 ```yaml
@@ -50,8 +50,8 @@ spec:
 
 ### Parent group reference
 
-Non-root `CompositePodGroup` resources specify their parent group using
-`spec.parentCompositePodGroupName`. Root `CompositePodGroup` objects leave this field unset.
+Non-root CompositePodGroup resources specify their parent group using
+`spec.parentCompositePodGroupName`. Root CompositePodGroup objects leave this field unset.
 
 ```yaml
 spec:
@@ -60,8 +60,8 @@ spec:
 
 ### Workload reference
 
-The `spec.workloadRef` field links the `CompositePodGroup` back to the
-`CompositePodGroupTemplate` in the `Workload` object it was derived from.
+The `spec.workloadRef` field links the CompositePodGroup back to the
+`CompositePodGroupTemplate` in the Workload object it was derived from.
 
 ```yaml
 spec:
@@ -72,17 +72,17 @@ spec:
 
 ### Status
 
-The `CompositePodGroup` API schema includes a `status` subresource. In the alpha release,
+The CompositePodGroup API schema includes a `status` subresource. In the alpha release,
 the `status` field is present in the API type, but `kube-scheduler` does not update or
-populate status conditions for `CompositePodGroup` objects. Status tracking for composite
+populate status conditions for CompositePodGroup objects. Status tracking for composite
 groups will be implemented in future releases.
 
 ## Creating a CompositePodGroup
 
-Workload controllers create `CompositePodGroup` objects automatically from `Workload`
+Workload controllers create CompositePodGroup objects automatically from Workload
 templates at runtime.
 
-The following manifest creates a root `CompositePodGroup` with a gang scheduling policy
+The following manifest creates a root CompositePodGroup with a gang scheduling policy
 that requires at least 2 child groups to be schedulable simultaneously:
 
 ```yaml
@@ -100,7 +100,7 @@ spec:
       minGroupCount: 2
 ```
 
-You can inspect `CompositePodGroup` resources in your cluster:
+You can inspect CompositePodGroup resources in your cluster:
 
 ```shell
 kubectl get compositepodgroups
@@ -117,11 +117,11 @@ kubectl describe compositepodgroup root-group-0
 The relationship between controllers, Workloads, CompositePodGroups, PodGroups, and
 Pods follows this pattern:
 
-1. The workload controller creates a `Workload` defining a tree of
+1. The workload controller creates a Workload defining a tree of
    `CompositePodGroupTemplates` and leaf `PodGroupTemplates`.
-2. For each runtime instance, the controller creates a root `CompositePodGroup`,
-   descendant `CompositePodGroup` objects, and leaf `PodGroup` objects in a top-down manner.
-3. The controller creates `Pods` that reference their leaf `PodGroup` via
+2. For each runtime instance, the controller creates a root CompositePodGroup,
+   descendant CompositePodGroup objects, and leaf PodGroup objects in a top-down manner.
+3. The controller creates `Pods` that reference their leaf PodGroup via
    `spec.schedulingGroup.podGroupName`.
 
 The following example illustrates a complete manifest hierarchy for a two-level workload:
@@ -202,8 +202,8 @@ spec:
     image: registry.k8s.io/pause:3.9
 ```
 
-The `Workload` acts as a long-lived policy template, while `CompositePodGroup` and
-`PodGroup` resources handle per-instance runtime scheduling state.
+The Workload acts as a long-lived policy template, while CompositePodGroup and
+PodGroup resources handle per-instance runtime scheduling state.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
+++ b/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
@@ -42,15 +42,15 @@ It instructs the scheduler that all pods from the PodGroup have to be disrupted 
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-A `CompositePodGroup` can also declare a `disruptionMode` in its specification, which controls
+A CompositePodGroup can also declare a `disruptionMode` in its specification, which controls
 how the scheduler disrupts child groups within the composite group during preemption events.
 
-The API supports two disruption modes for `CompositePodGroups`:
+The API supports two disruption modes for CompositePodGroups:
 
-- **`Single`**: Allows individual child groups within the `CompositePodGroup` to be disrupted
+- **`Single`**: Allows individual child groups within the CompositePodGroup to be disrupted
   independently during preemption.
-- **`All`**: Enforces all-or-nothing disruption semantics across the `CompositePodGroup` hierarchy.
-  If any Pod contained in the hierarchy below this `CompositePodGroup` has to be preempted, all of
+- **`All`**: Enforces all-or-nothing disruption semantics across the CompositePodGroup hierarchy.
+  If any Pod contained in the hierarchy below this CompositePodGroup has to be preempted, all of
   the Pods from the entire hierarchy must be preempted.
 
 If not specified, the mode defaults to `Single`.
@@ -106,46 +106,46 @@ spec:
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-`CompositePodGroup` API has `priorityClassName` and `priority` fields as well and their resolution
-is performed in the same way as for the `PodGroups`, through the priority admission controller.
+CompositePodGroup API has `priorityClassName` and `priority` fields as well and their resolution
+is performed in the same way as for the PodGroups, through the priority admission controller.
 
-The priority of a root `CompositePodGroup` acts as the authoritative priority for all child groups
+The priority of a root CompositePodGroup acts as the authoritative priority for all child groups
 and Pods within its hierarchy during
 [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) events.
 All Pods within a single group hierarchy must share the exact same priority and must be equal to the
-priority of the root `CompositePodGroup`.
+priority of the root CompositePodGroup.
 
-The value of priority is also used for the ordering of root `CompositePodGroups` in the scheduling
+The value of priority is also used for the ordering of root CompositePodGroups in the scheduling
 active queue.
 
 {{< note >}}
 In v1.37, the scheduler doesn't validate if the non-root groups have priority value that is equal to
-the priority of the root `CompositePodGroup`.
+the priority of the root CompositePodGroup.
 {{< /note >}}
 
 ### PreemptionPolicy in CompositePodGroup
 
 {{< feature-state feature_gate_name="PodGroupPreemptionPolicy" >}}
 
-The `CompositePodGroup` API has the `preemptionPolicy` field as well and its resolution is performed
-in the exact same way as for the `PodGroup` API.
+The CompositePodGroup API has the `preemptionPolicy` field as well and its resolution is performed
+in the exact same way as for the PodGroup API.
 
-The value of `preemptionPolicy` of the root `CompositePodGroup` determines whether
+The value of `preemptionPolicy` of the root CompositePodGroup determines whether
 [workload-aware preemption](/docs/concepts/scheduling-eviction/workload-aware-preemption/) can be
 invoked to fit its Pods during scheduling if needed:
 
 - `PreemptLowerPriority` policy allows preempting victims with lower priority,
-- `Never` policy disables workload-aware preemption for that root `CompositePodGroup`.
+- `Never` policy disables workload-aware preemption for that root CompositePodGroup.
 
 All Pods within a single group hierarchy must share the exact same preemption policy which must be
-equal to the preemption policy of the root `CompositePodGroup`.
+equal to the preemption policy of the root CompositePodGroup.
 
-If the feature flag is disabled, the root `CompositePodGroup` will be allowed to perform preemption
+If the feature flag is disabled, the root CompositePodGroup will be allowed to perform preemption
 unless one of the Pods that belongs to the group hierarchy has `preemptionPolicy` set to `Never`.
 
 {{< note >}}
 In v1.37, when the feature gate is enabled, the scheduler doesn't validate if the non-root groups
-have preemption policy that is equal to the preemption policy of the root `CompositePodGroup`.
+have preemption policy that is equal to the preemption policy of the root CompositePodGroup.
 {{< /note >}}
 
 ## {{% heading "whatsnext" %}}

--- a/content/en/docs/concepts/workloads/workload-api/policies.md
+++ b/content/en/docs/concepts/workloads/workload-api/policies.md
@@ -70,23 +70,23 @@ directly on the PodGroup itself.
 
 {{< feature-state feature_gate_name="CompositePodGroup" >}}
 
-When the [`CompositePodGroup`](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
+When the [CompositePodGroup](/docs/reference/command-line-tools-reference/feature-gates/#CompositePodGroup)
 feature gate and the `scheduling.k8s.io/v1alpha3` {{< glossary_tooltip text="API group" term_id="api-group" >}}
-are enabled, `CompositePodGroupTemplates` in a Workload and the `CompositePodGroup` objects also
+are enabled, `CompositePodGroupTemplates` in a Workload and the CompositePodGroup objects also
 declare a scheduling policy.
 
-While a scheduling policy in a `PodGroup` governs a collection of individual Pods, a
-`CompositePodGroup` scheduling policy governs its direct **child groups** (which can be both
-`CompositePodGroup` and `PodGroup` objects).
+While a scheduling policy in a PodGroup governs a collection of individual Pods, a
+CompositePodGroup scheduling policy governs its direct **child groups** (which can be both
+CompositePodGroup and PodGroup objects).
 
 ### Policy types for CompositePodGroups
 
-Similar to `PodGroups`, the `spec.schedulingPolicy` field of a `CompositePodGroup` supports two
+Similar to PodGroups, the `spec.schedulingPolicy` field of a CompositePodGroup supports two
 types:
 
-- **`basic`**: Child groups within the `CompositePodGroup` are evaluated and admitted independently.
+- **`basic`**: Child groups within the CompositePodGroup are evaluated and admitted independently.
 - **`gang`**: Enforces multi-level all-or-nothing scheduling across child groups. The
-  `CompositePodGroup` is schedulable only if at least `minGroupCount` child groups can be scheduled
+  CompositePodGroup is schedulable only if at least `minGroupCount` child groups can be scheduled
   simultaneously.
 
 ```yaml
@@ -100,8 +100,8 @@ schedulingPolicy:
 ### Setting composite policies via templates
 
 When using the [Workload API](/docs/concepts/workloads/workload-api/), scheduling policies for
-`CompositePodGroups` are defined inside `CompositePodGroupTemplates`. Workload controllers copy the
-`schedulingPolicy` specified in the templates into each `CompositePodGroup` created at runtime.
+CompositePodGroups are defined inside `CompositePodGroupTemplates`. Workload controllers copy the
+`schedulingPolicy` specified in the templates into each CompositePodGroup created at runtime.
 Unlike leaf `PodGroupTemplates` where `minCount` can be updated, `minGroupCount` in a
 `CompositePodGroupTemplate` is immutable.
 


### PR DESCRIPTION
Fixes #56893.

The style guide says API kinds are [written verbatim, without backticks](/docs/contribute/style/style-guide/#code-style-inline-code) — "API kinds such as StatefulSet or ConfigMap are written verbatim (no backticks); this allows using possessive apostrophes". The CompositePodGroup pages wrote them as teletype text instead.

This removes the backticks from `CompositePodGroup`, `PodGroup` and `Workload` — and their plurals — across the seven files listed in the issue. 134 occurrences.

Targeting **dev-1.37**, since v1.37 has not been released yet. I understand from @lmktfy's comment on the issue that this may be held until after the release; that's fine.

## What I did not change

Only those three API kinds. Other backticked identifiers on these pages are left alone, because they are not API kinds and the rule does not apply to them:

- field and property names (`spec.replicas` and similar)
- scheduler plugin names such as `GangScheduling`
- `TopologyPlacement`

If any of those should also change, I'm happy to do it in a follow-up once someone confirms which are API kinds.

## How I checked it

- Replacements were applied only outside fenced code blocks, so the `kind: CompositePodGroup` lines in the YAML examples are untouched.
- Markdown links were rewritten as `[CompositePodGroup](/url)` rather than being left with a stray backtick inside the label.
- No backticked occurrences of the three kinds remain, and the backtick count in every file is still even.

This was submitted by an AI agent and has not been checked by a human.
