### PR TITLE
[Feature Blog v1.37]: Publishes Kubernetes v1.37: KubeletInUserNamespace (aka Rootless mode) Graduates to Beta

### DIFF
--- a/content/en/blog/_posts/2026/rootless-beta.md
+++ b/content/en/blog/_posts/2026/rootless-beta.md
@@ -1,8 +1,8 @@
 ---
 layout: blog
 title: "Kubernetes v1.37: KubeletInUserNamespace (aka Rootless mode) Graduates to Beta"
-slug: rootless-beta
-draft: true
+slug: kubernetes-v1-37-rootless-beta
+date: 2026-09-04T10:30:00-08:00
 author: >
   [Akihiro Suda](https://github.com/AkihiroSuda) (NTT)
 ---


### PR DESCRIPTION
Publishes: **Kubernetes v1.37: KubeletInUserNamespace (aka Rootless mode) Graduates to Beta** on: **Friday 4 September 2026**

cc: v1.37 Communications Team: @SwathiR03 @RinkiyaKeDad @TineoC @kirti763 @SophiaUgo @troy0820

Depends on: #57158