### PR TITLE
Update the kubectl reference for v1.37.0.

### DIFF
--- a/content/en/docs/reference/kubectl/generated/kubectl.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl.md
@@ -181,6 +181,13 @@ kubectl [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_annotate/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_annotate/_index.md
@@ -73,14 +73,14 @@ kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=V
 <td colspan="2">--all</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Select all resources, in the namespace of the specified resource types.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Select all resources in the namespace of the specified resource types</p></td>
 </tr>
 
 <tr>
 <td colspan="2">-A, --all-namespaces</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>If true, check the specified action in all namespaces.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.</p></td>
 </tr>
 
 <tr>
@@ -115,7 +115,7 @@ kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=V
 <td colspan="2">-f, --filename strings</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Filename, directory, or URL to files identifying the resource to update the annotation</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>identifying the resource.</p></td>
 </tr>
 
 <tr>
@@ -129,7 +129,7 @@ kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=V
 <td colspan="2">-k, --kustomize string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Process the kustomization directory. This flag can't be used together with -f or -R.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Process a kustomization directory. This flag can't be used together with -f or -R.</p></td>
 </tr>
 
 <tr>
@@ -161,7 +161,7 @@ kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=V
 </tr>
 
 <tr>
-<td colspan="2">-R, --recursive</td>
+<td colspan="2">-R, --recursive&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: true</td>
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.</p></td>
@@ -178,7 +178,7 @@ kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=V
 <td colspan="2">-l, --selector string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Selector (label query) to filter on, supports '=', '==', '!=', 'in', 'notin'.(e.g. -l key1=value1,key2=value2,key3 in (value3)). Matching objects must satisfy all of the specified label constraints.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)</p></td>
 </tr>
 
 <tr>
@@ -340,6 +340,13 @@ kubectl annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=V
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Name of the file to write the profile to</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_api-resources/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_api-resources/_index.md
@@ -279,6 +279,13 @@ kubectl api-resources [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_api-versions/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_api-versions/_index.md
@@ -201,6 +201,13 @@ kubectl api-versions
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_apply/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_apply/_index.md
@@ -105,7 +105,7 @@ kubectl apply (-f FILENAME | -k DIRECTORY)
 <td colspan="2">-f, --filename strings</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The files that contain the configurations to apply.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The files, directories or URLs that contain the configurations to apply.</p></td>
 </tr>
 
 <tr>
@@ -386,6 +386,13 @@ kubectl apply (-f FILENAME | -k DIRECTORY)
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Name of the file to write the profile to</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_apply/kubectl_apply_edit-last-applied.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_apply/kubectl_apply_edit-last-applied.md
@@ -281,6 +281,13 @@ kubectl apply edit-last-applied (RESOURCE/NAME | -f FILENAME)
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_apply/kubectl_apply_set-last-applied.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_apply/kubectl_apply_set-last-applied.md
@@ -255,6 +255,13 @@ kubectl apply set-last-applied -f FILENAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_apply/kubectl_apply_view-last-applied.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_apply/kubectl_apply_view-last-applied.md
@@ -247,6 +247,13 @@ kubectl apply view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FILENAM
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_attach/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_attach/_index.md
@@ -254,6 +254,13 @@ kubectl attach (POD | TYPE/NAME) -c CONTAINER
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_auth/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_auth/_index.md
@@ -194,6 +194,13 @@ kubectl auth [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_can-i.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_can-i.md
@@ -262,6 +262,13 @@ kubectl auth can-i VERB [TYPE | TYPE/NAME | NONRESOURCEURL]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_reconcile.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_reconcile.md
@@ -278,6 +278,13 @@ kubectl auth reconcile -f FILENAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_whoami.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_whoami.md
@@ -235,6 +235,13 @@ kubectl auth whoami
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_autoscale/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_autoscale/_index.md
@@ -45,7 +45,7 @@ kubectl autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --max=MA
   kubectl autoscale deployment bar --min=3 --max=6 --cpu=500m --memory=200Mi
   
   # Auto scale a deployment "bar", with the number of pods between 2 and 8, target CPU utilization 60% and memory utilization 70%
-  kubectl autoscale deployment bar --min=3 --max=6 --cpu=60% --memory=70%
+  kubectl autoscale deployment bar --min=2 --max=8 --cpu=60% --memory=70%
 ```
 
 ## {{% heading "options" %}}
@@ -314,6 +314,13 @@ kubectl autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --max=MA
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Name of the file to write the profile to</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_certificate/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_certificate/_index.md
@@ -194,6 +194,13 @@ kubectl certificate SUBCOMMAND
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_certificate/kubectl_certificate_approve.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_certificate/kubectl_certificate_approve.md
@@ -260,6 +260,13 @@ kubectl certificate approve (-f FILENAME | NAME)
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_certificate/kubectl_certificate_deny.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_certificate/kubectl_certificate_deny.md
@@ -258,6 +258,13 @@ kubectl certificate deny (-f FILENAME | NAME)
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_cluster-info/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_cluster-info/_index.md
@@ -201,6 +201,13 @@ kubectl cluster-info [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_cluster-info/kubectl_cluster-info_dump.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_cluster-info/kubectl_cluster-info_dump.md
@@ -267,6 +267,13 @@ kubectl cluster-info dump [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_completion/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_completion/_index.md
@@ -258,6 +258,13 @@ kubectl completion SHELL
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/_index.md
@@ -200,6 +200,13 @@ kubectl config SUBCOMMAND
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_current-context.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_current-context.md
@@ -200,6 +200,13 @@ kubectl config current-context [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_delete-cluster.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_delete-cluster.md
@@ -200,6 +200,13 @@ kubectl config delete-cluster NAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_delete-context.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_delete-context.md
@@ -200,6 +200,13 @@ kubectl config delete-context NAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_delete-user.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_delete-user.md
@@ -200,6 +200,13 @@ kubectl config delete-user NAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_get-clusters.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_get-clusters.md
@@ -200,6 +200,13 @@ kubectl config get-clusters [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_get-contexts.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_get-contexts.md
@@ -217,6 +217,13 @@ kubectl config get-contexts [(-o|--output=)name)]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_get-users.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_get-users.md
@@ -200,6 +200,13 @@ kubectl config get-users [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_rename-context.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_rename-context.md
@@ -206,6 +206,13 @@ kubectl config rename-context CONTEXT_NAME NEW_NAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_set-context.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_set-context.md
@@ -216,6 +216,13 @@ kubectl config set-context [NAME | --current] [--cluster=cluster_nickname] [--us
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_set-credentials.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_set-credentials.md
@@ -321,6 +321,13 @@ kubectl config set-credentials NAME [--client-certificate=path/to/certfile] [--c
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_set.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_set.md
@@ -222,6 +222,13 @@ kubectl config set PROPERTY_NAME PROPERTY_VALUE
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_unset.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_unset.md
@@ -205,6 +205,13 @@ kubectl config unset PROPERTY_NAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_use-context.md
@@ -200,6 +200,13 @@ kubectl config use-context CONTEXT_NAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_view.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_config/kubectl_config_view.md
@@ -264,6 +264,13 @@ kubectl config view [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_cordon/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_cordon/_index.md
@@ -215,6 +215,13 @@ kubectl cordon NODE
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_cp/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_cp/_index.md
@@ -244,6 +244,13 @@ kubectl cp <file-spec-src> <file-spec-dest>
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/_index.md
@@ -314,6 +314,13 @@ kubectl create -f FILENAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_clusterrole.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_clusterrole.md
@@ -306,6 +306,13 @@ kubectl create clusterrole NAME --verb=verb --resource=resource.group [--resourc
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_clusterrolebinding.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_clusterrolebinding.md
@@ -284,6 +284,13 @@ kubectl create clusterrolebinding NAME --clusterrole=NAME [--user=username] [--g
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_configmap.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_configmap.md
@@ -299,6 +299,13 @@ kubectl create configmap NAME [--from-file=[key=]source] [--from-literal=key1=va
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_cronjob.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_cronjob.md
@@ -280,6 +280,13 @@ kubectl create cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAND] 
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_deployment.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_deployment.md
@@ -289,6 +289,13 @@ kubectl create deployment NAME --image=image -- [COMMAND] [args...]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_ingress.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_ingress.md
@@ -317,6 +317,13 @@ kubectl create ingress NAME --rule=host/path=service:port[,tls[=secret]]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_job.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_job.md
@@ -276,6 +276,13 @@ kubectl create job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args..
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_namespace.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_namespace.md
@@ -256,6 +256,13 @@ kubectl create namespace NAME [--dry-run=server|client|none]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_poddisruptionbudget.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_poddisruptionbudget.md
@@ -282,6 +282,13 @@ kubectl create poddisruptionbudget NAME --selector=SELECTOR --min-available=N [-
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_priorityclass.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_priorityclass.md
@@ -290,6 +290,13 @@ kubectl create priorityclass NAME --value=VALUE --global-default=BOOL [--dry-run
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_quota.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_quota.md
@@ -273,6 +273,13 @@ kubectl create quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scop
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_role.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_role.md
@@ -286,6 +286,13 @@ kubectl create role NAME --verb=verb --resource=resource.group/subresource [--re
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_rolebinding.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_rolebinding.md
@@ -294,6 +294,13 @@ kubectl create rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret.md
@@ -199,6 +199,13 @@ kubectl create secret (docker-registry | generic | tls)
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_docker-registry.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_docker-registry.md
@@ -312,6 +312,13 @@ kubectl create secret docker-registry NAME --docker-username=user --docker-passw
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_generic.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_generic.md
@@ -309,6 +309,13 @@ kubectl create secret generic NAME [--type=string] [--from-file=[key=]source] [-
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_tls.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_tls.md
@@ -279,6 +279,13 @@ kubectl create secret tls NAME --cert=path/to/cert/file --key=path/to/key/file [
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service.md
@@ -193,6 +193,13 @@ kubectl create service [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service_clusterip.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service_clusterip.md
@@ -273,6 +273,13 @@ kubectl create service clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run=ser
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service_externalname.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service_externalname.md
@@ -272,6 +272,13 @@ kubectl create service externalname NAME --external-name external.name [--dry-ru
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service_loadbalancer.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service_loadbalancer.md
@@ -263,6 +263,13 @@ kubectl create service loadbalancer NAME [--tcp=port:targetPort] [--dry-run=serv
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service_nodeport.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_service_nodeport.md
@@ -270,6 +270,13 @@ kubectl create service nodeport NAME [--tcp=port:targetPort] [--dry-run=server|c
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_serviceaccount.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_serviceaccount.md
@@ -256,6 +256,13 @@ kubectl create serviceaccount NAME [--dry-run=server|client|none]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_token.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_create/kubectl_create_token.md
@@ -278,6 +278,13 @@ kubectl create token SERVICE_ACCOUNT_NAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_debug/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_debug/_index.md
@@ -395,6 +395,13 @@ kubectl debug (POD | TYPE[[.VERSION].GROUP]/NAME) [ -- COMMAND [args...] ]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_delete/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_delete/_index.md
@@ -364,6 +364,13 @@ kubectl delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | --all)
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_describe/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_describe/_index.md
@@ -274,6 +274,13 @@ kubectl describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_diff/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_diff/_index.md
@@ -298,6 +298,13 @@ kubectl diff -f FILENAME
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_drain/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_drain/_index.md
@@ -289,6 +289,13 @@ kubectl drain NODE
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_edit/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_edit/_index.md
@@ -316,6 +316,13 @@ kubectl edit (RESOURCE/NAME | -f FILENAME)
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_events/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_events/_index.md
@@ -285,6 +285,13 @@ kubectl events [(-o|--output=)json|yaml|kyaml|name|go-template|go-template-file|
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_exec/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_exec/_index.md
@@ -263,6 +263,13 @@ kubectl exec (POD | TYPE/NAME) [-c CONTAINER] [flags] -- COMMAND [args...]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_explain/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_explain/_index.md
@@ -28,7 +28,7 @@ Describe fields and structure of various resources.
 
  This command describes the fields associated with each supported API resource. Fields are identified via a simple JSONPath identifier:
 
-        &lt;type&gt;.&lt;fieldName&gt;[.&lt;fieldName&gt;]
+        TYPE.FIELDNAME[.FIELDNAME]
         
  Information about each field is retrieved from the server in OpenAPI format.
 
@@ -46,6 +46,9 @@ kubectl explain TYPE [--recursive=FALSE|TRUE] [--api-version=api-version-group] 
   
   # Get all the fields in the resource
   kubectl explain pods --recursive
+  
+  # Get fields in the resource up to a specific recursive depth
+  kubectl explain pods --recursive --max-depth=2
   
   # Get the explanation for deployment in supported api versions
   kubectl explain deployments --api-version=apps/v1
@@ -81,6 +84,13 @@ kubectl explain TYPE [--recursive=FALSE|TRUE] [--api-version=api-version-group] 
 </tr>
 
 <tr>
+<td colspan="2">--max-depth int</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Maximum recursion depth when printing nested fields with --recursive. 0 means no limit. Requires --recursive when greater than 0.</p></td>
+</tr>
+
+<tr>
 <td colspan="2">-o, --output string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "plaintext"</td>
 </tr>
 <tr>
@@ -91,7 +101,7 @@ kubectl explain TYPE [--recursive=FALSE|TRUE] [--api-version=api-version-group] 
 <td colspan="2">-R, --recursive</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Print the fields of fields (Currently only 1 level deep)</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Print the fields of fields. Use --max-depth to cap the recursion depth.</p></td>
 </tr>
 
 </tbody>
@@ -239,6 +249,13 @@ kubectl explain TYPE [--recursive=FALSE|TRUE] [--api-version=api-version-group] 
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Name of the file to write the profile to</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_expose/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_expose/_index.md
@@ -386,6 +386,13 @@ kubectl expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP|SCTP]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_get/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_get/_index.md
@@ -407,6 +407,13 @@ kubectl get [(-o|--output=)json|yaml|kyaml|name|go-template|go-template-file|tem
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_kuberc/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_kuberc/_index.md
@@ -209,6 +209,13 @@ kubectl kuberc SUBCOMMAND
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_kuberc/kubectl_kuberc_set.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_kuberc/kubectl_kuberc_set.md
@@ -284,6 +284,13 @@ kubectl kuberc set --section (defaults|aliases) --command COMMAND
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_kuberc/kubectl_kuberc_view.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_kuberc/kubectl_kuberc_view.md
@@ -234,6 +234,13 @@ kubectl kuberc view
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_kustomize/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_kustomize/_index.md
@@ -298,6 +298,13 @@ kubectl kustomize DIR [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_label/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_label/_index.md
@@ -341,6 +341,13 @@ kubectl label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_logs/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_logs/_index.md
@@ -364,6 +364,13 @@ kubectl logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_options/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_options/_index.md
@@ -201,6 +201,13 @@ kubectl options [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_patch/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_patch/_index.md
@@ -318,6 +318,13 @@ kubectl patch (-f FILENAME | TYPE NAME) [-p PATCH|--patch-file FILE]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_plugin/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_plugin/_index.md
@@ -208,6 +208,13 @@ kubectl plugin [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_plugin/kubectl_plugin_list.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_plugin/kubectl_plugin_list.md
@@ -212,6 +212,13 @@ kubectl plugin list [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_port-forward/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_port-forward/_index.md
@@ -237,6 +237,13 @@ kubectl port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_POR
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_proxy/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_proxy/_index.md
@@ -311,6 +311,13 @@ kubectl proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-pref
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_replace/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_replace/_index.md
@@ -91,7 +91,7 @@ kubectl replace -f FILENAME
 <td colspan="2">-f, --filename strings</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The files that contain the configurations to replace.</p></td>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>The files, directories or URLs that contain the configurations to replace.</p></td>
 </tr>
 
 <tr>
@@ -337,6 +337,13 @@ kubectl replace -f FILENAME
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Name of the file to write the profile to</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_rollout/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_rollout/_index.md
@@ -216,6 +216,13 @@ kubectl rollout SUBCOMMAND
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_history.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_history.md
@@ -266,6 +266,13 @@ kubectl rollout history (TYPE NAME | TYPE/NAME) [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_pause.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_pause.md
@@ -267,6 +267,13 @@ kubectl rollout pause RESOURCE
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_restart.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_restart.md
@@ -274,6 +274,13 @@ kubectl rollout restart RESOURCE
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_resume.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_resume.md
@@ -265,6 +265,13 @@ kubectl rollout resume RESOURCE
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_status.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_status.md
@@ -251,6 +251,13 @@ kubectl rollout status (TYPE NAME | TYPE/NAME) [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_undo.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_undo.md
@@ -276,6 +276,13 @@ kubectl rollout undo (TYPE NAME | TYPE/NAME) [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_run/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_run/_index.md
@@ -141,13 +141,6 @@ kubectl run NAME --image=image [--env="key=value"] [--port=port] [--dry-run=serv
 </tr>
 
 <tr>
-<td colspan="2">-f, --filename strings</td>
-</tr>
-<tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>to use to replace the resource.</p></td>
-</tr>
-
-<tr>
 <td colspan="2">--force</td>
 </tr>
 <tr>
@@ -467,6 +460,13 @@ kubectl run NAME --image=image [--env="key=value"] [--port=port] [--dry-run=serv
 </tr>
 <tr>
 <td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Name of the file to write the profile to</p></td>
+</tr>
+
+<tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
 </tr>
 
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_scale/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_scale/_index.md
@@ -315,6 +315,13 @@ kubectl scale [--resource-version=version] [--current-replicas=count] --replicas
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_set/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_set/_index.md
@@ -196,6 +196,13 @@ kubectl set SUBCOMMAND
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_env.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_env.md
@@ -379,6 +379,13 @@ kubectl set env RESOURCE/NAME KEY_1=VAL_1 ... KEY_N=VAL_N
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_image.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_image.md
@@ -297,6 +297,13 @@ kubectl set image (-f FILENAME | TYPE NAME) CONTAINER_NAME_1=CONTAINER_IMAGE_1 .
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_resources.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_resources.md
@@ -318,6 +318,13 @@ kubectl set resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requests=
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_selector.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_selector.md
@@ -280,6 +280,13 @@ kubectl set selector (-f FILENAME | TYPE NAME) EXPRESSIONS [--resource-version=v
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_serviceaccount.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_serviceaccount.md
@@ -284,6 +284,13 @@ kubectl set serviceaccount (-f FILENAME | TYPE NAME) SERVICE_ACCOUNT
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_subject.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_set/kubectl_set_subject.md
@@ -311,6 +311,13 @@ kubectl set subject (-f FILENAME | TYPE NAME) [--user=username] [--group=groupna
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_taint/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_taint/_index.md
@@ -291,6 +291,13 @@ kubectl taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_top/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_top/_index.md
@@ -208,6 +208,13 @@ kubectl top [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_top/kubectl_top_node.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_top/kubectl_top_node.md
@@ -247,6 +247,13 @@ kubectl top node [NAME | -l label]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_top/kubectl_top_pod.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_top/kubectl_top_pod.md
@@ -276,6 +276,13 @@ kubectl top pod [NAME | -l label]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_uncordon/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_uncordon/_index.md
@@ -215,6 +215,13 @@ kubectl uncordon NODE
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_version/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_version/_index.md
@@ -215,6 +215,13 @@ kubectl version [flags]
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>

--- a/content/en/docs/reference/kubectl/generated/kubectl_wait/_index.md
+++ b/content/en/docs/reference/kubectl/generated/kubectl_wait/_index.md
@@ -326,6 +326,13 @@ kubectl wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l
 </tr>
 
 <tr>
+<td colspan="2">--proxy-url string</td>
+</tr>
+<tr>
+<td></td><td style="line-height: 130%; word-wrap: break-word;"><p>Proxy URL to use for requests to the API server</p></td>
+</tr>
+
+<tr>
 <td colspan="2">--request-timeout string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default: "0"</td>
 </tr>
 <tr>


### PR DESCRIPTION
Regenerated the kubectl reference for v1.37.0.

- Generated with `make copycomp-kubectl` from kubernetes-sigs/reference-docs 
- Generator changes: kubernetes-sigs/reference-docs https://github.com/kubernetes-sigs/reference-docs/pull/471
- Generated files only, with no hand edits


cc: @kubernetes/release-team-docs @dipesh-rawat

/hold until upstream  https://github.com/kubernetes-sigs/reference-docs/pull/471 is review and merged