### PR TITLE
Add more information about offline events to the Community page

### DIFF
--- a/content/en/community/_index.html
+++ b/content/en/community/_index.html
@@ -182,10 +182,35 @@ menu:
 </div>
 
 <div class="community-section" id="meetups">
-  <h2>Global community</h2>
+  <h2>Conferences and meetups</h2>
   <p>
-    With over 150 meetups in the world and growing, go find your local kube people. If one isn't near, take charge and create your own.
+    Offline events are one of the strongest aspects of the worldwide Kubernetes community:
+    a great way to see the community in action, make connections, and get involved.
+    Visit, speak to share your stories, join the organizers (many of these events are
+    run by the community), or watch recordings from past events:
   </p>
+  <ul>
+    <li>
+      <a href="https://www.cncf.io/kubecon-cloudnativecon-events/">KubeCon&nbsp;+&nbsp;CloudNativeCon</a>,
+      the flagship Cloud Native conference, hosted by the CNCF. Recordings of past events
+      are available on the
+      <a href="https://www.youtube.com/@CNCF">CNCF YouTube channel</a>.
+    </li>
+    <li>
+      <a href="https://www.cncf.io/kcds/">Kubernetes Community Days</a>, community-organized
+      events supported by the CNCF
+      (<a href="https://github.com/cncf/kubernetes-community-days/">GitHub</a>).
+    </li>
+    <li>
+      <a href="https://ocgroups.dev/cncf">Cloud Native Community Groups</a>, local
+      community groups supported by the CNCF
+      (<a href="https://github.com/cncf/communitygroups/">GitHub</a>).
+    </li>
+    <li>
+      <a href="https://www.meetup.com/topics/kubernetes/">Kubernetes meetups</a> on
+      Meetup, with over 150 groups worldwide and growing.
+    </li>
+  </ul>
   <a href="https://www.meetup.com/topics/kubernetes/" class="community-cta-button">
     <span class="community-cta">Find a meetup</span>
   </a>


### PR DESCRIPTION
### Description

Expands the Community page's former "Global community" section into a "Conferences and meetups" section that gives offline events proper emphasis:

- Renames the section to "Conferences and meetups" (as proposed in the issue)
- Links the major offline event formats: KubeCon + CloudNativeCon (CNCF), Kubernetes Community Days (community-organized, CNCF-supported, with GitHub repo), Cloud Native Community Groups (with GitHub repo), and Kubernetes meetups on Meetup
- Mentions ways to get involved beyond attending: speaking, joining organizers of community-run events, and watching recordings of past events (CNCF YouTube)
- Keeps the existing "Find a meetup" CTA button

Per the issue discussion, this is the initial, links-only implementation; listing upcoming events on our side (needing a machine-readable data source) is left for follow-up work.

### Issue

Closes: #57089