### PR TITLE
Fix pt-br kubectl cheatsheet language switcher redirect

### DIFF
--- a/static/_redirects.base
+++ b/static/_redirects.base
@@ -43,6 +43,7 @@
 /docs/reference/using-api/api-overview/     /docs/reference/using-api/ 301
 /docs/reference/access-authn-authz/controlling-access/   /docs/concepts/security/controlling-access/ 301
 /docs/reference/kubectl/cheatsheet/   /docs/reference/kubectl/quick-reference/ 301
+/pt-br/docs/reference/kubectl/cheatsheet/   /pt-br/docs/reference/kubectl/quick-reference/ 301
 /kubectlguide /docs/reference/kubectl/quick-reference/ 302
 
 # Serve custom "not found" pages


### PR DESCRIPTION
### Description

The English kubectl cheat sheet page was renamed from `/docs/reference/kubectl/cheatsheet/` to `/docs/reference/kubectl/quick-reference/`, but the pt-br translation still lived at the old `cheatsheet` slug. Because the two locales used different slugs, the language switcher on the pt-br page couldn't find a matching English page and fell back to the homepage instead of the equivalent quick-reference page.

This PR aligns the pt-br page with the English slug instead of adding a global redirect entry:

- Delete the stale `content/pt-br/docs/reference/kubectl/cheatsheet.md` page.
- Add an `aliases` entry on `content/pt-br/docs/reference/kubectl/quick-reference.md` for the old `/pt-br/docs/reference/kubectl/cheatsheet/` URL, so existing links/bookmarks still resolve.
- `static/_redirects.base` is left unchanged (matches `main`), since the alias now handles the old URL and both locales share the same slug.

### Issue

Fixes #56512