### PR TITLE
Fixes: v1.37 Rootless beta Blog links

### DIFF
--- a/content/en/blog/_posts/2026/rootless-beta.md
+++ b/content/en/blog/_posts/2026/rootless-beta.md
@@ -13,7 +13,7 @@ CNI plugins, and kube-proxy) can run as a non-root user on the host, using a
 [Linux user namespace](https://man7.org/linux/man-pages/man7/user_namespaces.7.html).
 This technique is also known as _rootless mode_.
 The work started as an experiment in 2018, and was merged into Kubernetes v1.22 (2021)
-as an alpha feature (Kubernetes Enhancement Proposal [KEP-2033](https://github.com/kubernetes/enhancements/issues/2033)).
+as an alpha feature (Kubernetes Enhancement Proposal [KEP-2033](https://www.kubernetes.dev/resources/keps/2033/)).
 
 This feature should not be confused with [user namespaces for pods](/docs/concepts/workloads/pods/user-namespaces/)
 (`hostUsers: false` with the `UserNamespacesSupport` feature gate, GA since v1.36),
@@ -80,7 +80,7 @@ A Linux kernel _user namespace_ maps a host level non-root user (e.g., UID 1000)
 privileges are limited to the inside of the namespace.
 The fake root is enough for most of the node components' tasks: mounting volumes,
 creating cgroups, and configuring the network namespaces of pods.
-It still comes with some [caveats](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2033-kubelet-in-userns-aka-rootless/README.md#notesconstraintscaveats-optional) that may break compatibility with specific CNI and CSI drivers, though.
+It still comes with some [caveats](https://www.kubernetes.dev/resources/keps/2033/#notesconstraintscaveats-optional) that may break compatibility with specific CNI and CSI drivers, though.
 
 The user namespace has to be created outside of Kubernetes.
 For example, [Rootless](https://docs.docker.com/engine/security/rootless/) Docker can be used to prepare the user namespace in which Kubernetes runs.

--- a/content/en/blog/_posts/2026/rootless-beta.md
+++ b/content/en/blog/_posts/2026/rootless-beta.md
@@ -172,8 +172,8 @@ open an issue in the [kubernetes/kubernetes](https://github.com/kubernetes/kuber
 
 The project is also discussing several Kubernetes Enhancement Proposals that may contribute to
 simplifying Kubernetes-in-Kubernetes with this feature:
-- [KEP-5474: Enable Writable cgroups for unprivileged containers](https://github.com/kubernetes/enhancements/issues/5474)
-- [KEP-5714: Allow specifying whether to unshare cgroup namespaces](https://github.com/kubernetes/enhancements/issues/5714)
+- [KEP-5474: Enable Writable cgroups for unprivileged containers](https://www.kubernetes.dev/resources/keps/5474/)
+- [KEP-5714: Allow specifying whether to unshare cgroup namespaces](https://www.kubernetes.dev/resources/keps/5714)
 
 ## Getting involved
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->


<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->



<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Description

#### What this PR does

Updates the KEP-5474 and KEP-5714 links in the rootless blog post to point to their Kubernetes.dev KEP pages instead of the GitHub issue pages.

#### Why

The current links are not the preferred KEP URLs and should be updated before publication.

#### Related

The hyperlink issues were noted during the review of #56420.

### Issue

Not applicable.