### PR TITLE
[pt-br] Localize concepts/cluster-administration/compatibility-version.md

### DIFF
--- a/content/pt-br/docs/concepts/cluster-administration/compatibility-version.md
+++ b/content/pt-br/docs/concepts/cluster-administration/compatibility-version.md
@@ -1,0 +1,23 @@
+---
+title: Versão de Compatibilidade para Componentes do Control Plane do Kubernetes
+content_type: concept
+weight: 70
+---
+
+<!-- overview -->
+
+Desde o release v1.32, introduzimos opções configuráveis de compatibilidade e emulação de versão nos componentes do control plane do Kubernetes para tornar os upgrades mais seguros, oferecendo mais controle e aumentando a granularidade das etapas disponíveis para os administradores de cluster.
+
+<!-- body -->
+
+## Versão Emulada
+
+A opção de emulação é definida pela flag `--emulated-version` dos componentes do control plane. Ela permite que o componente emule o comportamento (APIs, funcionalidades, ...) de uma versão anterior do Kubernetes.
+
+Quando utilizada, as capacidades disponíveis corresponderão à versão emulada:
+* Qualquer capacidade presente na versão do binário que tenha sido introduzida após a versão de emulação estará indisponível.
+* Qualquer capacidade removida após a versão de emulação estará disponível.
+
+Isso permite que um binário de um release específico do Kubernetes emule o comportamento de uma versão anterior com fidelidade suficiente para que a interoperabilidade com outros componentes do sistema possa ser definida em termos da versão emulada.
+
+O `--emulated-version` deve ser <= `binaryVersion`. Consulte a mensagem de ajuda da flag `--emulated-version` para conhecer a faixa de versões emuladas suportadas.


### PR DESCRIPTION
### Description

This PR localizes `content/en/docs/concepts/cluster-administration/compatibility-version.md` into Brazilian Portuguese.

- Adds `content/pt-br/docs/concepts/cluster-administration/compatibility-version.md`
- Translated from the English page at `main` (commit 8ab33b886d)
- Terminology follows existing pt-br conventions (e.g., "control plane" and "release" are kept in English, as used across current pt-br content)

### Issue

Closes: #57119