### PR TITLE
Move kubectl upgrade to alongside kubeadm on Linux node upgrade

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -28,29 +28,38 @@ document.
 
 ## Upgrading worker nodes
 
-### Upgrade kubeadm
+### Upgrade kubeadm and kubectl
 
-Upgrade kubeadm:
+Upgrade kubeadm and kubectl:
+
+{{< note >}}
+kubectl must be within one minor version of kube-apiserver as per the
+[version skew policy](/releases/version-skew-policy/#kubectl).
+If you are upgrading the control plane across multiple minor versions before
+upgrading worker nodes, the node-local kubectl may fall outside the allowed
+skew. Upgrading kubectl alongside kubeadm here ensures it stays within
+the supported version range throughout the node upgrade process.
+{{< /note >}}
 
 {{< tabs name="k8s_install_kubeadm_worker_nodes" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
 ```shell
 # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-sudo apt-mark unhold kubeadm && \
-sudo apt-get update && sudo apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' && \
-sudo apt-mark hold kubeadm
+sudo apt-mark unhold kubeadm kubectl && \
+sudo apt-get update && sudo apt-get install -y kubeadm='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
+sudo apt-mark hold kubeadm kubectl
 ```
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
 For systems with DNF4 (Fedora < 41, RHEL/Centos < 10):
 ```shell
 # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-sudo dnf install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+sudo dnf install -y kubeadm-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
 ```
 For systems with DNF5:
 ```shell
 # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-sudo dnf install -y kubeadm-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
+sudo dnf install -y kubeadm-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -73,29 +82,29 @@ Prepare the node for maintenance by marking it unschedulable and evicting the wo
 kubectl drain <node-to-drain> --ignore-daemonsets
 ```
 
-### Upgrade kubelet and kubectl
+### Upgrade kubelet
 
-1. Upgrade the kubelet and kubectl:
+1. Upgrade the kubelet:
 
    {{< tabs name="k8s_kubelet_and_kubectl" >}}
    {{% tab name="Ubuntu, Debian or HypriotOS" %}}
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo apt-mark unhold kubelet kubectl && \
-   sudo apt-get update && sudo apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' kubectl='{{< skew currentVersion >}}.x-*' && \
-   sudo apt-mark hold kubelet kubectl
+   sudo apt-mark unhold kubelet && \
+   sudo apt-get update && sudo apt-get install -y kubelet='{{< skew currentVersion >}}.x-*' && \
+   sudo apt-mark hold kubelet
    ```
    {{% /tab %}}
    {{% tab name="CentOS, RHEL or Fedora" %}}
    For systems with DNF4 (Fedora < 41, RHEL/CentOS < 10):
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo dnf install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+   sudo dnf install -y kubelet-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
    ```
    For systems with DNF5:
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo dnf install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
+   sudo dnf install -y kubelet-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
    ```
    {{% /tab %}}
    {{< /tabs >}}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/website/issues/57157

The upgrading-linux-nodes page previously instructed users to upgrade kubectl together with kubelet, after draining the node. This is incorrect when the control plane has been upgraded across multiple minor versions before the worker nodes are upgraded.

Per the version skew policy, kubectl must be within +/-1 minor version of kube-apiserver. If the control plane is upgraded by 2 or 3 minor versions while worker nodes are not yet upgraded, the node-local kubectl can fall outside the allowed skew before kubelet is upgraded.

Move kubectl upgrade to the first step alongside kubeadm, and add a note explaining the version skew constraint. Update the last step from 'Upgrade kubelet and kubectl' to 'Upgrade kubelet' only.

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #