### PR TITLE
[Feature Blog v1.37]: Publishes Kubernetes v1.37: Metrics API graduates to stable

### DIFF
--- a/content/en/blog/_posts/2026/kubernetes-v1-37-metrics-api-ga/index.md
+++ b/content/en/blog/_posts/2026/kubernetes-v1-37-metrics-api-ga/index.md
@@ -2,7 +2,7 @@
 layout: blog
 title: "Kubernetes v1.37: Metrics API graduates to stable"
 slug: kubernetes-v1-37-metrics-api-ga
-draft: true
+date: 2026-08-27T10:30:00-08:00
 author: >
   [ChengHao Yang](https://github.com/tico88612)
 ---


### PR DESCRIPTION
Publishes: **Kubernetes v1.37: Metrics API graduates to stable** on: **Thursday 27 August 2026**

cc: v1.37 Communications Team: @SwathiR03 @RinkiyaKeDad @TineoC @kirti763 @SophiaUgo @troy0820