### PR TITLE
Update patch release schedule for 1.34.x

### DIFF
--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -60,11 +60,13 @@ schedules:
   releaseDate: "2025-12-17"
 - endOfLifeDate: "2026-10-27"
   maintenanceModeStartDate: "2026-08-27"
-  next:
-    cherryPickDeadline: "2026-07-10"
+  previousPatches:
+  - cherryPickDeadline: "2026-08-07"
+    release: 1.34.11
+    targetDate: "2026-08-11"
+  - cherryPickDeadline: "2026-07-10"
     release: 1.34.10
     targetDate: "2026-07-14"
-  previousPatches:
   - cherryPickDeadline: "2026-06-05"
     release: 1.34.9
     targetDate: "2026-06-09"


### PR DESCRIPTION
### What this PR does / why we need it

Updates the patch release schedule in data/releases/schedule.yaml to move v1.34.10 and v1.34.11 to previousPatches. This ensures the Kubernetes release pages accurately display v1.34.10 and v1.34.11. The 1.34 branch enters maintenance mode on 2026-08-27 so no next patch release is scheduled.

### Which issue(s) this PR fixes
Fixes https://github.com/kubernetes/website/issues/57267
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #