### PR TITLE
Fix incorrect field name in Windows user guide

### DIFF
--- a/content/en/docs/concepts/windows/user-guide.md
+++ b/content/en/docs/concepts/windows/user-guide.md
@@ -170,7 +170,7 @@ to `windows`.
 {{< note >}}
 If you are running a version of Kubernetes older than 1.24, you may need to enable
 the `IdentifyPodOS` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-to be able to set a value for `.spec.pod.os`.
+to be able to set a value for `.spec.os.name`.
 {{< /note >}}
 
 The scheduler does not use the value of `.spec.os.name` when assigning Pods to nodes. You should


### PR DESCRIPTION
### Description

The `IdentifyPodOS` feature gate note referred to `.spec.pod.os`, which is not a valid field. The correct field is `.spec.os.name`, which is what the rest of the same page already uses. This updates the note to match.

### Issue

Closes: #57150