### PR TITLE
[zh-cn]sync kubeadm_init_phase_{etcd_local,control-plane_controller-manager} kubeadm_config_images_list

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config/kubeadm_config_images_list.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config/kubeadm_config_images_list.md
@@ -1,11 +1,10 @@
 <!--
 ### Synopsis
+
+Print a list of images kubeadm will use. The configuration file is used in case any images or image repositories are customized
 -->
 ### 概要
 
-<!--
-Print a list of images kubeadm will use. The configuration file is used in case any images or image repositories are customized
--->
 打印 kubeadm 要使用的镜像列表。配置文件用于自定义镜像或镜像存储库。
 
 ```shell
@@ -31,7 +30,8 @@ kubeadm config images list [flags]
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!-- 
 If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
@@ -46,7 +46,8 @@ If true, ignore any errors in templates when a field or map key is missing in th
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 Path to a kubeadm configuration file.
@@ -62,9 +63,10 @@ kubeadm 配置文件的路径。
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
-<!--  
+<!-- 
 Output format. One of: text|json|yaml|kyaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
 -->
 输出格式：text|json|yaml|kyaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file 其中之一。
@@ -81,13 +83,9 @@ Output format. One of: text|json|yaml|kyaml|go-template|go-template-file|templat
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 A set of key=value pairs that describe feature gates for various features. Options are:<br/>
-NodeLocalCRISocket=true|false (default=true)<br/>
-PublicKeysECDSA=true|false (DEPRECATED - default=false)<br/>
 RootlessControlPlane=true|false (ALPHA - default=false)
 -->
 一组用来描述各种特性门控的键值（key=value）对。选项是：<br/>
-NodeLocalCRISocket=true|false (默认值=true)<br/>
-PublicKeysECDSA=true|false (DEPRECATED - 默认值=false)<br/>
 RootlessControlPlane=true|false (ALPHA - 默认值=false)
 </p>
 </td>
@@ -97,7 +95,8 @@ RootlessControlPlane=true|false (ALPHA - 默认值=false)
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 help for list
@@ -137,7 +136,8 @@ Choose a container registry to pull control plane images from
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 Choose a specific Kubernetes version for the control plane.
@@ -156,7 +156,8 @@ Choose a specific Kubernetes version for the control plane.
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 If true, keep the managedFields when printing objects in JSON or YAML format.
@@ -190,7 +191,8 @@ If true, keep the managedFields when printing objects in JSON or YAML format.
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
@@ -205,7 +207,8 @@ The kubeconfig file to use when talking to the cluster. If the flag is not set, 
 <td colspan="2">--rootfs string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 [EXPERIMENTAL] The path to the 'real' host root filesystem.

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_controller-manager.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_controller-manager.md
@@ -1,11 +1,10 @@
 <!--
 ### Synopsis
+
+Generates the kube-controller-manager static Pod manifest
 -->
 ### 概要
 
-<!--
-Generates the kube-controller-manager static Pod manifest
--->
 生成 kube-controller-manager 静态 Pod 清单。
 
 ```shell
@@ -25,7 +24,7 @@ kubeadm init phase control-plane controller-manager [flags]
 <tbody>
 
 <tr>
-<td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default: "/etc/kubernetes/pki"-->默认值："/etc/kubernetes/pki"</td>
+<td colspan="2">--cert-dir string&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<!--Default:-->默认值："/etc/kubernetes/pki"</td>
 </tr>
 <tr>
 <td></td>
@@ -147,15 +146,17 @@ Choose a specific Kubernetes version for the control plane.
 <td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
-Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd", "kubeletconfiguration". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.
+Path to a directory that contains files named &quot;target[suffix][+patchtype].extension&quot;. For example, &quot;kube-apiserver0+merge.yaml&quot; or just &quot;etcd.json&quot;. &quot;target&quot; can be one of &quot;kube-apiserver&quot;, &quot;kube-controller-manager&quot;, &quot;kube-scheduler&quot;, &quot;etcd&quot;, &quot;kubeletconfiguration&quot;, &quot;corednsdeployment&quot;, &quot;kubeproxydaemonset&quot;. &quot;patchtype&quot; can be one of &quot;strategic&quot;, &quot;merge&quot; or &quot;json&quot; and they match the patch formats supported by kubectl. The default &quot;patchtype&quot; is &quot;strategic&quot;. &quot;extension&quot; must be either &quot;json&quot; or &quot;yaml&quot;. &quot;suffix&quot; is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
-包含名为 "target[suffix][+patchtype].extension" 的文件的目录。
-例如，"kube-apiserver0+merge.yaml" 或者 "etcd.json"。
-"target" 可以是 "kube-apiserver"、"kube-controller-manager"、"kube-scheduler"、"etcd"、"kubeletconfiguration" 之一。
-"patchtype" 可以是 "strategic"、"merge" 或 "json" 之一，分别与 kubectl
-所支持的 patch 格式相匹配。默认的 "patchtype" 是 "strategic"。
-"extension" 必须是 "json" 或 "yaml"。
-"suffix" 是一个可选的字符串，用来确定按字母顺序排序时首先应用哪些 patch。
+包含名为 &quot;target[suffix][+patchtype].extension&quot; 的文件的目录。
+例如，&quot;kube-apiserver0+merge.yaml&quot; 或者 &quot;etcd.json&quot;。
+&quot;target&quot; 可以是 &quot;kube-apiserver&quot;、&quot;kube-controller-manager&quot;、
+&quot;kube-scheduler&quot;、&quot;etcd&quot;、&quot;kubeletconfiguration&quot;、&quot;corednsdeployment&quot;、&quot;kubeproxydaemonset&quot; 之一。
+&quot;patchtype&quot; 可以是 &quot;strategic&quot;、&quot;merge&quot; 
+或 &quot;json&quot; 之一，分别与 kubectl
+所支持的 patch 格式相匹配。默认的 &quot;patchtype&quot; 是 &quot;strategic&quot;。
+&quot;extension&quot; 必须是 &quot;json&quot; 或 &quot;yaml&quot;。
+&quot;suffix&quot; 是一个可选的字符串，用来确定按字母顺序排序时首先应用哪些 patch。
 </p>
 </td>
 </tr>

--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_etcd_local.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_etcd_local.md
@@ -1,11 +1,10 @@
 <!--
 ### Synopsis
+
+Generate the static Pod manifest file for a local, single-node local etcd instance
 -->
 ### 概要
 
-<!--
-Generate the static Pod manifest file for a local, single-node local etcd instance
--->
 为本地单节点 etcd 实例生成静态 Pod 清单文件。
 
 ```shell
@@ -57,7 +56,8 @@ kubeadm init phase etcd local --config config.yaml
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 The path where to save and store the certificates.
@@ -71,7 +71,8 @@ The path where to save and store the certificates.
 <td colspan="2">--config string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 Path to a kubeadm configuration file.
@@ -85,7 +86,8 @@ kubeadm 配置文件的路径。
 <td colspan="2">--dry-run</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 Don't apply any changes; just output what would be done.
@@ -99,7 +101,8 @@ Don't apply any changes; just output what would be done.
 <td colspan="2">-h, --help</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 help for local
@@ -118,7 +121,8 @@ local 操作的帮助命令。
 </td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 Choose a container registry to pull control plane images from
@@ -132,17 +136,20 @@ Choose a container registry to pull control plane images from
 <td colspan="2">--patches string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
-Path to a directory that contains files named &quot;target[suffix][+patchtype].extension&quot;. For example, &quot;kube-apiserver0+merge.yaml&quot; or just &quot;etcd.json&quot;. &quot;target&quot; can be one of &quot;kube-apiserver&quot;, &quot;kube-controller-manager&quot;, &quot;kube-scheduler&quot;, &quot;etcd&quot;, &quot;kubeletconfiguration&quot;. &quot;patchtype&quot; can be one of &quot;strategic&quot;, &quot;merge&quot; or &quot;json&quot; and they match the patch formats supported by kubectl. The default &quot;patchtype&quot; is &quot;strategic&quot;. &quot;extension&quot; must be either &quot;json&quot; or &quot;yaml&quot;. &quot;suffix&quot; is an optional string that can be used to determine which patches are applied first alpha-numerically.
+Path to a directory that contains files named &quot;target[suffix][+patchtype].extension&quot;. For example, &quot;kube-apiserver0+merge.yaml&quot; or just &quot;etcd.json&quot;. &quot;target&quot; can be one of &quot;kube-apiserver&quot;, &quot;kube-controller-manager&quot;, &quot;kube-scheduler&quot;, &quot;etcd&quot;, &quot;kubeletconfiguration&quot;, &quot;corednsdeployment&quot;, &quot;kubeproxydaemonset&quot;. &quot;patchtype&quot; can be one of &quot;strategic&quot;, &quot;merge&quot; or &quot;json&quot; and they match the patch formats supported by kubectl. The default &quot;patchtype&quot; is &quot;strategic&quot;. &quot;extension&quot; must be either &quot;json&quot; or &quot;yaml&quot;. &quot;suffix&quot; is an optional string that can be used to determine which patches are applied first alpha-numerically.
 -->
 包含名为 "target[suffix][+patchtype].extension" 的文件的目录的路径。
 例如，"kube-apiserver0+merge.yaml" 或是简单的 "etcd.json"。
-&quot;target&quot; 可以是 &quot;kube-apiserver&quot;、&quot;kube-controller-manager&quot;、&quot;kube-scheduler&quot;、
-&quot;etcd&quot; 、&quot;kubeletconfiguration&quot; 之一。
-&quot;patchtype&quot; 可以是 &quot;strategic&quot;、&quot;merge&quot; 或者 &quot;json&quot; 之一，
-并且它们与 kubectl 支持的补丁格式相匹配。
+&quot;target&quot; 可以是 &quot;kube-apiserver&quot;、
+&quot;kube-controller-manager&quot;、&quot;kube-scheduler&quot;、
+&quot;etcd&quot; 、&quot;kubeletconfiguration&quot;、
+&quot;corednsdeployment&quot;、&quot;kubeproxydaemonset&quot; 之一。
+&quot;patchtype&quot; 可以是 &quot;strategic&quot;、&quot;merge&quot; 
+或者 &quot;json&quot; 之一，并且它们与 kubectl 支持的补丁格式相匹配。
 默认的 &quot;patchtype&quot; 是 &quot;strategic&quot;。
 &quot;extension&quot; 必须是 &quot;json&quot; 或 &quot;yaml&quot;。
 &quot;suffix&quot; 是一个可选字符串，可用于确定首先按字母顺序应用哪些补丁。
@@ -169,7 +176,8 @@ Path to a directory that contains files named &quot;target[suffix][+patchtype].e
 <td colspan="2">--rootfs string</td>
 </tr>
 <tr>
-<td></td><td style="line-height: 130%; word-wrap: break-word;">
+<td></td>
+<td style="line-height: 130%; word-wrap: break-word;">
 <p>
 <!--
 [EXPERIMENTAL] The path to the 'real' host root filesystem.


### PR DESCRIPTION
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_config/kubeadm_config_images_list.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_control-plane_controller-manager.md
content/zh-cn/docs/reference/setup-tools/kubeadm/generated/kubeadm_init/kubeadm_init_phase_etcd_local.md