### PR TITLE
[ja] Translate content/en/docs/reference/glossary/downward-api.md into Japanese

### DIFF
--- a/content/ja/docs/reference/glossary/downward-api.md
+++ b/content/ja/docs/reference/glossary/downward-api.md
@@ -8,11 +8,12 @@ full_link: /docs/concepts/workloads/pods/downward-api/
 tags:
 - architecture
 ---
- Podやコンテナのフィールドの値を、コンテナ内で実行されているコードに公開するためのKubernetesの仕組みです。
+Podやコンテナのフィールドの値を、コンテナ内で実行されているコードに公開するためのKubernetesの仕組みです。
 <!--more-->
 コンテナのコードをKubernetesに直接結合させるような変更を加えることなく、コンテナが自分自身についての情報を持つことは有用な場合があります。
 
-KubernetesのDownward APIを用いることで、コンテナは自分自身やKubernetesクラスター内のコンテキストに関する情報を取得することができます。コンテナ内のアプリケーションは、Kubernetes APIのクライアントとして動作することなく、その情報にアクセスできます。
+KubernetesのDownward APIを用いることで、コンテナは自分自身やKubernetesクラスター内のコンテキストに関する情報を取得することができます。
+コンテナ内のアプリケーションは、Kubernetes APIのクライアントとして動作することなく、その情報にアクセスできます。
 
 実行中のコンテナにPodおよびコンテナフィールドを公開する方法は2つあります:
 

--- a/content/ja/docs/reference/glossary/downward-api.md
+++ b/content/ja/docs/reference/glossary/downward-api.md
@@ -1,0 +1,22 @@
+---
+title: Downward API
+id: downward-api
+short_description: >
+  Podやコンテナのフィールドの値を、コンテナ内で実行されているコードに公開するための仕組みです。
+aka:
+full_link: /docs/concepts/workloads/pods/downward-api/
+tags:
+- architecture
+---
+ Podやコンテナのフィールドの値を、コンテナ内で実行されているコードに公開するためのKubernetesの仕組みです。
+<!--more-->
+コンテナのコードをKubernetesに直接結合させるような変更を加えることなく、コンテナが自分自身についての情報を持つことは有用な場合があります。
+
+KubernetesのDownward APIを用いることで、コンテナは自分自身やKubernetesクラスター内のコンテキストに関する情報を取得することができます。コンテナ内のアプリケーションは、Kubernetes APIのクライアントとして動作することなく、その情報にアクセスできます。
+
+実行中のコンテナにPodおよびコンテナフィールドを公開する方法は2つあります:
+
+- [環境変数](/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)を使用する
+- [`downwardAPI`ボリューム](/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/)を使用する
+
+これらPodおよびコンテナフィールドを公開する2つの方法を総称して、_downward API_ と呼びます。


### PR DESCRIPTION
### Description

Add the Japanese translation for the glossary term `downward-api` (`content/en/docs/reference/glossary/downward-api.md`).

- Terminology and phrasing follow the existing Japanese concept page `content/ja/docs/concepts/workloads/pods/downward-api.md` (e.g. これらPodおよびコンテナフィールドを公開する2つの方法を総称して、_downward API_ と呼びます), so the glossary entry stays consistent with the page it links to.
- `full_link` is kept without the `/ja` prefix per the localization guide.

This PR was written in part with the assistance of generative AI; the translation has been checked against the existing ja pages' terminology by a human.

### Issue

Closes: #56987

/area localization
/language ja

<!-- oss-radar:idempotency=auto-20260827-151151.w7.kubernetes_website.56987 -->