### PR TITLE
Fix "allows to" grammar in concept and task docs

### DIFF
--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -66,7 +66,7 @@ on GitHub.
 
 ## Introduction
 
-User namespaces is a Linux feature that allows to map users in the container to
+User namespaces is a Linux feature that allows you to map users in the container to
 different users in the host. Furthermore, the capabilities granted to a pod in
 a user namespace are valid only in the namespace and void outside of it.
 

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -262,7 +262,7 @@ Error from server: Get https://10.19.0.41:10250/containerLogs/default/mysql-ddc6
 
   Use `ip addr show` to check for this scenario instead of `ifconfig` because `ifconfig` will
   not display the offending alias IP address. Alternatively an API endpoint specific to
-  DigitalOcean allows to query for the anchor IP from the droplet:
+  DigitalOcean allows you to query for the anchor IP from the droplet:
 
   ```sh
   curl http://169.254.169.254/metadata/v1/interfaces/public/0/anchor_ipv4/address

--- a/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
+++ b/content/en/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions.md
@@ -1392,7 +1392,7 @@ Avoid nested lists and maps if possible where validation rules are used.
 To use defaulting, your CustomResourceDefinition must use API version `apiextensions.k8s.io/v1`.
 {{< /note >}}
 
-Defaulting allows to specify default values in the [OpenAPI v3 validation schema](#validation):
+Defaulting allows you to specify default values in the [OpenAPI v3 validation schema](#validation):
 
 ```yaml
 apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
### Description

"allows to <verb>" is not grammatical in English. The correct form is "allows you to <verb>". This fixes three hand-written pages where the phrasing appears:

- Custom Resource Definitions ("Defaulting allows you to specify default values")
- User Namespaces ("a Linux feature that allows you to map users")
- kubeadm troubleshooting ("DigitalOcean allows you to query for the anchor IP")

Generated reference pages that contain the same phrasing were left alone, since those are produced from source and should be fixed upstream.

### Issue

None; small grammar correction found while reading the docs.