### PR TITLE
[Feature Blog v1.37]: Publishes Kubernetes v1.37: Scale Workloads to Zero with HorizontalPodAutoscaler

### DIFF
--- a/content/en/blog/_posts/2026/hpa-scale-to-zero-beta.md
+++ b/content/en/blog/_posts/2026/hpa-scale-to-zero-beta.md
@@ -1,10 +1,10 @@
 ---
 layout: blog
 title: "Kubernetes v1.37: Scale Workloads to Zero with HorizontalPodAutoscaler"
-slug: hpa-scale-to-zero-beta
+slug: kubernetes-v1-37-hpa-scale-to-zero-beta
 author: >
   Johannes Würbach
-draft: true
+date: 2026-09-02T10:30:00-08:00
 ---
 
 Kubernetes v1.37 includes API support for horizontal autoscaling of workloads down


### PR DESCRIPTION
Publishes: **Kubernetes v1.37: Scale Workloads to Zero with HorizontalPodAutoscaler** on: **Wednesday 2 September 2026**

cc: v1.37 Communications Team: @SwathiR03 @RinkiyaKeDad @TineoC @kirti763 @SophiaUgo @troy0820