### PR TITLE
[Feature Blog v1.37]: Publishes Kubernetes v1.37: Pod Certificates and Cluster Trust Bundles

### DIFF
--- a/content/en/blog/_posts/2026/pod-certificates-and-cluster-trust-bundles/index.md
+++ b/content/en/blog/_posts/2026/pod-certificates-and-cluster-trust-bundles/index.md
@@ -1,8 +1,8 @@
 ---
 layout: blog
-title: "Kubernetes 1.37: Pod Certificates and Cluster Trust Bundles"
-draft: true
-slug: pod-certificates-and-cluster-trust-bundles
+title: "Kubernetes v1.37: Pod Certificates and Cluster Trust Bundles"
+date: 2026-08-28T10:30:00-08:00
+slug: kubernetes-v1-37-pod-certificates-and-cluster-trust-bundles
 author: >
   [Taahir Ahmed](https://github.com/ahmedtd)
 ---


### PR DESCRIPTION
Publishes: **Kubernetes v1.37: Pod Certificates and Cluster Trust Bundles** on: **Friday 28 August 2026**

cc: v1.37 Communications Team: @SwathiR03 @RinkiyaKeDad @TineoC @kirti763 @SophiaUgo @troy0820