### PR TITLE
[zh-cn]sync kubeadm_init_phase_{addon_coredns,control-plane_apiserver}

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_coredns.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_coredns.md
@@ -1,11 +1,10 @@
 <!--
 ### Synopsis
+
+Install the CoreDNS addon components via the API server. Please note that although the DNS server is deployed, it will not be scheduled until CNI is installed.
 -->
 ### 概要
 
-<!--
-Install the CoreDNS addon components via the API server. Please note that although the DNS server is deployed, it will not be scheduled until CNI is installed.
--->
 通过 API 服务器安装 CoreDNS 附加组件。请注意，即使 DNS 服务器已部署，在安装 CNI
 之前 DNS 服务器不会被调度执行。
 
@@ -29,7 +28,8 @@ kubeadm init phase addon coredns [flags]
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -44,7 +44,8 @@ kubeadm 配置文件的路径。
 <td colspan="2">--dry-run</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -59,18 +60,15 @@ Don't apply any changes; just output what would be done.
 <td colspan="2">--feature-gates string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-NodeLocalCRISocket=true|false (default=true)<br/>
-PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
 RootlessControlPlane=true|false (ALPHA - default=false)
 -->
 一组用来描述各种特性门控的键值对（key=value）。选项是：<br/>
-NodeLocalCRISocket=true|false (默认值=true)<br/>
-PublicKeysECDSA=true|false (已弃用 - 默认值=false)<br/>
 RootlessControlPlane=true|false (ALPHA - 默认值=false)
 </p>
 </td>
@@ -80,7 +78,8 @@ RootlessControlPlane=true|false (ALPHA - 默认值=false)
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -100,7 +99,8 @@ coredns 操作的帮助命令。
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -120,7 +120,8 @@ Choose a container registry to pull control plane images from
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -141,7 +142,8 @@ kubeconfig 文件。
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -156,7 +158,8 @@ Choose a specific Kubernetes version for the control plane.
 <td colspan="2">--print-manifest</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -176,7 +179,8 @@ Print the addon manifests to STDOUT instead of installing them
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -196,7 +200,8 @@ Use alternative range of IP address for service VIPs.
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -226,7 +231,8 @@ Use alternative domain for services, e.g. &quot;myorg.internal&quot;.
 <td colspan="2">--rootfs string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_apiserver.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_apiserver.md
@@ -28,7 +28,8 @@ kubeadm init phase control-plane apiserver [flags]
 <td colspan="2">--apiserver-advertise-address string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -48,7 +49,8 @@ API 服务器所公布的其正在监听的 IP 地址。如果未设置，将使
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -63,7 +65,8 @@ Port for the API Server to bind to.
 <td colspan="2">--apiserver-extra-args <!--&lt;comma-separated 'key=value' pairs&gt;-->&lt;逗号分隔的 'key=value' 对&gt;</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -84,7 +87,8 @@ A set of extra flags to pass to the API Server or override default ones in form 
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -99,7 +103,8 @@ The path where to save and store the certificates.
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -114,7 +119,8 @@ kubeadm 配置文件的路径。
 <td colspan="2">--control-plane-endpoint string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -128,7 +134,8 @@ Specify a stable IP address or DNS name for the control plane.
 <td colspan="2">--dry-run</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -143,18 +150,15 @@ Don't apply any changes; just output what would be done.
 <td colspan="2">--feature-gates string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-NodeLocalCRISocket=true|false (default=true)<br/>
-PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
 RootlessControlPlane=true|false (ALPHA - default=false)
 -->
 一组键值对，用于描述各种功能特性的特性门控。选项是：<br/>
-NodeLocalCRISocket=true|false (默认值=true)<br/>
-PublicKeysECDSA=true|false (已弃用 - 默认值=false)<br/>
 RootlessControlPlane=true|false (ALPHA - 默认值=false)
 </p>
 </td>
@@ -164,7 +168,8 @@ RootlessControlPlane=true|false (ALPHA - 默认值=false)
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -184,7 +189,8 @@ apiserver 操作的帮助命令。
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -204,7 +210,8 @@ Choose a container registry to pull control plane images from
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -219,20 +226,24 @@ Choose a specific Kubernetes version for the control plane.
 <td colspan="2">--patches string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
-Path to a directory that contains files named &quot;target[suffix][+patchtype].extension&quot;. For example, &quot;kube-apiserver0+merge.yaml&quot; or just &quot;etcd.json&quot;. &quot;target&quot; can be one of &quot;kube-apiserver&quot;, &quot;kube-controller-manager&quot;, &quot;kube-scheduler&quot;, &quot;etcd&quot;, &quot;kubeletconfiguration&quot;. &quot;patchtype&quot; can be one of &quot;strategic&quot;, &quot;merge&quot; or &quot;json&quot; and they match the patch formats supported by kubectl. The default &quot;patchtype&quot; is &quot;strategic&quot;. &quot;extension&quot; must be either &quot;json&quot; or &quot;yaml&quot;. &quot;suffix&quot; is an optional string that can be used to determine which patches are applied first alpha-numerically.
+Path to a directory that contains files named &quot;target[suffix][+patchtype].extension&quot;. For example, &quot;kube-apiserver0+merge.yaml&quot; or just &quot;etcd.json&quot;. &quot;target&quot; can be one of &quot;kube-apiserver&quot;, &quot;kube-controller-manager&quot;, &quot;kube-scheduler&quot;, &quot;etcd&quot;, &quot;kubeletconfiguration&quot;, &quot;corednsdeployment&quot;, &quot;kubeproxydaemonset&quot;. &quot;patchtype&quot; can be one of &quot;strategic&quot;, &quot;merge&quot; or &quot;json&quot; and they match the patch formats supported by kubectl. The default &quot;patchtype&quot; is &quot;strategic&quot;. &quot;extension&quot; must be either &quot;json&quot; or &quot;yaml&quot;. &quot;suffix&quot; is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
 包含名为 &quot;target[suffix][+patchtype].extension&quot; 的文件的目录的路径。
 例如，&quot;kube-apiserver0+merge.yaml&quot;或仅仅是 &quot;etcd.json&quot;。
-&quot;target&quot; 可以是 &quot;kube-apiserver&quot;、&quot;kube-controller-manager&quot;、&quot;kube-scheduler&quot;、
-&quot;etcd&quot;、&quot;kubeletconfiguration&quot; 之一。
-&quot;patchtype&quot; 可以是 &quot;strategic&quot;、&quot;merge&quot; 或者 &quot;json&quot; 之一，
+&quot;target&quot; 可以是 &quot;kube-apiserver&quot;、
+&quot;kube-controller-manager&quot;、&quot;kube-scheduler&quot;、
+&quot;etcd&quot;、&quot;kubeletconfiguration&quot;、
+&quot;corednsdeployment&quot;、&quot;kubeproxydaemonset&quot; 之一。
+&quot;patchtype&quot; 可以是 &quot;strategic&quot;、
+&quot;merge&quot; 或者 &quot;json&quot; 之一，
 并且它们与 kubectl 支持的补丁格式相同。
 默认的 &quot;patchtype&quot; 是 &quot;strategic&quot;。
-&quot;extension&quot; 必须是&quot;json&quot; 或&quot;yaml&quot;。
+&quot;extension&quot; 必须是 &quot;json&quot; 或 &quot;yaml&quot;。
 &quot;suffix&quot; 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
 </p>
 </td>
@@ -247,7 +258,8 @@ Path to a directory that contains files named &quot;target[suffix][+patchtype].e
 </td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
@@ -277,7 +289,8 @@ Use alternative range of IP address for service VIPs.
 <td colspan="2">--rootfs string</td>
 </tr>
 <tr>
-<td></td>
+<td>
+</td>
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--


### PR DESCRIPTION
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_addon_coredns.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_apiserver.md