### PR TITLE
Update patch release schedule for 1.35.x

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -30,10 +30,16 @@ schedules:
 - endOfLifeDate: "2027-02-28"
   maintenanceModeStartDate: "2026-12-28"
   next:
-    cherryPickDeadline: "2026-07-10"
+    cherryPickDeadline: "2026-09-11"
+    release: 1.35.9
+    targetDate: "2026-09-15"
+  previousPatches:
+  - cherryPickDeadline: "2026-08-07"
+    release: 1.35.8
+    targetDate: "2026-08-11"
+  - cherryPickDeadline: "2026-07-10"
     release: 1.35.7
     targetDate: "2026-07-14"
-  previousPatches:
   - cherryPickDeadline: "2026-06-05"
     release: 1.35.6
     targetDate: "2026-06-09"


### PR DESCRIPTION
### What this PR does / why we need it
Updates the patch release schedule in data/releases/schedule.yaml to move v1.35.7 and v1.35.8 to previousPatches and set v1.35.9 as the next scheduled patch release for September 2026. This ensures the Kubernetes release pages accurately display v1.35.7, v1.35.8 and upcoming patch release schedules.

### Which issue(s) this PR fixes
https://github.com/kubernetes/website/issues/57266

Special notes for your reviewer
None.

Description
Issue
Closes: #
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #