### PR TITLE
Update footer with LF Projects trademarks disclaimer

### DIFF
--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -493,7 +493,7 @@ other = "Explore the community"
 other = "Contribute"
 
 [main_copyright_notice]
-other = """The Linux Foundation &reg;. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a>"""
+other = """Copyright &copy; Kubernetes a Series of LF Projects, LLC. For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" class="light-text">https://lfprojects.org/policies/</a>"""
 
 [main_documentation_license]
 other = """The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a>"""


### PR DESCRIPTION
### Description

Updated the Kubernetes website footer to comply with the new LF Projects Series LLC trademark disclaimer requirements. This PR targets only English localization. Also no AI was used for this PR. 

Changes made:
- Added the “A Series of LF Projects, LLC” wording to the footer
- Added the LF Projects policies link: https://lfprojects.org/policies/


### Issue

Closes: #55578