### PR TITLE
Enhance feature state messages with Kubernetes context

### DIFF
--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -97,10 +97,10 @@ and then a paragraph, and sometimes you just get the paragraph.
               {{- else -}}
             <div class="feature-state-locked feature-state-removed">
               {{- if isset . "toVersion" -}}
-              <p><em>{{ T "feature_gate_removed_before_ga_final_version_clear" (dict "featureGateName" $feature_gate_name "fromVersion" .fromVersion "toVersion" .toVersion ) | safeHTML }}</em></p>
+              <p><em>{{ T "feature_gate_removed_before_ga_final_version_clear" (dict "featureGateName" $feature_gate_name "fromVersion" .fromVersion "toVersion" .toVersion "kubernetes" (T "feature_state_kubernetes_label")) | safeHTML }}</em></p>
               {{- else -}}
               {{- warnf "Removed feature gate %s doesn't seem to have a toVersion set for its final stage" $feature_gate_name -}}
-              <p><em>{{ T "feature_gate_removed_before_ga_final_version_unclear" (dict "featureGateName" $feature_gate_name "fromVersion" .fromVersion ) | safeHTML }}</em></p>
+              <p><em>{{ T "feature_gate_removed_before_ga_final_version_unclear" (dict "featureGateName" $feature_gate_name "fromVersion" .fromVersion "kubernetes" (T "feature_state_kubernetes_label")) | safeHTML }}</em></p>
               {{- end -}}
             </div>
               {{- end -}}
@@ -141,7 +141,7 @@ and then a paragraph, and sometimes you just get the paragraph.
                {{ end -}}
               </span>
             </div>
-            
+
             {{/* Additional details section (expandable using HTML details element) */}}
             <div class="feature-{{ .stage }}{{ if $stableInLatestRelease }} stable-in-latest-release{{end}}">
               {{/* For stable features */}}
@@ -149,10 +149,10 @@ and then a paragraph, and sometimes you just get the paragraph.
               <details>
               <summary>{{ T "feature_gate_more_details" }}</summary>
               <p>
-              {{- if $locked -}}            
+              {{- if $locked -}}
                 {{ T "feature_gate_stable_locked" (dict "featureGateName" $feature_gate_name "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "kubernetes" (T "feature_state_kubernetes_label") "stableVersion" .fromVersion) | safeHTML }}</p>
               {{- else -}}
-                <em>{{ T "feature_gate_stable_graduated" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion ) | safeHTML }}</em>
+                <em>{{ T "feature_gate_stable_graduated" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion "kubernetes" (T "feature_state_kubernetes_label")) | safeHTML }}</em>
                 {{/* Special message for feature that are both stable and disabled by default */}}
                 {{- if not .defaultValue -}}
                 <em>{{ T "feature_gate_stable_graduated_disabled" }}</em>
@@ -167,7 +167,7 @@ and then a paragraph, and sometimes you just get the paragraph.
                 <details>
                 <summary>{{ T "feature_gate_more_details" }}</summary>
                 {{ T "feature_gate_more_information_how_to_enable" (dict "feature_gate_name" $feature_gate_name ) | safeHTML }}
-         
+
                 </details>
                 {{ end -}}
               {{- end -}}

--- a/layouts/shortcodes/feature-state.html
+++ b/layouts/shortcodes/feature-state.html
@@ -150,7 +150,7 @@ and then a paragraph, and sometimes you just get the paragraph.
               <summary>{{ T "feature_gate_more_details" }}</summary>
               <p>
               {{- if $locked -}}
-                {{ T "feature_gate_stable_locked" (dict "featureGateName" $feature_gate_name "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "kubernetes" (T "feature_state_kubernetes_label") "stableVersion" .fromVersion) | safeHTML }}</p>
+                {{ T "feature_gate_stable_locked" (dict "featureGateName" $feature_gate_name "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "kubernetes" (T "feature_state_kubernetes_label") "stableVersion" .fromVersion) | safeHTML }}
               {{- else -}}
                 <em>{{ T "feature_gate_stable_graduated" (dict "firstReleaseWithThisFeature" $firstReleaseWithThisFeature "stableVersion" .fromVersion "kubernetes" (T "feature_state_kubernetes_label")) | safeHTML }}</em>
                 {{/* Special message for feature that are both stable and disabled by default */}}


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description

These minor cosmetic changes introduce a missing variable to the status messages for the feature state.  The updated feature state messages now include Kubernetes context for improved clarity and consistency in messaging.

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #