### PR TITLE
[zh-cn] Fix Gateway API conformance links

### DIFF
--- a/content/zh-cn/blog/_posts/2024/gateway-api-v1-1/index.md
+++ b/content/zh-cn/blog/_posts/2024/gateway-api-v1-1/index.md
@@ -184,7 +184,7 @@ For more information, see
 有关细节请参阅[挂接到 Gateways](https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways)。
 
 <!--
-#### [Conformance Profiles and Reports](https://gateway-api.sigs.k8s.io/concepts/conformance/#conformance-profiles)
+#### [Conformance Profiles and Reports](https://gateway-api.sigs.k8s.io/docs/concepts/conformance/#conformance-profiles)
 
 The conformance report API has been expanded with the `mode` field (intended to
 specify the working mode of the implementation), and the `gatewayAPIChannel`
@@ -194,7 +194,7 @@ description of the testing outcome. The Reports have been reorganized in a more
 structured way, and the implementations can now add information on how the tests
 have been run and provide reproduction steps.
 -->
-#### [合规性配置文件和报告](https://gateway-api.sigs.k8s.io/concepts/conformance/#conformance-profiles)
+#### [合规性配置文件和报告](https://gateway-api.sigs.k8s.io/docs/concepts/conformance/#conformance-profiles)
 
 合规性报告 API 被扩展了，添加了 `mode` 字段（用于指定实现的工作模式）以及 `gatewayAPIChannel`（标准或实验性）。
 `gatewayAPIVersion` 和 `gatewayAPIChannel` 现在由套件机制自动填充，并附有测试结果的简要描述。
@@ -425,4 +425,3 @@ Kubernetes routing APIs for both ingress and service mesh.
 * 2023 年 10 月 [Gateway API v1.0：正式发布（GA）](/zh-cn/blog/2023/10/31/gateway-api-ga/)
 * 2023 年 10 月[介绍 ingress2gateway；简化 Gateway API 升级](/blog/2023/10/25/introducing-ingress2gateway/)
 * 2023 年 8 月 [Gateway API v0.8.0：引入服务网格支持](/zh-cn/blog/2023/08/29/gateway-api-v0-8/)
-  

--- a/content/zh-cn/docs/concepts/services-networking/gateway.md
+++ b/content/zh-cn/docs/concepts/services-networking/gateway.md
@@ -413,7 +413,7 @@ Gateway API covers a broad set of features and is widely implemented. This combi
 clear conformance definitions and tests to ensure that the API provides a consistent experience
 wherever it is used.
 
-See the [conformance](https://gateway-api.sigs.k8s.io/concepts/conformance/) documentation to
+See the [conformance](https://gateway-api.sigs.k8s.io/docs/concepts/conformance/) documentation to
 understand details such as release channels, support levels, and running conformance tests.
 -->
 ## 标准合规性 {#conformance}
@@ -421,7 +421,7 @@ understand details such as release channels, support levels, and running conform
 Gateway API 涵盖广泛的功能并得到广泛实现。
 这种组合需要明确的标准合规性定义和测试，以确保 API 在任何地方使用时都能提供一致的体验。
 
-请参阅[合规性](https://gateway-api.sigs.k8s.io/concepts/conformance/)相关的文档，
+请参阅[合规性](https://gateway-api.sigs.k8s.io/docs/concepts/conformance/)相关的文档，
 以了解发布渠道、支持级别和运行合规性测试等详细信息。
 
 <!-- 


### PR DESCRIPTION
### Description

Update outdated Gateway API conformance links in the Chinese localization.

- Fix the conformance link in the Chinese Gateway documentation.
- Fix the same link in the Chinese Gateway API v1.1 blog post.
- Update the corresponding English source comments retained in the localized files.

The old URL returns 404. The updated URL points to:

https://gateway-api.sigs.k8s.io/docs/concepts/conformance/

### Issue

Closes: #