### PR TITLE
Update patch release schedule for 1.36.x, 1.35.x and 1.34.x

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -15,10 +15,16 @@ schedules:
 - endOfLifeDate: "2027-06-28"
   maintenanceModeStartDate: "2027-04-28"
   next:
-    cherryPickDeadline: "2026-07-10"
+    cherryPickDeadline: "2026-09-11"
+    release: 1.36.5
+    targetDate: "2026-09-15"
+  previousPatches:
+  - cherryPickDeadline: "2026-08-07"
+    release: 1.36.4
+    targetDate: "2026-08-11"
+  - cherryPickDeadline: "2026-07-10"
     release: 1.36.3
     targetDate: "2026-07-14"
-  previousPatches:
   - cherryPickDeadline: "2026-06-05"
     release: 1.36.2
     targetDate: "2026-06-09"
@@ -30,10 +36,16 @@ schedules:
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:
-    cherryPickDeadline: "2026-07-10"
+    cherryPickDeadline: "2026-09-11"
+    release: 1.35.9
+    targetDate: "2026-09-15"
+  previousPatches:
+  - cherryPickDeadline: "2026-08-07"
+    release: 1.35.8
+    targetDate: "2026-08-11"
+  - cherryPickDeadline: "2026-07-10"
     release: 1.35.7
     targetDate: "2026-07-14"
-  previousPatches:
   - cherryPickDeadline: "2026-06-05"
     release: 1.35.6
     targetDate: "2026-06-09"
@@ -61,10 +73,16 @@ schedules:
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
   next:
-    cherryPickDeadline: "2026-07-10"
+    cherryPickDeadline: "2026-09-11"
+    release: 1.34.12
+    targetDate: "2026-09-15"
+  previousPatches:
+  - cherryPickDeadline: "2026-08-07"
+    release: 1.34.11
+    targetDate: "2026-08-11"
+  - cherryPickDeadline: "2026-07-10"
     release: 1.34.10
     targetDate: "2026-07-14"
-  previousPatches:
   - cherryPickDeadline: "2026-06-05"
     release: 1.34.9
     targetDate: "2026-06-09"
@@ -149,9 +167,9 @@ schedules:
   release: "1.33"
   releaseDate: "2025-04-23"
 upcoming_releases:
-- cherryPickDeadline: "2026-07-10"
-  targetDate: "2026-07-14"
-- cherryPickDeadline: "2026-08-07"
-  targetDate: "2026-08-11"
 - cherryPickDeadline: "2026-09-11"
   targetDate: "2026-09-15"
+- cherryPickDeadline: "2026-10-09"
+  targetDate: "2026-10-13"
+- cherryPickDeadline: "2026-11-06"
+  targetDate: "2026-11-10"


### PR DESCRIPTION
### What this PR does / why we need it

Updates the patch release schedule in data/releases/schedule.yaml  using schedule-builder to have below changes.

1.36 → added 1.36.3, 1.36.4 to previousPatches, next is now 1.36.5
1.35 → added 1.35.8 to previousPatches, next is now 1.35.9
1.34 → added 1.34.11 to previousPatches, next is now 1.34.12

### Which issue(s) this PR fixes
Fixes 
https://github.com/kubernetes/website/issues/57187
https://github.com/kubernetes/website/issues/57267
https://github.com/kubernetes/website/issues/57266

### Special notes for your reviewer
None.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #