### PR TITLE
Show video hyperlink on narrow viewports

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -466,12 +466,6 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
   }
 }
 
-@media (max-width: 10cm) {
-  .td-home section#video {
-    display: none;
-  }
-}
-
 @media only screen and (max-width: 640px) and (orientation: portrait) {
   .td-home section#video {
     display: none;

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -466,9 +466,22 @@ footer .row > .order-3 { flex: 0 0 16.6667%; max-width: 16.6667%; }
   }
 }
 
-@media only screen and (max-width: 640px) and (orientation: portrait) {
+.video-mobile-link {
+  display: none;
+}
+
+@media (max-width: 10cm), only screen and (max-width: 640px) and (orientation: portrait) {
   .td-home section#video {
     display: none;
+  }
+
+  .video-mobile-link {
+    display: block;
+    text-align: center;
+    background: #13110f; // match video section background
+    color: #fff;
+    font-weight: 700;
+    padding: 1rem;
   }
 }
 

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -50,6 +50,9 @@ To download Kubernetes, visit the [download](/releases/download/) section.
     <button id="closeButton"></button>
 </div>
 {{< /blocks/section >}}
+<a class="video-mobile-link" href="https://www.youtube.com/watch?v=XNZvGHlpJ_4" aria-label="Watch The Absolute Beginner's Guide To Cloud Native">
+  Watch The Absolute Beginner's Guide To Cloud Native
+</a>
 {{< blocks/section id="upcoming-events" >}}
 <h2>Attend upcoming KubeCon + CloudNativeCon events</h2>
 <!--


### PR DESCRIPTION
### Description

The video section on the landing page is hidden on narrow (portrait phone-style) viewports via a `@media (max-width: 10cm)` rule, leaving no way to reach the video from those viewports. As discussed in #56577, this PR follows the approach agreed there: **keep the video section hidden on small viewports, and show a hyperlink to the video instead**.

- The video section keeps its existing `display: none` behavior on very narrow viewports (no layout change on desktop/tablet)
- A new, unobtrusive link (`video-mobile-link`), showing the video title and pointing to the YouTube watch page, is displayed only under the same `@media (max-width: 10cm)` breakpoint
- On wider viewports the link is hidden and nothing else changes

Scoping this to a small link keeps the change compatible with the landing page redesign planned in #55774; a full redesign of the video section should happen there.

### Test

- Desktop / tablet / landscape: video section renders as before; the new link is not visible
- Narrow portrait viewport: video section is hidden as before; the new link appears centered on a dark background matching the video section

### Issue

Closes: #56577