### PR TITLE
[Feature Blog v1.37]: Publishes Kubernetes v1.37: Storage Version Migration Enabled by Default

### DIFF
--- a/content/en/blog/_posts/2026/kubernetes-v1-37-storage-version-migration-ga.md
+++ b/content/en/blog/_posts/2026/kubernetes-v1-37-storage-version-migration-ga.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.37: Storage Version Migration Enabled by Default"
-draft: true
+date: 2026-08-31T10:30:00-08:00
 slug: kubernetes-v1-37-storage-version-migration-ga
 author: >
   [Michael Aspinwall](https://github.com/michaelasp) (Google)


### PR DESCRIPTION
Publishes: **Kubernetes v1.37: Storage Version Migration Enabled by Default** on: **Monday 31 August 2026**

cc: v1.37 Communications Team: @SwathiR03 @RinkiyaKeDad @TineoC @kirti763 @SophiaUgo @troy0820