### PR TITLE
[Feature Blog v1.37]: Publishes week 1 batch (Aug 27-28 2026)

### DIFF
--- a/content/en/blog/_posts/2026/kubernetes-v1-37-metrics-api-ga/index.md
+++ b/content/en/blog/_posts/2026/kubernetes-v1-37-metrics-api-ga/index.md
@@ -2,7 +2,7 @@
 layout: blog
 title: "Kubernetes v1.37: Metrics API graduates to stable"
 slug: kubernetes-v1-37-metrics-api-ga
-draft: true
+date: 2026-08-27T10:30:00-08:00
 author: >
   [ChengHao Yang](https://github.com/tico88612)
 ---

--- a/content/en/blog/_posts/2026/pod-certificates-and-cluster-trust-bundles/index.md
+++ b/content/en/blog/_posts/2026/pod-certificates-and-cluster-trust-bundles/index.md
@@ -1,8 +1,8 @@
 ---
 layout: blog
-title: "Kubernetes 1.37: Pod Certificates and Cluster Trust Bundles"
-draft: true
-slug: pod-certificates-and-cluster-trust-bundles
+title: "Kubernetes v1.37: Pod Certificates and Cluster Trust Bundles"
+date: 2026-08-28T10:30:00-08:00
+slug: kubernetes-v1-37-pod-certificates-and-cluster-trust-bundles
 author: >
   [Taahir Ahmed](https://github.com/ahmedtd)
 ---


### PR DESCRIPTION
Publishes:

- **Kubernetes v1.37: Metrics API graduates to stable** on: **Thursday 27 August 2026**
- **Kubernetes v1.37: Pod Certificates and Cluster Trust Bundles** on: **Friday 28 August 2026**

cc: v1.37 Communications Team: @SwathiR03 @RinkiyaKeDad @TineoC @kirti763 @SophiaUgo @troy0820