### PR TITLE
Added Note - Upgrade to Bump Multiple Minor Versions

### DIFF
--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -6,7 +6,7 @@ weight: 40
 
 <!-- overview -->
 
-This page explains how to upgrade a Linux Worker Nodes created with kubeadm.
+This page explains how to upgrade a Linux Worker Nodes created with `kubeadm`.
 
 ## {{% heading "prerequisites" %}}
 
@@ -15,22 +15,25 @@ This page explains how to upgrade a Linux Worker Nodes created with kubeadm.
 cluster](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade). You will want to
 upgrade the control plane nodes before upgrading your Linux Worker nodes.
 
+>[!NOTE]
+>There are additional constraints if you are upgrading the control-plane to bump multiple minor versions. Doing so before upgrading the worker nodes results in `kubectl` being more than +/- 1 version from kube-apiserver, which is not allowed by the version skew policy. To prevent this issue, avoid using the node-local `kubectl` before the node upgrade is done.
+
 <!-- steps -->
 
 ## Changing the package repository
 
 If you're using the community-owned package repositories (`pkgs.k8s.io`), you need to 
 enable the package repository for the desired Kubernetes minor release. This is explained in
-[Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
+[Changing the Kubernetes package repository](/docs/tasks/administer-cluster//change-package-repository/)
 document.
 
 {{% legacy-repos-deprecation %}}
 
 ## Upgrading worker nodes
 
-### Upgrade kubeadm
+### Upgrade 
 
-Upgrade kubeadm:
+Upgrade `kubeadm`:
 
 {{< tabs name="k8s_install_kubeadm_worker_nodes" >}}
 {{% tab name="Ubuntu, Debian or HypriotOS" %}}
@@ -57,7 +60,7 @@ sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --setopt=disable_e
 
 ### Call "kubeadm upgrade"
 
-For worker nodes this upgrades the local kubelet configuration:
+For worker nodes this upgrades the local `kubelet` configuration:
 
 ```shell
 sudo kubeadm upgrade node
@@ -75,7 +78,7 @@ kubectl drain <node-to-drain> --ignore-daemonsets
 
 ### Upgrade kubelet and kubectl
 
-1. Upgrade the kubelet and kubectl:
+1. Upgrade the `kubelet` and `kubectl`:
 
    {{< tabs name="k8s_kubelet_and_kubectl" >}}
    {{% tab name="Ubuntu, Debian or HypriotOS" %}}
@@ -100,7 +103,7 @@ kubectl drain <node-to-drain> --ignore-daemonsets
    {{% /tab %}}
    {{< /tabs >}}
 
-1. Restart the kubelet:
+1. Restart the `kubelet`:
 
    ```shell
    sudo systemctl daemon-reload

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -15,8 +15,11 @@ This page explains how to upgrade a Linux Worker Nodes created with `kubeadm`.
 cluster](/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade). You will want to
 upgrade the control plane nodes before upgrading your Linux Worker nodes.
 
->[!NOTE]
->There are additional constraints if you are upgrading the control-plane to bump multiple minor versions. Doing so before upgrading the worker nodes results in `kubectl` being more than +/- 1 version from kube-apiserver, which is not allowed by the version skew policy. To prevent this issue, avoid using the node-local `kubectl` before the node upgrade is done.
+{{< note >}}
+There are additional constraints if you are upgrading the control-plane to bump multiple minor versions.
+Doing so before upgrading the worker nodes results in `kubectl` being more than +/- 1 version from kube-apiserver, which is not allowed by the [version skew policy](/releases/version-skew-policy/).
+To prevent this issue, avoid using the node-local `kubectl` before the node upgrade is done.
+{{< /note >}}
 
 <!-- steps -->
 

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -27,7 +27,7 @@ To prevent this issue, avoid using the node-local `kubectl` before the node upgr
 
 If you're using the community-owned package repositories (`pkgs.k8s.io`), you need to 
 enable the package repository for the desired Kubernetes minor release. This is explained in
-[Changing the Kubernetes package repository](/docs/tasks/administer-cluster//change-package-repository/)
+[Changing the Kubernetes package repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/)
 document.
 
 {{% legacy-repos-deprecation %}}


### PR DESCRIPTION
### Summary

This topic begins by suggesting to upgrade the control-plane before upgrading worker nodes. However, there are additional constraints if upgrading multiple version. I've added a note to describe these.

Also, added code style to unformatted instances of kubectl, kubelet, and Kubeadm

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #57157 