### PR TITLE
Fix incorrect anchor link in pod-sidecar-containers tutorial

### DIFF
--- a/content/en/docs/tutorials/configuration/pod-sidecar-containers.md
+++ b/content/en/docs/tutorials/configuration/pod-sidecar-containers.md
@@ -71,7 +71,7 @@ Using Kubernetes' native support for sidecar containers provides several benefit
 1. Also, with Jobs, built-in sidecar containers would keep being restarted once they are done,
    even if regular containers would not with Pod's `restartPolicy: Never`.
 
-See [differences from init containers](/docs/concepts/workloads/pods/sidecar-containers/#differences-from-application-containers)
+See [differences from init containers](/docs/concepts/workloads/pods/sidecar-containers/#differences-from-init-containers)
 to learn more about it.
 
 ## Adopting built-in sidecar containers


### PR DESCRIPTION
Fixed an incorrect anchor link in the pod-sidecar-containers tutorial. The
link labeled "differences from init containers" was pointing to the wrong
section anchor (#differences-from-application-containers) instead of the
correct one (#differences-from-init-containers) in the sidecar-containers
concept page.

Closes: #57159