### PR TITLE
[Feature Blog v1.37]: Publishes Kubernetes v1.37: etcd RangeStream Cuts Memory Use on Large List Reads

### DIFF
--- a/content/en/blog/_posts/2026/kubernetes-v1-37-etcd-range-stream.md
+++ b/content/en/blog/_posts/2026/kubernetes-v1-37-etcd-range-stream.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "Kubernetes v1.37: etcd RangeStream Cuts Memory Use on Large List Reads"
-draft: true
+date: 2026-09-01T10:30:00-08:00
 slug: kubernetes-v1-37-etcd-range-stream
 author: >
   [Jeffrey Ying](https://github.com/Jefftree) (Google)


### PR DESCRIPTION
Publishes: **Kubernetes v1.37: etcd RangeStream Cuts Memory Use on Large List Reads** on: **Tuesday 1 September 2026**

cc: v1.37 Communications Team: @SwathiR03 @RinkiyaKeDad @TineoC @kirti763 @SophiaUgo @troy0820