### PR TITLE
Remove stale TODO: --cascade flag is already documented as a string

### DIFF
--- a/content/en/docs/tasks/administer-cluster/use-cascading-deletion.md
+++ b/content/en/docs/tasks/administer-cluster/use-cascading-deletion.md
@@ -55,7 +55,6 @@ Kubernetes API.
 **Using kubectl**
 
 Run the following command:
-<!--TODO: verify release after which the --cascade flag is switched to a string in https://github.com/kubernetes/kubectl/commit/fd930e3995957b0093ecc4b9fd8b0525d94d3b4e-->
 
 ```shell
 kubectl delete deployment nginx-deployment --cascade=foreground


### PR DESCRIPTION
### Description
Removes a stale TODO comment asking to verify the release in which `kubectl delete`'s `--cascade` flag switched from a boolean to a string. This has already happened: the current kubectl reference docs document `--cascade` as `string[="background"]` (accepting `background`, `orphan` or `foreground`) so the verification this TODO asked for is no longer needed. 
This is a docs-only cleanup with no content or behavioral change.