### PR TITLE
Update the configuration API reference for v1.37

### DIFF
--- a/content/en/docs/reference/config-api/apiserver-admission.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-admission.v1.md
@@ -152,7 +152,7 @@ requested. e.g. a patch can result in either a CREATE or UPDATE Operation.</p>
 </td>
 </tr>
 <tr><td><code>userInfo</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
 </td>
 <td>
    <p>userInfo is information about the requesting user</p>
@@ -226,7 +226,7 @@ This must be copied over from the corresponding AdmissionRequest.</p>
 </td>
 </tr>
 <tr><td><code>status</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#status-v1-meta"><code>meta/v1.Status</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#status-v1-meta"><code>meta/v1.Status</code></a>
 </td>
 <td>
    <p>status is the result contains extra details into why an admission request was denied.

--- a/content/en/docs/reference/config-api/apiserver-audit.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-audit.v1.md
@@ -71,14 +71,14 @@ For non-resource requests, this is the lower-cased HTTP method.</p>
 </td>
 </tr>
 <tr><td><code>user</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
 </td>
 <td>
    <p>Authenticated user information.</p>
 </td>
 </tr>
 <tr><td><code>impersonatedUser</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#userinfo-v1-authentication-k8s-io"><code>authentication/v1.UserInfo</code></a>
 </td>
 <td>
    <p>Impersonated user information.</p>
@@ -123,7 +123,7 @@ Does not apply for List-type requests, or non-resource requests.</p>
 </td>
 </tr>
 <tr><td><code>responseStatus</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#status-v1-meta"><code>meta/v1.Status</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#status-v1-meta"><code>meta/v1.Status</code></a>
 </td>
 <td>
    <p>The response status, populated even when the ResponseObject is not a Status type.
@@ -151,14 +151,14 @@ at Response Level.</p>
 </td>
 </tr>
 <tr><td><code>requestReceivedTimestamp</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
 </td>
 <td>
    <p>Time the request reached the apiserver.</p>
 </td>
 </tr>
 <tr><td><code>stageTimestamp</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
 </td>
 <td>
    <p>Time the request reached current audit stage.</p>
@@ -195,7 +195,7 @@ should be short. Annotations are included in the Metadata level.</p>
     
   
 <tr><td><code>metadata</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>
@@ -230,7 +230,7 @@ categories are logged.</p>
     
   
 <tr><td><code>metadata</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
 </td>
 <td>
    <p>ObjectMeta is included for interoperability with API infrastructure.</p>
@@ -285,7 +285,7 @@ in a rule will override the global default.</p>
     
   
 <tr><td><code>metadata</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>

--- a/content/en/docs/reference/config-api/apiserver-config.v1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1.md
@@ -245,7 +245,7 @@ resources:
 <tr><td><code>TracingConfiguration</code> <B>[Required]</B><br/>
 <a href="#TracingConfiguration"><code>TracingConfiguration</code></a>
 </td>
-<td>(Members of <code>TracingConfiguration</code> are embedded into this type.)
+<td>
    <p>Embed the component config tracing configuration struct</p>
 </td>
 </tr>

--- a/content/en/docs/reference/config-api/apiserver-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1alpha1.md
@@ -202,7 +202,7 @@ Must be at least one.</p>
 <tr><td><code>TracingConfiguration</code> <B>[Required]</B><br/>
 <a href="#TracingConfiguration"><code>TracingConfiguration</code></a>
 </td>
-<td>(Members of <code>TracingConfiguration</code> are embedded into this type.)
+<td>
    <p>Embed the component config tracing configuration struct</p>
 </td>
 </tr>

--- a/content/en/docs/reference/config-api/apiserver-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/apiserver-config.v1beta1.md
@@ -178,7 +178,7 @@ Must be at least one.</p>
 <tr><td><code>TracingConfiguration</code> <B>[Required]</B><br/>
 <a href="#TracingConfiguration"><code>TracingConfiguration</code></a>
 </td>
-<td>(Members of <code>TracingConfiguration</code> are embedded into this type.)
+<td>
    <p>Embed the component config tracing configuration struct</p>
 </td>
 </tr>

--- a/content/en/docs/reference/config-api/client-authentication.v1.md
+++ b/content/en/docs/reference/config-api/client-authentication.v1.md
@@ -205,7 +205,7 @@ itself should at least be protected via file permissions.</p>
     
   
 <tr><td><code>expirationTimestamp</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>ExpirationTimestamp indicates a time when the provided credentials expire.</p>

--- a/content/en/docs/reference/config-api/client-authentication.v1beta1.md
+++ b/content/en/docs/reference/config-api/client-authentication.v1beta1.md
@@ -205,7 +205,7 @@ itself should at least be protected via file permissions.</p>
     
   
 <tr><td><code>expirationTimestamp</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>ExpirationTimestamp indicates a time when the provided credentials expire.</p>

--- a/content/en/docs/reference/config-api/imagepolicy.v1alpha1.md
+++ b/content/en/docs/reference/config-api/imagepolicy.v1alpha1.md
@@ -28,10 +28,10 @@ auto_generated: true
     
   
 <tr><td><code>metadata</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
 </td>
 <td>
-   <p>Standard object's metadata.
+   <p>metadata is the standard object's metadata.
 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata</p>
 Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
@@ -39,14 +39,14 @@ Refer to the Kubernetes API documentation for the fields of the <code>metadata</
 <a href="#imagepolicy-k8s-io-v1alpha1-ImageReviewSpec"><code>ImageReviewSpec</code></a>
 </td>
 <td>
-   <p>Spec holds information about the pod being evaluated</p>
+   <p>spec holds information about the pod being evaluated</p>
 </td>
 </tr>
 <tr><td><code>status</code><br/>
 <a href="#imagepolicy-k8s-io-v1alpha1-ImageReviewStatus"><code>ImageReviewStatus</code></a>
 </td>
 <td>
-   <p>Status is filled in by the backend and indicates whether the pod should be allowed.</p>
+   <p>status is filled in by the backend and indicates whether the pod should be allowed.</p>
 </td>
 </tr>
 </tbody>
@@ -72,7 +72,7 @@ Refer to the Kubernetes API documentation for the fields of the <code>metadata</
 <code>string</code>
 </td>
 <td>
-   <p>This can be in the form image:tag or image@SHA:012345679abcdef.</p>
+   <p>image can be in the form image:tag or image@SHA:012345679abcdef.</p>
 </td>
 </tr>
 </tbody>
@@ -98,14 +98,14 @@ Refer to the Kubernetes API documentation for the fields of the <code>metadata</
 <a href="#imagepolicy-k8s-io-v1alpha1-ImageReviewContainerSpec"><code>[]ImageReviewContainerSpec</code></a>
 </td>
 <td>
-   <p>Containers is a list of a subset of the information in each container of the Pod being created.</p>
+   <p>containers is a list of a subset of the information in each container of the Pod being created.</p>
 </td>
 </tr>
 <tr><td><code>annotations</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   <p>Annotations is a list of key-value pairs extracted from the Pod's annotations.
+   <p>annotations is a list of key-value pairs extracted from the Pod's annotations.
 It only includes keys which match the pattern <code>*.image-policy.k8s.io/*</code>.
 It is up to each webhook backend to determine how to interpret these annotations, if at all.</p>
 </td>
@@ -114,7 +114,7 @@ It is up to each webhook backend to determine how to interpret these annotations
 <code>string</code>
 </td>
 <td>
-   <p>Namespace is the namespace the pod is being created in.</p>
+   <p>namespace is the namespace the pod is being created in.</p>
 </td>
 </tr>
 </tbody>
@@ -140,14 +140,14 @@ It is up to each webhook backend to determine how to interpret these annotations
 <code>bool</code>
 </td>
 <td>
-   <p>Allowed indicates that all images were allowed to be run.</p>
+   <p>allowed indicates that all images were allowed to be run.</p>
 </td>
 </tr>
 <tr><td><code>reason</code><br/>
 <code>string</code>
 </td>
 <td>
-   <p>Reason should be empty unless Allowed is false in which case it
+   <p>reason should be empty unless Allowed is false in which case it
 may contain a short description of what is wrong.  Kubernetes
 may truncate excessively long errors when displaying to the user.</p>
 </td>
@@ -156,7 +156,7 @@ may truncate excessively long errors when displaying to the user.</p>
 <code>map[string]string</code>
 </td>
 <td>
-   <p>AuditAnnotations will be added to the attributes object of the
+   <p>auditAnnotations will be added to the attributes object of the
 admission controller request using 'AddAnnotation'.  The keys should
 be prefix-less (i.e., the admission controller will add an
 appropriate prefix).</p>

--- a/content/en/docs/reference/config-api/kube-controller-manager-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kube-controller-manager-config.v1alpha1.md
@@ -301,6 +301,14 @@ both in cloud controller manager and kube-controller manager.</p>
 related features.</p>
 </td>
 </tr>
+<tr><td><code>NodeLifecycleController</code> <B>[Required]</B><br/>
+<code>k8s.io/cloud-provider/controllers/nodelifecycle/config/v1alpha1.NodeLifecycleControllerConfiguration</code>
+</td>
+<td>
+   <p>NodeLifecycleController holds configuration for node lifecycle controller
+related features.</p>
+</td>
+</tr>
 <tr><td><code>ServiceController</code> <B>[Required]</B><br/>
 <a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
 </td>
@@ -413,13 +421,6 @@ individual service account credentials.</p>
 </td>
 <td>
    <p>routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</p>
-</td>
-</tr>
-<tr><td><code>NodeMonitorPeriod</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</p>
 </td>
 </tr>
 <tr><td><code>ClusterName</code> <B>[Required]</B><br/>
@@ -744,6 +745,14 @@ related features.</p>
 <td>
    <p>DeploymentControllerConfiguration holds configuration for
 DeploymentController related features.</p>
+</td>
+</tr>
+<tr><td><code>DisruptionController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DisruptionControllerConfiguration"><code>DisruptionControllerConfiguration</code></a>
+</td>
+<td>
+   <p>DisruptionControllerConfiguration holds configuration for
+DisruptionController related features.</p>
 </td>
 </tr>
 <tr><td><code>StatefulSetController</code> <B>[Required]</B><br/>
@@ -1213,6 +1222,34 @@ but more CPU (and network) load.</p>
    <p>ConcurrentSyncs is the number of operations (deleting a pod, updating a ResourcClaim status, etc.)
 that will be done concurrently. Larger number = processing, but more CPU (and network) load.</p>
 <p>The default is 10.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DisruptionControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DisruptionControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>DisruptionControllerConfiguration contains elements describing DisruptionController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentDisruptionSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentDisruptionSyncs is the number of PodDisruptionBudget objects that
+are allowed to sync concurrently. Larger number = more responsive PDB
+updates, but more CPU (and network) load.</p>
 </td>
 </tr>
 </tbody>
@@ -1737,6 +1774,13 @@ HTTP2_PING_TIMEOUT_SECONDS and HTTP2_READ_IDLE_TIMEOUT_SECONDS.</p>
 <td>
    <p>Zone is treated as unhealthy in nodeEvictionRate and secondaryNodeEvictionRate when at least
 unhealthyZoneThreshold (no less than 3) of Nodes in the zone are NotReady</p>
+</td>
+</tr>
+<tr><td><code>NodeMonitorPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>NodeMonitorPeriod is the period for syncing NodeStatus in NodeLifecycleController.</p>
 </td>
 </tr>
 </tbody>

--- a/content/en/docs/reference/config-api/kube-proxy-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kube-proxy-config.v1alpha1.md
@@ -68,7 +68,7 @@ Only available when the LoggingAlphaOptions feature gate is enabled.</p>
 <tr><td><code>OutputRoutingOptions</code> <B>[Required]</B><br/>
 <a href="#OutputRoutingOptions"><code>OutputRoutingOptions</code></a>
 </td>
-<td>(Members of <code>OutputRoutingOptions</code> are embedded into this type.)
+<td>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 </tbody>
@@ -240,7 +240,7 @@ Only available when the LoggingAlphaOptions feature gate is enabled.</p>
 <tr><td><code>OutputRoutingOptions</code> <B>[Required]</B><br/>
 <a href="#OutputRoutingOptions"><code>OutputRoutingOptions</code></a>
 </td>
-<td>(Members of <code>OutputRoutingOptions</code> are embedded into this type.)
+<td>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 </tbody>
@@ -660,12 +660,17 @@ used.)</p>
 <code>[]string</code>
 </td>
 <td>
-   <p>nodePortAddresses is a list of CIDR ranges that contain valid node IPs, or
-alternatively, the single string 'primary'. If set to a list of CIDRs,
-connections to NodePort services will only be accepted on node IPs in one of
-the indicated ranges. If set to 'primary', NodePort services will only be
-accepted on the node's primary IPv4 and/or IPv6 address according to the Node
-object. If unset, NodePort connections will be accepted on all local IPs.</p>
+   <p>nodePortAddresses is a list of CIDR ranges and/or keywords that expand to CIDR
+ranges. NodePort services are only accessible on node IPs covered by the list.
+Supported keywords: 'primary' (the Node object's primary IPv4 and/or IPv6
+addresses), 'localhost' (127.0.0.0/8 and ::1/128), and 'all' (0.0.0.0/0 and ::/0).
+Any combination of valid keywords and CIDRs may be included in the list.</p>
+<p>Serving NodePorts on loopback IPs is only supported in iptables mode (IPv4
+only, see iptables.localhostNodePorts), and, only for TCP, in nftables mode when
+the KubeProxyNFTablesLocalhostNodePorts feature gate is enabled and the list
+explicitly includes loopback (e.g. 'localhost').</p>
+<p>If unset, this defaults to 'all' in iptables and ipvs mode, and to 'primary' in
+nftables mode.</p>
 </td>
 </tr>
 <tr><td><code>oomScoreAdj</code> <B>[Required]</B><br/>

--- a/content/en/docs/reference/config-api/kube-scheduler-config.v1.md
+++ b/content/en/docs/reference/config-api/kube-scheduler-config.v1.md
@@ -398,7 +398,7 @@ settings for the proxy server to use when communicating with the apiserver.</p>
 <tr><td><code>DebuggingConfiguration</code> <B>[Required]</B><br/>
 <a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
 </td>
-<td>(Members of <code>DebuggingConfiguration</code> are embedded into this type.)
+<td>
    <p>DebuggingConfiguration holds configuration for Debugging related features
 TODO: We might wanna make this a substruct like Debugging componentbaseconfigv1alpha1.DebuggingConfiguration</p>
 </td>
@@ -482,7 +482,7 @@ Defaults to false.</p>
     
   
 <tr><td><code>addedAffinity</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeaffinity-v1-core"><code>core/v1.NodeAffinity</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#nodeaffinity-v1-core"><code>core/v1.NodeAffinity</code></a>
 </td>
 <td>
    <p>AddedAffinity is applied to all Pods additionally to the NodeAffinity
@@ -581,7 +581,7 @@ The default strategy is LeastAllocated with an equal &quot;cpu&quot; and &quot;m
     
   
 <tr><td><code>defaultConstraints</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#topologyspreadconstraint-v1-core"><code>[]core/v1.TopologySpreadConstraint</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#topologyspreadconstraint-v1-core"><code>[]core/v1.TopologySpreadConstraint</code></a>
 </td>
 <td>
    <p>DefaultConstraints defines topology spread constraints to be applied to
@@ -1203,6 +1203,14 @@ plugin through MultiPoint. This follows the same behavior as all other extension
 </td>
 <td>
    <p>PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.</p>
+</td>
+</tr>
+<tr><td><code>podGroupPostFilter</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   <p>PodGroupPostFilter is a list of plugins that are invoked after the workload scheduling phase,
+but only when the PodGroup cannot be scheduled (equivalent to PostFilter for single pods).</p>
 </td>
 </tr>
 </tbody>

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta3.md
@@ -309,7 +309,7 @@ for, so other administrators can know its purpose.</p>
 </td>
 </tr>
 <tr><td><code>expires</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
@@ -1043,7 +1043,7 @@ file from which to load cluster information.</p>
 </td>
 </tr>
 <tr><td><code>pathType</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
 </td>
 <td>
    <p><code>pathType</code> is the type of the <code>hostPath</code>.</p>
@@ -1269,7 +1269,7 @@ This information will be annotated to the Node API object, for later re-use.</p>
 </td>
 </tr>
 <tr><td><code>taints</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#taint-v1-core"><code>[]core/v1.Taint</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
    <p><code>taints</code> specifies the taints the Node API object should be registered with.
@@ -1301,7 +1301,7 @@ Value <code>all</code> ignores errors from all checks.</p>
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
    <p><code>imagePullPolicy</code> specifies the policy for image pulling during kubeadm &quot;init&quot; and

--- a/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
+++ b/content/en/docs/reference/config-api/kubeadm-config.v1beta4.md
@@ -408,7 +408,7 @@ for, so other administrators can know its purpose.</p>
 </td>
 </tr>
 <tr><td><code>expires</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
@@ -1262,7 +1262,7 @@ does not contain any other authentication information.</p>
     
   
 <tr><td><code>EnvVar</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#envvar-v1-core"><code>core/v1.EnvVar</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#envvar-v1-core"><code>core/v1.EnvVar</code></a>
 </td>
 <td>(Members of <code>EnvVar</code> are embedded into this type.)
    <span class="text-muted">No description provided.</span></td>
@@ -1446,7 +1446,7 @@ file from which to load cluster information.</p>
 </td>
 </tr>
 <tr><td><code>pathType</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
 </td>
 <td>
    <p><code>pathType</code> is the type of the <code>hostPath</code>.</p>
@@ -1683,7 +1683,7 @@ This information will be annotated to the Node API object, for later re-use.</p>
 </td>
 </tr>
 <tr><td><code>taints</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#taint-v1-core"><code>[]core/v1.Taint</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
    <p><code>taints</code> specifies the taints the Node API object should be registered with.
@@ -1716,7 +1716,7 @@ Value 'all' ignores errors from all checks.</p>
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
    <p><code>imagePullPolicy</code> specifies the policy for image pulling during kubeadm <code>init</code> and
@@ -1993,7 +1993,7 @@ NOTE: This field is currently ignored for <code>kubeadm upgrade apply</code>, bu
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
    <p><code>imagePullPolicy</code> specifies the policy for image pulling during <code>kubeadm upgrade apply</code> operations.
@@ -2108,7 +2108,7 @@ The list of phases can be obtained with the <code>kubeadm upgrade node phase --h
 </td>
 </tr>
 <tr><td><code>imagePullPolicy</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
    <p><code>imagePullPolicy</code> specifies the policy for image pulling during <code>kubeadm upgrade node</code> operations.

--- a/content/en/docs/reference/config-api/kubeconfig.v1.md
+++ b/content/en/docs/reference/config-api/kubeconfig.v1.md
@@ -5,6 +5,7 @@ package: v1
 auto_generated: true
 ---
 
+
 ## Resource Types 
 
 

--- a/content/en/docs/reference/config-api/kubelet-config.v1alpha1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1alpha1.md
@@ -91,7 +91,7 @@ image represented by this record is being requested.</p>
     
   
 <tr><td><code>lastUpdatedTime</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>LastUpdatedTime is the time of the last update to this record</p>

--- a/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
+++ b/content/en/docs/reference/config-api/kubelet-config.v1beta1.md
@@ -72,7 +72,7 @@ Only available when the LoggingAlphaOptions feature gate is enabled.</p>
 <tr><td><code>OutputRoutingOptions</code> <B>[Required]</B><br/>
 <a href="#OutputRoutingOptions"><code>OutputRoutingOptions</code></a>
 </td>
-<td>(Members of <code>OutputRoutingOptions</code> are embedded into this type.)
+<td>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 </tbody>
@@ -242,7 +242,7 @@ Only available when the LoggingAlphaOptions feature gate is enabled.</p>
 <tr><td><code>OutputRoutingOptions</code> <B>[Required]</B><br/>
 <a href="#OutputRoutingOptions"><code>OutputRoutingOptions</code></a>
 </td>
-<td>(Members of <code>OutputRoutingOptions</code> are embedded into this type.)
+<td>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 </tbody>
@@ -427,7 +427,7 @@ image represented by this record is being requested.</p>
     
   
 <tr><td><code>lastUpdatedTime</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>LastUpdatedTime is the time of the last update to this record</p>
@@ -838,10 +838,9 @@ Default: &quot;4h&quot;</p>
 </td>
 <td>
    <p>nodeStatusUpdateFrequency is the frequency that kubelet computes node
-status. If node lease feature is not enabled, it is also the frequency that
-kubelet posts node status to master.
-Note: When node lease feature is not enabled, be cautious when changing the
-constant, it must work with nodeMonitorGracePeriod in nodecontroller.
+status and checks if an update to the API server is necessary. Status
+is posted to the API server either when it changes or when
+nodeStatusReportFrequency has elapsed since the last report.
 Default: &quot;10s&quot;</p>
 </td>
 </tr>
@@ -850,10 +849,11 @@ Default: &quot;10s&quot;</p>
 </td>
 <td>
    <p>nodeStatusReportFrequency is the frequency that kubelet posts node
-status to master if node status does not change. Kubelet will ignore this
-frequency and post node status immediately if any change is detected. It is
-only used when node lease feature is enabled. nodeStatusReportFrequency's
-default value is 5m. But if nodeStatusUpdateFrequency is set explicitly,
+status to the API server if node status does not change. Kubelet will
+ignore this frequency and post node status immediately if any change
+is detected.
+nodeStatusReportFrequency's default value is 5m. But if
+nodeStatusUpdateFrequency is set explicitly,
 nodeStatusReportFrequency's default value will be set to
 nodeStatusUpdateFrequency for backward compatibility.
 Default: &quot;5m&quot;</p>
@@ -1541,6 +1541,16 @@ and <code>net.*</code>. For example: &quot;<code>kernel.msg*,net.ipv4.route.min_
 Default: []</p>
 </td>
 </tr>
+<tr><td><code>defaultPodSysctls</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   <p>DefaultPodSysctls is a set of default sysctls that will be applied to all pods.
+It can be overridden by sysctls set in pod spec.securityContext.sysctls.
+Support namespaced groups: <code>kernel.shm*</code>, <code>kernel.msg*</code>, <code>kernel.sem</code>, <code>fs.mqueue.*</code>, <code>net.*</code>, <code>kernel.domainname</code>, and <code>user.*</code>.
+For example: {&quot;net.ipv4.ip_forward&quot;: &quot;1&quot;, &quot;kernel.shmall&quot;: &quot;1048576&quot;}</p>
+</td>
+</tr>
 <tr><td><code>volumePluginDir</code><br/>
 <code>string</code>
 </td>
@@ -1718,9 +1728,9 @@ Default: false</p>
    <p>MemoryThrottlingFactor specifies the factor multiplied by the memory limit or node allocatable memory
 when setting the cgroupv2 memory.high value to enforce MemoryQoS.
 Decreasing this factor will set lower high limit for container cgroups and put heavier reclaim pressure
-while increasing will put less reclaim pressure.
+while increasing will put less reclaim pressure. If nil, memory.high is not set.
 See https://kep.k8s.io/2570 for more details.
-Default: 0.9</p>
+Default: nil</p>
 </td>
 </tr>
 <tr><td><code>memoryReservationPolicy</code><br/>
@@ -1737,7 +1747,7 @@ Default: None</p>
 </td>
 </tr>
 <tr><td><code>registerWithTaints</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#taint-v1-core"><code>[]core/v1.Taint</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
    <p>registerWithTaints are an array of taints to add to a node object when
@@ -1835,7 +1845,7 @@ It exists in the kubeletconfig API group because it is classified as a versioned
     
   
 <tr><td><code>source</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#nodeconfigsource-v1-core"><code>core/v1.NodeConfigSource</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#nodeconfigsource-v1-core"><code>core/v1.NodeConfigSource</code></a>
 </td>
 <td>
    <p>source is the source that we are serializing.</p>
@@ -2366,7 +2376,7 @@ and groups corresponding to the Organization in the client certificate.</p>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 <tr><td><code>limits</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>

--- a/content/en/docs/reference/external-api/custom-metrics.v1beta2.md
+++ b/content/en/docs/reference/external-api/custom-metrics.v1beta2.md
@@ -14,7 +14,6 @@ auto_generated: true
 - [MetricValue](#custom-metrics-k8s-io-v1beta2-MetricValue)
 - [MetricValueList](#custom-metrics-k8s-io-v1beta2-MetricValueList)
   
-    
 
 ## `MetricListOptions`     {#custom-metrics-k8s-io-v1beta2-MetricListOptions}
     
@@ -69,7 +68,7 @@ Defaults to everything.</p>
     
   
 <tr><td><code>describedObject</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectreference-v1-core"><code>core/v1.ObjectReference</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#objectreference-v1-core"><code>core/v1.ObjectReference</code></a>
 </td>
 <td>
    <p>a reference to the described object</p>
@@ -82,7 +81,7 @@ Defaults to everything.</p>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 <tr><td><code>timestamp</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>indicates the time at which the metrics were produced</p>
@@ -124,7 +123,7 @@ non-calculated instantaneous metrics).</p>
     
   
 <tr><td><code>metadata</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>
@@ -163,7 +162,7 @@ non-calculated instantaneous metrics).</p>
 </td>
 </tr>
 <tr><td><code>selector</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>meta/v1.LabelSelector</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#labelselector-v1-meta"><code>meta/v1.LabelSelector</code></a>
 </td>
 <td>
    <p>selector represents the label selector that could be used to select

--- a/content/en/docs/reference/external-api/external-metrics.v1beta1.md
+++ b/content/en/docs/reference/external-api/external-metrics.v1beta1.md
@@ -13,7 +13,6 @@ auto_generated: true
 - [ExternalMetricValue](#external-metrics-k8s-io-v1beta1-ExternalMetricValue)
 - [ExternalMetricValueList](#external-metrics-k8s-io-v1beta1-ExternalMetricValueList)
   
-    
 
 ## `ExternalMetricValue`     {#external-metrics-k8s-io-v1beta1-ExternalMetricValue}
     
@@ -51,7 +50,7 @@ For one metric there can be multiple values with different sets of labels.</p>
 </td>
 </tr>
 <tr><td><code>timestamp</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta"><code>meta/v1.Time</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
    <p>indicates the time at which the metrics were produced</p>
@@ -93,7 +92,7 @@ non-calculated instantaneous metrics).</p>
     
   
 <tr><td><code>metadata</code> <B>[Required]</B><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
    <span class="text-muted">No description provided.</span></td>

--- a/content/en/docs/reference/external-api/metrics.v1.md
+++ b/content/en/docs/reference/external-api/metrics.v1.md
@@ -1,27 +1,27 @@
 ---
-title: Kubernetes Metrics (v1beta1)
+title: Kubernetes Metrics (v1)
 content_type: tool-reference
-package: metrics.k8s.io/v1beta1
+package: metrics.k8s.io/v1
 auto_generated: true
 ---
-<p>Package v1beta1 is the v1beta1 version of the metrics API.</p>
+<p>Package v1 is the v1 version of the metrics API.</p>
 
 
 ## Resource Types 
 
 
-- [NodeMetrics](#metrics-k8s-io-v1beta1-NodeMetrics)
-- [NodeMetricsList](#metrics-k8s-io-v1beta1-NodeMetricsList)
-- [PodMetrics](#metrics-k8s-io-v1beta1-PodMetrics)
-- [PodMetricsList](#metrics-k8s-io-v1beta1-PodMetricsList)
+- [NodeMetrics](#metrics-k8s-io-v1-NodeMetrics)
+- [NodeMetricsList](#metrics-k8s-io-v1-NodeMetricsList)
+- [PodMetrics](#metrics-k8s-io-v1-PodMetrics)
+- [PodMetricsList](#metrics-k8s-io-v1-PodMetricsList)
   
 
-## `NodeMetrics`     {#metrics-k8s-io-v1beta1-NodeMetrics}
+## `NodeMetrics`     {#metrics-k8s-io-v1-NodeMetrics}
     
 
 **Appears in:**
 
-- [NodeMetricsList](#metrics-k8s-io-v1beta1-NodeMetricsList)
+- [NodeMetricsList](#metrics-k8s-io-v1-NodeMetricsList)
 
 
 <p>NodeMetrics sets resource usage metrics of a node.</p>
@@ -31,7 +31,7 @@ auto_generated: true
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeMetrics</code></td></tr>
     
   
@@ -67,7 +67,7 @@ collected from the interval [Timestamp-Window, Timestamp].</p>
 </tbody>
 </table>
 
-## `NodeMetricsList`     {#metrics-k8s-io-v1beta1-NodeMetricsList}
+## `NodeMetricsList`     {#metrics-k8s-io-v1-NodeMetricsList}
     
 
 
@@ -78,7 +78,7 @@ collected from the interval [Timestamp-Window, Timestamp].</p>
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeMetricsList</code></td></tr>
     
   
@@ -91,7 +91,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 </td>
 </tr>
 <tr><td><code>items</code> <B>[Required]</B><br/>
-<a href="#metrics-k8s-io-v1beta1-NodeMetrics"><code>[]NodeMetrics</code></a>
+<a href="#metrics-k8s-io-v1-NodeMetrics"><code>[]NodeMetrics</code></a>
 </td>
 <td>
    <p>List of node metrics.</p>
@@ -100,12 +100,12 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 </tbody>
 </table>
 
-## `PodMetrics`     {#metrics-k8s-io-v1beta1-PodMetrics}
+## `PodMetrics`     {#metrics-k8s-io-v1-PodMetrics}
     
 
 **Appears in:**
 
-- [PodMetricsList](#metrics-k8s-io-v1beta1-PodMetricsList)
+- [PodMetricsList](#metrics-k8s-io-v1-PodMetricsList)
 
 
 <p>PodMetrics sets resource usage metrics of a pod.</p>
@@ -115,7 +115,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>PodMetrics</code></td></tr>
     
   
@@ -142,7 +142,7 @@ collected from the interval [Timestamp-Window, Timestamp].</p>
    <span class="text-muted">No description provided.</span></td>
 </tr>
 <tr><td><code>containers</code> <B>[Required]</B><br/>
-<a href="#metrics-k8s-io-v1beta1-ContainerMetrics"><code>[]ContainerMetrics</code></a>
+<a href="#metrics-k8s-io-v1-ContainerMetrics"><code>[]ContainerMetrics</code></a>
 </td>
 <td>
    <p>Metrics for all containers are collected within the same time window.</p>
@@ -151,7 +151,7 @@ collected from the interval [Timestamp-Window, Timestamp].</p>
 </tbody>
 </table>
 
-## `PodMetricsList`     {#metrics-k8s-io-v1beta1-PodMetricsList}
+## `PodMetricsList`     {#metrics-k8s-io-v1-PodMetricsList}
     
 
 
@@ -162,7 +162,7 @@ collected from the interval [Timestamp-Window, Timestamp].</p>
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>PodMetricsList</code></td></tr>
     
   
@@ -175,7 +175,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 </td>
 </tr>
 <tr><td><code>items</code> <B>[Required]</B><br/>
-<a href="#metrics-k8s-io-v1beta1-PodMetrics"><code>[]PodMetrics</code></a>
+<a href="#metrics-k8s-io-v1-PodMetrics"><code>[]PodMetrics</code></a>
 </td>
 <td>
    <p>List of pod metrics.</p>
@@ -184,12 +184,12 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
 </tbody>
 </table>
 
-## `ContainerMetrics`     {#metrics-k8s-io-v1beta1-ContainerMetrics}
+## `ContainerMetrics`     {#metrics-k8s-io-v1-ContainerMetrics}
     
 
 **Appears in:**
 
-- [PodMetrics](#metrics-k8s-io-v1beta1-PodMetrics)
+- [PodMetrics](#metrics-k8s-io-v1-PodMetrics)
 
 
 <p>ContainerMetrics sets resource usage metrics of a container.</p>

--- a/content/en/docs/reference/instrumentation/cri-pod-container-metrics.md
+++ b/content/en/docs/reference/instrumentation/cri-pod-container-metrics.md
@@ -52,7 +52,7 @@ from cAdvisor. The following endpoints are affected:
 ### Summary API (`/stats/summary`)
 
 The kubelet fetches pod and container stats from the CRI runtime instead of cAdvisor for the
-[Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/). This includes CPU, memory,
+[Summary API](/docs/reference/kubelet-api/stats.v1alpha1/). This includes CPU, memory,
 network, and process stats for pods and containers.
 
 ### `/metrics/cadvisor`

--- a/content/en/docs/reference/instrumentation/node-metrics.md
+++ b/content/en/docs/reference/instrumentation/node-metrics.md
@@ -10,7 +10,7 @@ description: >-
 The [kubelet](/docs/reference/command-line-tools-reference/kubelet/)
 gathers metric statistics at the node, volume, pod and container level,
 and emits this information in the
-[Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/).
+[Summary API](/docs/reference/kubelet-api/stats.v1alpha1/).
 
 You can send a proxied request to the stats summary API via the
 Kubernetes API server.
@@ -50,7 +50,7 @@ the kubelet [fetches Pod- and container-level metric data using CRI](/docs/refer
 As a stable feature, Kubernetes lets you configure kubelet to collect Linux kernel
 [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html)
 (PSI) for CPU, memory, and I/O usage. The information is collected at node, pod and container level.
-See [Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/) for detailed schema.
+See [Summary API](/docs/reference/kubelet-api/stats.v1alpha1/) for detailed schema.
 Starting with Kubernetes v.1.36, the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is locked to true and cannot be disabled. The information is also exposed in
 [Prometheus metrics](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 

--- a/content/en/docs/reference/instrumentation/understand-psi-metrics.md
+++ b/content/en/docs/reference/instrumentation/understand-psi-metrics.md
@@ -16,7 +16,7 @@ As a stable feature, Kubernetes lets you configure the kubelet to collect Linux 
 Starting with Kubernetes v.1.36, the `KubeletPSI` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/) is locked to true and cannot be disabled.
 
 PSI metrics are exposed through two different sources:
-- The kubelet's [Summary API](/docs/reference/config-api/kubelet-stats.v1alpha1/), which provides PSI data at the node, pod, and container level.
+- The kubelet's [Summary API](/docs/reference/kubelet-api/stats.v1alpha1/), which provides PSI data at the node, pod, and container level.
 - The `/metrics/cadvisor` endpoint on the kubelet, which exposes PSI metrics in the [Prometheus format](/docs/concepts/cluster-administration/system-metrics#psi-metrics).
 
 ### Requirements

--- a/content/en/docs/reference/kubelet-api/_index.md
+++ b/content/en/docs/reference/kubelet-api/_index.md
@@ -1,0 +1,4 @@
+---
+title: Kubelet APIs
+weight: 140
+---

--- a/content/en/docs/reference/kubelet-api/stats.v1alpha1.md
+++ b/content/en/docs/reference/kubelet-api/stats.v1alpha1.md
@@ -1,0 +1,1156 @@
+---
+title: Kubelet Summary API (v1alpha1)
+content_type: tool-reference
+package: v1alpha1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [Summary](#Summary)
+  
+    
+    
+
+## `AcceleratorStats`     {#AcceleratorStats}
+    
+
+**Appears in:**
+
+- [ContainerStats](#ContainerStats)
+
+
+<p>AcceleratorStats contains stats for accelerators attached to the container.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>make</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Make of the accelerator (nvidia, amd, google etc.)</p>
+</td>
+</tr>
+<tr><td><code>model</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Model of the accelerator (tesla-p100, tesla-k80 etc.)</p>
+</td>
+</tr>
+<tr><td><code>id</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>ID of the accelerator.</p>
+</td>
+</tr>
+<tr><td><code>memoryTotal</code> <B>[Required]</B><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Total accelerator memory.
+unit: bytes</p>
+</td>
+</tr>
+<tr><td><code>memoryUsed</code> <B>[Required]</B><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Total accelerator memory allocated.
+unit: bytes</p>
+</td>
+</tr>
+<tr><td><code>dutyCycle</code> <B>[Required]</B><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Percent of time over the past sample period (10s) during which
+the accelerator was actively processing.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `CPUStats`     {#CPUStats}
+    
+
+**Appears in:**
+
+- [ContainerStats](#ContainerStats)
+
+- [NodeStats](#NodeStats)
+
+- [PodStats](#PodStats)
+
+
+<p>CPUStats contains data about CPU usage.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>time</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which these stats were updated.</p>
+</td>
+</tr>
+<tr><td><code>usageNanoCores</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Total CPU usage (sum of all cores) averaged over the sample window.
+The &quot;core&quot; unit can be interpreted as CPU core-nanoseconds per second.</p>
+</td>
+</tr>
+<tr><td><code>usageCoreNanoSeconds</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Cumulative CPU usage (sum of all cores) since object creation.</p>
+</td>
+</tr>
+<tr><td><code>psi</code><br/>
+<a href="#PSIStats"><code>PSIStats</code></a>
+</td>
+<td>
+   <p>CPU PSI stats.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ContainerStats`     {#ContainerStats}
+    
+
+**Appears in:**
+
+- [NodeStats](#NodeStats)
+
+- [PodStats](#PodStats)
+
+
+<p>ContainerStats holds container-level unprocessed sample stats.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Reference to the measured container.</p>
+</td>
+</tr>
+<tr><td><code>startTime</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which data collection for this container was (re)started.</p>
+</td>
+</tr>
+<tr><td><code>cpu</code><br/>
+<a href="#CPUStats"><code>CPUStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to CPU resources.</p>
+</td>
+</tr>
+<tr><td><code>memory</code><br/>
+<a href="#MemoryStats"><code>MemoryStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to memory (RAM) resources.</p>
+</td>
+</tr>
+<tr><td><code>io</code><br/>
+<a href="#IOStats"><code>IOStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to IO resources.</p>
+</td>
+</tr>
+<tr><td><code>accelerators</code> <B>[Required]</B><br/>
+<a href="#AcceleratorStats"><code>[]AcceleratorStats</code></a>
+</td>
+<td>
+   <p>Metrics for Accelerators. Each Accelerator corresponds to one element in the array.</p>
+</td>
+</tr>
+<tr><td><code>rootfs</code><br/>
+<a href="#FsStats"><code>FsStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to container rootfs usage of filesystem resources.
+Rootfs.UsedBytes is the number of bytes used for the container write layer.</p>
+</td>
+</tr>
+<tr><td><code>logs</code><br/>
+<a href="#FsStats"><code>FsStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to container logs usage of filesystem resources.
+Logs.UsedBytes is the number of bytes used for the container logs.</p>
+</td>
+</tr>
+<tr><td><code>userDefinedMetrics</code> <B>[Required]</B><br/>
+<a href="#UserDefinedMetric"><code>[]UserDefinedMetric</code></a>
+</td>
+<td>
+   <p>User defined metrics that are exposed by containers in the pod. Typically, we expect only one container in the pod to be exposing user defined metrics. In the event of multiple containers exposing metrics, they will be combined here.</p>
+</td>
+</tr>
+<tr><td><code>swap</code><br/>
+<a href="#SwapStats"><code>SwapStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to swap resources. This is reported to non-windows systems only.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `FsStats`     {#FsStats}
+    
+
+**Appears in:**
+
+- [ContainerStats](#ContainerStats)
+
+- [NodeStats](#NodeStats)
+
+- [PodStats](#PodStats)
+
+- [RuntimeStats](#RuntimeStats)
+
+- [VolumeStats](#VolumeStats)
+
+
+<p>FsStats contains data about filesystem usage.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>time</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which these stats were updated.</p>
+</td>
+</tr>
+<tr><td><code>availableBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>AvailableBytes represents the storage space available (bytes) for the filesystem.</p>
+</td>
+</tr>
+<tr><td><code>capacityBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>CapacityBytes represents the total capacity (bytes) of the filesystems underlying storage.</p>
+</td>
+</tr>
+<tr><td><code>usedBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>UsedBytes represents the bytes used for a specific task on the filesystem.
+This may differ from the total bytes used on the filesystem and may not equal CapacityBytes - AvailableBytes.
+e.g. For ContainerStats.Rootfs this is the bytes used by the container rootfs on the filesystem.</p>
+</td>
+</tr>
+<tr><td><code>inodesFree</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>InodesFree represents the free inodes in the filesystem.</p>
+</td>
+</tr>
+<tr><td><code>inodes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Inodes represents the total inodes in the filesystem.</p>
+</td>
+</tr>
+<tr><td><code>inodesUsed</code> <B>[Required]</B><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>InodesUsed represents the inodes used by the filesystem
+This may not equal Inodes - InodesFree because this filesystem may share inodes with other &quot;filesystems&quot;
+e.g. For ContainerStats.Rootfs, this is the inodes used only by that container, and does not count inodes used by other containers.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `IOStats`     {#IOStats}
+    
+
+**Appears in:**
+
+- [ContainerStats](#ContainerStats)
+
+- [NodeStats](#NodeStats)
+
+- [PodStats](#PodStats)
+
+
+<p>IOStats contains data about IO usage.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>time</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which these stats were updated.</p>
+</td>
+</tr>
+<tr><td><code>psi</code><br/>
+<a href="#PSIStats"><code>PSIStats</code></a>
+</td>
+<td>
+   <p>IO PSI stats.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `InterfaceStats`     {#InterfaceStats}
+    
+
+**Appears in:**
+
+- [NetworkStats](#NetworkStats)
+
+
+<p>InterfaceStats contains resource value data about interface.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>The name of the interface</p>
+</td>
+</tr>
+<tr><td><code>rxBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Cumulative count of bytes received.</p>
+</td>
+</tr>
+<tr><td><code>rxErrors</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Cumulative count of receive errors encountered.</p>
+</td>
+</tr>
+<tr><td><code>txBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Cumulative count of bytes transmitted.</p>
+</td>
+</tr>
+<tr><td><code>txErrors</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Cumulative count of transmit errors encountered.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `MemoryStats`     {#MemoryStats}
+    
+
+**Appears in:**
+
+- [ContainerStats](#ContainerStats)
+
+- [NodeStats](#NodeStats)
+
+- [PodStats](#PodStats)
+
+
+<p>MemoryStats contains data about memory usage.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>time</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which these stats were updated.</p>
+</td>
+</tr>
+<tr><td><code>availableBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Available memory for use.  This is defined as the memory limit - workingSetBytes.
+If memory limit is undefined, the available bytes is omitted.</p>
+</td>
+</tr>
+<tr><td><code>usageBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Total memory in use. This includes all memory regardless of when it was accessed.</p>
+</td>
+</tr>
+<tr><td><code>workingSetBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>The amount of working set memory. This includes recently accessed memory,
+dirty memory, and kernel memory. WorkingSetBytes is &lt;= UsageBytes</p>
+</td>
+</tr>
+<tr><td><code>rssBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>The amount of anonymous and swap cache memory (includes transparent
+hugepages).</p>
+</td>
+</tr>
+<tr><td><code>pageFaults</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Cumulative number of minor page faults.</p>
+</td>
+</tr>
+<tr><td><code>majorPageFaults</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Cumulative number of major page faults.</p>
+</td>
+</tr>
+<tr><td><code>psi</code><br/>
+<a href="#PSIStats"><code>PSIStats</code></a>
+</td>
+<td>
+   <p>Memory PSI stats.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `NetworkStats`     {#NetworkStats}
+    
+
+**Appears in:**
+
+- [NodeStats](#NodeStats)
+
+- [PodStats](#PodStats)
+
+
+<p>NetworkStats contains data about network resources.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>time</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which these stats were updated.</p>
+</td>
+</tr>
+<tr><td><code>InterfaceStats</code> <B>[Required]</B><br/>
+<a href="#InterfaceStats"><code>InterfaceStats</code></a>
+</td>
+<td>
+   <p>Stats for the default interface, if found</p>
+</td>
+</tr>
+<tr><td><code>interfaces</code> <B>[Required]</B><br/>
+<a href="#InterfaceStats"><code>[]InterfaceStats</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+</tbody>
+</table>
+
+## `NodeStats`     {#NodeStats}
+    
+
+**Appears in:**
+
+- [Summary](#Summary)
+
+
+<p>NodeStats holds node-level unprocessed sample stats.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>nodeName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Reference to the measured Node.</p>
+</td>
+</tr>
+<tr><td><code>systemContainers</code><br/>
+<a href="#ContainerStats"><code>[]ContainerStats</code></a>
+</td>
+<td>
+   <p>Stats of system daemons tracked as raw containers.
+The system containers are named according to the SystemContainer* constants.</p>
+</td>
+</tr>
+<tr><td><code>startTime</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which data collection for the node-scoped (i.e. aggregate) stats was (re)started.</p>
+</td>
+</tr>
+<tr><td><code>cpu</code><br/>
+<a href="#CPUStats"><code>CPUStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to CPU resources.</p>
+</td>
+</tr>
+<tr><td><code>memory</code><br/>
+<a href="#MemoryStats"><code>MemoryStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to memory (RAM) resources.</p>
+</td>
+</tr>
+<tr><td><code>io</code><br/>
+<a href="#IOStats"><code>IOStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to IO resources.</p>
+</td>
+</tr>
+<tr><td><code>network</code><br/>
+<a href="#NetworkStats"><code>NetworkStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to network resources.</p>
+</td>
+</tr>
+<tr><td><code>fs</code><br/>
+<a href="#FsStats"><code>FsStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to total usage of filesystem resources on the rootfs used by node k8s components.
+NodeFs.Used is the total bytes used on the filesystem.</p>
+</td>
+</tr>
+<tr><td><code>runtime</code><br/>
+<a href="#RuntimeStats"><code>RuntimeStats</code></a>
+</td>
+<td>
+   <p>Stats about the underlying container runtime.</p>
+</td>
+</tr>
+<tr><td><code>rlimit</code><br/>
+<a href="#RlimitStats"><code>RlimitStats</code></a>
+</td>
+<td>
+   <p>Stats about the rlimit of system.</p>
+</td>
+</tr>
+<tr><td><code>swap</code><br/>
+<a href="#SwapStats"><code>SwapStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to swap resources. This is reported to non-windows systems only.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PSIData`     {#PSIData}
+    
+
+**Appears in:**
+
+- [PSIStats](#PSIStats)
+
+
+<p>PSI data for an individual resource.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>total</code> <B>[Required]</B><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Total time duration for tasks in the cgroup have waited due to congestion.
+Unit: nanoseconds.</p>
+</td>
+</tr>
+<tr><td><code>avg10</code> <B>[Required]</B><br/>
+<code>float64</code>
+</td>
+<td>
+   <p>The average (in %) tasks have waited due to congestion over a 10 second window.</p>
+</td>
+</tr>
+<tr><td><code>avg60</code> <B>[Required]</B><br/>
+<code>float64</code>
+</td>
+<td>
+   <p>The average (in %) tasks have waited due to congestion over a 60 second window.</p>
+</td>
+</tr>
+<tr><td><code>avg300</code> <B>[Required]</B><br/>
+<code>float64</code>
+</td>
+<td>
+   <p>The average (in %) tasks have waited due to congestion over a 300 second window.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PSIStats`     {#PSIStats}
+    
+
+**Appears in:**
+
+- [CPUStats](#CPUStats)
+
+- [IOStats](#IOStats)
+
+- [MemoryStats](#MemoryStats)
+
+
+<p>PSI statistics for an individual resource.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>full</code> <B>[Required]</B><br/>
+<a href="#PSIData"><code>PSIData</code></a>
+</td>
+<td>
+   <p>PSI data for all tasks in the cgroup.</p>
+</td>
+</tr>
+<tr><td><code>some</code> <B>[Required]</B><br/>
+<a href="#PSIData"><code>PSIData</code></a>
+</td>
+<td>
+   <p>PSI data for some tasks in the cgroup.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PVCReference`     {#PVCReference}
+    
+
+**Appears in:**
+
+- [VolumeStats](#VolumeStats)
+
+
+<p>PVCReference contains enough information to describe the referenced PVC.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+<tr><td><code>namespace</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+</tbody>
+</table>
+
+## `PodReference`     {#PodReference}
+    
+
+**Appears in:**
+
+- [PodStats](#PodStats)
+
+
+<p>PodReference contains enough information to locate the referenced pod.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+<tr><td><code>namespace</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+<tr><td><code>uid</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+</tbody>
+</table>
+
+## `PodStats`     {#PodStats}
+    
+
+**Appears in:**
+
+- [Summary](#Summary)
+
+
+<p>PodStats holds pod-level unprocessed sample stats.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>podRef</code> <B>[Required]</B><br/>
+<a href="#PodReference"><code>PodReference</code></a>
+</td>
+<td>
+   <p>Reference to the measured Pod.</p>
+</td>
+</tr>
+<tr><td><code>startTime</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which data collection for the pod-scoped (e.g. network) stats was (re)started.</p>
+</td>
+</tr>
+<tr><td><code>containers</code> <B>[Required]</B><br/>
+<a href="#ContainerStats"><code>[]ContainerStats</code></a>
+</td>
+<td>
+   <p>Stats of containers in the measured pod.</p>
+</td>
+</tr>
+<tr><td><code>cpu</code><br/>
+<a href="#CPUStats"><code>CPUStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to CPU resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).</p>
+</td>
+</tr>
+<tr><td><code>memory</code><br/>
+<a href="#MemoryStats"><code>MemoryStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to memory (RAM) resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).</p>
+</td>
+</tr>
+<tr><td><code>io</code><br/>
+<a href="#IOStats"><code>IOStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to IO resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).</p>
+</td>
+</tr>
+<tr><td><code>network</code><br/>
+<a href="#NetworkStats"><code>NetworkStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to network resources.</p>
+</td>
+</tr>
+<tr><td><code>volume</code><br/>
+<a href="#VolumeStats"><code>[]VolumeStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to volume usage of filesystem resources.
+VolumeStats.UsedBytes is the number of bytes used by the Volume</p>
+</td>
+</tr>
+<tr><td><code>ephemeral-storage</code><br/>
+<a href="#FsStats"><code>FsStats</code></a>
+</td>
+<td>
+   <p>EphemeralStorage reports the total filesystem usage for the containers and emptyDir-backed volumes in the measured Pod.</p>
+</td>
+</tr>
+<tr><td><code>process_stats</code><br/>
+<a href="#ProcessStats"><code>ProcessStats</code></a>
+</td>
+<td>
+   <p>ProcessStats pertaining to processes.</p>
+</td>
+</tr>
+<tr><td><code>swap</code><br/>
+<a href="#SwapStats"><code>SwapStats</code></a>
+</td>
+<td>
+   <p>Stats pertaining to swap resources. This is reported to non-windows systems only.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ProcessStats`     {#ProcessStats}
+    
+
+**Appears in:**
+
+- [PodStats](#PodStats)
+
+
+<p>ProcessStats are stats pertaining to processes.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>process_count</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Number of processes</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `RlimitStats`     {#RlimitStats}
+    
+
+**Appears in:**
+
+- [NodeStats](#NodeStats)
+
+
+<p>RlimitStats are stats rlimit of OS.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>time</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+<tr><td><code>maxpid</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   <p>The max number of extant process (threads, precisely on Linux) of OS. See RLIMIT_NPROC in getrlimit(2).
+The operating system ceiling on the number of process IDs that can be assigned.
+On Linux, tasks (either processes or threads) consume 1 PID each.</p>
+</td>
+</tr>
+<tr><td><code>curproc</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   <p>The number of running process (threads, precisely on Linux) in the OS.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `RuntimeStats`     {#RuntimeStats}
+    
+
+**Appears in:**
+
+- [NodeStats](#NodeStats)
+
+
+<p>RuntimeStats are stats pertaining to the underlying container runtime.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>imageFs</code><br/>
+<a href="#FsStats"><code>FsStats</code></a>
+</td>
+<td>
+   <p>Stats about the underlying filesystem where container images are stored.
+This filesystem could be the same as the primary (root) filesystem.
+Usage here refers to the total number of bytes occupied by images on the filesystem.</p>
+</td>
+</tr>
+<tr><td><code>containerFs</code><br/>
+<a href="#FsStats"><code>FsStats</code></a>
+</td>
+<td>
+   <p>Stats about the underlying filesystem where container's writeable layer is stored.
+This filesystem could be the same as the primary (root) filesystem or the ImageFS.
+Usage here refers to the total number of bytes occupied by the writeable layer on the filesystem.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `SwapStats`     {#SwapStats}
+    
+
+**Appears in:**
+
+- [ContainerStats](#ContainerStats)
+
+- [NodeStats](#NodeStats)
+
+- [PodStats](#PodStats)
+
+
+<p>SwapStats contains data about memory usage</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>time</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which these stats were updated.</p>
+</td>
+</tr>
+<tr><td><code>swapAvailableBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Available swap memory for use.  This is defined as the <!-- raw HTML omitted --> - <!-- raw HTML omitted -->.
+If swap limit is undefined, this value is omitted.</p>
+</td>
+</tr>
+<tr><td><code>swapUsageBytes</code><br/>
+<code>uint64</code>
+</td>
+<td>
+   <p>Total swap memory in use.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `UserDefinedMetric`     {#UserDefinedMetric}
+    
+
+**Appears in:**
+
+- [ContainerStats](#ContainerStats)
+
+
+<p>UserDefinedMetric represents a metric defined and generated by users.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>UserDefinedMetricDescriptor</code> <B>[Required]</B><br/>
+<a href="#UserDefinedMetricDescriptor"><code>UserDefinedMetricDescriptor</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span></td>
+</tr>
+<tr><td><code>time</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.37/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>The time at which these stats were updated.</p>
+</td>
+</tr>
+<tr><td><code>value</code> <B>[Required]</B><br/>
+<code>float64</code>
+</td>
+<td>
+   <p>Value of the metric. Float64s have 53 bit precision.
+We do not foresee any metrics exceeding that value.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `UserDefinedMetricDescriptor`     {#UserDefinedMetricDescriptor}
+    
+
+**Appears in:**
+
+- [UserDefinedMetric](#UserDefinedMetric)
+
+
+<p>UserDefinedMetricDescriptor contains metadata that describes a user defined metric.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>The name of the metric.</p>
+</td>
+</tr>
+<tr><td><code>type</code> <B>[Required]</B><br/>
+<a href="#UserDefinedMetricType"><code>UserDefinedMetricType</code></a>
+</td>
+<td>
+   <p>Type of the metric.</p>
+</td>
+</tr>
+<tr><td><code>units</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Display Units for the stats.</p>
+</td>
+</tr>
+<tr><td><code>labels</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   <p>Metadata labels associated with this metric.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `UserDefinedMetricType`     {#UserDefinedMetricType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [UserDefinedMetricDescriptor](#UserDefinedMetricDescriptor)
+
+
+<p>UserDefinedMetricType defines how the metric should be interpreted by the user.</p>
+
+
+
+
+## `VolumeStats`     {#VolumeStats}
+    
+
+**Appears in:**
+
+- [PodStats](#PodStats)
+
+
+<p>VolumeStats contains data about Volume filesystem usage.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>FsStats</code> <B>[Required]</B><br/>
+<a href="#FsStats"><code>FsStats</code></a>
+</td>
+<td>
+   <p>Embedded FsStats</p>
+</td>
+</tr>
+<tr><td><code>name</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the name given to the Volume</p>
+</td>
+</tr>
+<tr><td><code>pvcRef</code><br/>
+<a href="#PVCReference"><code>PVCReference</code></a>
+</td>
+<td>
+   <p>Reference to the PVC, if one exists</p>
+</td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
Regenerated the kubectl reference for v1.37.0.

- Generated with `make copyconfigapi` from kubernetes-sigs/reference-docs
- Generator changes: kubernetes-sigs/reference-docs https://github.com/kubernetes-sigs/reference-docs/pull/472
- Generated files only, with no hand edits


Two new pages:

- external-api/metrics.v1.md, the v1 metrics API now served alongside v1beta1
- config-api/kubelet-stats.v1alpha1.md, the kubelet Summary API, which genref has
  always generated but never published because the page had no front matter

Publishing the Summary API page fixes the four links that currently 404:
instrumentation/node-metrics.md (x2), instrumentation/understand-psi-metrics.md
and instrumentation/cri-pod-container-metrics.md.

Closes #56087
Closes #52308
Closes #51177



cc: @kubernetes/release-team-docs @dipesh-rawat

/hold until upstream is review and merged 