### PR TITLE
docs: expand Gateway API guidance on kubernetes.io

### DIFF
--- a/content/en/docs/concepts/services-networking/_index.md
+++ b/content/en/docs/concepts/services-networking/_index.md
@@ -48,6 +48,9 @@ The Kubernetes network model is built out of several pieces:
 * The [Gateway](/docs/concepts/services-networking/gateway/) API
   (or its predecessor, [Ingress](/docs/concepts/services-networking/ingress/))
   allows you to make Services accessible to clients that are outside the cluster.
+  Gateway API is the recommended successor to the Ingress API: it supports the
+  same core use cases and adds role-oriented configuration, advanced traffic
+  routing, and other features that Ingress only provides through annotations.
 
   * A simpler, but less-configurable, mechanism for cluster
     ingress is available via the Service API's

--- a/content/en/docs/concepts/services-networking/gateway.md
+++ b/content/en/docs/concepts/services-networking/gateway.md
@@ -262,6 +262,10 @@ Gateway API is the successor to the [Ingress](/docs/concepts/services-networking
 However, it does not include the Ingress kind. As a result, a one-time conversion from your existing
 Ingress resources to Gateway API resources is necessary.
 
+The [ingress2gateway](https://github.com/kubernetes-sigs/ingress2gateway) tool can help translate
+Ingress manifests into Gateway API resources. Not every Ingress controller or feature is supported
+yet, so review its output and the tool documentation before applying changes to production clusters.
+
 Refer to the [ingress migration](https://gateway-api.sigs.k8s.io/guides/getting-started/migrating-from-ingress)
 guide for details on migrating Ingress resources to Gateway API resources.
 
@@ -270,10 +274,14 @@ guide for details on migrating Ingress resources to Gateway API resources.
 Instead of Gateway API resources being natively implemented by Kubernetes, the specifications
 are defined as [Custom Resources](/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 supported by a wide range of [implementations](https://gateway-api.sigs.k8s.io/implementations/).
+Like Ingress, Gateway API requires a compatible controller implementation in your cluster.
 [Install](https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api) the Gateway API CRDs or
 follow the installation instructions of your selected implementation. After installing an
 implementation, use the [Getting Started](https://gateway-api.sigs.k8s.io/guides/) guide to help
 you quickly start working with Gateway API.
+
+To inspect and manage Gateway API resources from the command line, see the
+[gwctl](https://gateway-api.sigs.k8s.io/guides/gwctl/) documentation.
 
 {{< note >}}
 Make sure to review the documentation of your selected implementation to understand any caveats.


### PR DESCRIPTION
Fixes kubernetes-sigs/gateway-api#3268

Adds Gateway API context on the services-networking overview page, documents ingress2gateway for Ingress migration (with supported-feature caveats), notes that a controller implementation is required, and links to gwctl docs instead of duplicating content.

## Test plan
- [x] Docs-only change; reviewed updated markdown for link targets and wording consistency