### PR TITLE
Mark 1.33 as EOL

### DIFF
--- a/data/releases/eol.yaml
+++ b/data/releases/eol.yaml
@@ -4,6 +4,9 @@
 # schedule-builder -uc data/releases/schedule.yaml -e data/releases/eol.yaml
 ---
 branches:
+- endOfLifeDate: "2026-06-28"
+  finalPatchRelease: 1.33.13
+  release: "1.33"
 - endOfLifeDate: "2026-02-28"
   finalPatchRelease: 1.32.13
   release: "1.32"

--- a/data/releases/schedule.yaml
+++ b/data/releases/schedule.yaml
@@ -117,55 +117,6 @@ schedules:
     targetDate: "2025-09-09"
   release: "1.34"
   releaseDate: "2025-08-27"
-- endOfLifeDate: "2026-06-28"
-  maintenanceModeStartDate: "2026-04-28"
-  previousPatches:
-  - cherryPickDeadline: "2026-06-05"
-    release: 1.33.13
-    targetDate: "2026-06-09"
-  - cherryPickDeadline: "2026-05-08"
-    release: 1.33.12
-    targetDate: "2026-05-12"
-  - cherryPickDeadline: "2026-04-10"
-    release: 1.33.11
-    targetDate: "2026-04-14"
-  - cherryPickDeadline: "2026-03-13"
-    release: 1.33.10
-    targetDate: "2026-03-19"
-  - cherryPickDeadline: "2026-02-26"
-    note: Out of band patch release to pick up a new version of Go to [address several
-      Go CVEs](https://groups.google.com/g/golang-dev/c/ytMTMwK7QBk/m/hpcstrxADwAJ).
-      No other changes.
-    release: 1.33.9
-    targetDate: "2026-02-26"
-  - cherryPickDeadline: "2026-02-06"
-    note: January 2026 patches consolidated with February
-    release: 1.33.8
-    targetDate: "2026-02-10"
-  - cherryPickDeadline: "2025-12-05"
-    release: 1.33.7
-    targetDate: "2025-12-09"
-  - cherryPickDeadline: "2025-11-07"
-    note: October 2025 patches consolidated with November
-    release: 1.33.6
-    targetDate: "2025-11-11"
-  - cherryPickDeadline: "2025-09-05"
-    release: 1.33.5
-    targetDate: "2025-09-09"
-  - cherryPickDeadline: "2025-08-08"
-    release: 1.33.4
-    targetDate: "2025-08-12"
-  - cherryPickDeadline: "2025-07-11"
-    release: 1.33.3
-    targetDate: "2025-07-15"
-  - cherryPickDeadline: "2025-06-06"
-    release: 1.33.2
-    targetDate: "2025-06-17"
-  - cherryPickDeadline: "2025-05-09"
-    release: 1.33.1
-    targetDate: "2025-05-15"
-  release: "1.33"
-  releaseDate: "2025-04-23"
 upcoming_releases:
 - cherryPickDeadline: "2026-09-11"
   targetDate: "2026-09-15"


### PR DESCRIPTION
### Description

The 1.33 release has not been marked as EOL due to a bug in `schedule-builder` that got fixed with https://github.com/kubernetes/release/pull/4510

This PR re-runs `schedule-builder` to ensure that 1.33 is removed from the scheduled and added to the EOL list.

### Issue

None

cc @kubernetes/release-engineering 