### PR TITLE
Document MutatingAdmissionPolicy on the general Admission Control page

### DIFF
--- a/content/en/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/admission-controllers.md
@@ -47,18 +47,19 @@ administrator.
 
 ### Admission control extension points
 
-Within the full [list](#what-does-each-admission-controller-do), there are three
+Within the full [list](#what-does-each-admission-controller-do), there are four
 special controllers:
 [MutatingAdmissionWebhook](#mutatingadmissionwebhook),
+[MutatingAdmissionPolicy](#mutatingadmissionpolicy),
 [ValidatingAdmissionWebhook](#validatingadmissionwebhook), and
 [ValidatingAdmissionPolicy](#validatingadmissionpolicy).
 The two webhook controllers execute the mutating and validating (respectively)
 [admission control webhooks](/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks)
 which are configured in the API. ValidatingAdmissionPolicy provides a way to embed
 declarative validation code within the API, without relying on any external HTTP
-callouts.
+callouts; MutatingAdmissionPolicy does the same for declarative mutations.
 
-You can use these three admission controllers to customize cluster behavior at
+You can use these four admission controllers to customize cluster behavior at
 admission time.
 
 ### Admission control phases
@@ -127,7 +128,7 @@ kube-apiserver -h | grep enable-admission-plugins
 In Kubernetes {{< skew currentVersion >}}, the default ones are:
 
 ```shell
-CertificateApproval, CertificateSigning, CertificateSubjectRestriction, DefaultIngressClass, DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, PodSecurity, Priority, ResourceQuota, RuntimeClass, ServiceAccount, StorageObjectInUseProtection, TaintNodesByCondition, ValidatingAdmissionPolicy, ValidatingAdmissionWebhook
+CertificateApproval, CertificateSigning, CertificateSubjectRestriction, DefaultIngressClass, DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionPolicy, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, PodSecurity, Priority, ResourceQuota, RuntimeClass, ServiceAccount, StorageObjectInUseProtection, TaintNodesByCondition, ValidatingAdmissionPolicy, ValidatingAdmissionWebhook
 ```
 
 ## What does each admission controller do?
@@ -515,6 +516,18 @@ Pods in the `default` namespace.
 See the [LimitRange API reference](/docs/reference/kubernetes-api/policy-resources/limit-range-v1/)
 and the [example of LimitRange](/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
 for more details.
+
+### MutatingAdmissionPolicy {#mutatingadmissionpolicy}
+
+**Type**: Mutating.
+
+[This admission controller](/docs/reference/access-authn-authz/mutating-admission-policy/) implements
+declarative, in-process mutations for incoming matched requests, defined as CEL expressions that
+modify matched objects using apply configurations or JSON patches.
+It provides a lower-latency alternative to
+[MutatingAdmissionWebhook](#mutatingadmissionwebhook), without relying on any external HTTP
+callouts.
+If any of the MutatingAdmissionPolicies fails, the request fails.
 
 ### MutatingAdmissionWebhook {#mutatingadmissionwebhook}
 


### PR DESCRIPTION
### Description

Documents the `MutatingAdmissionPolicy` admission controller on the general admission controllers reference page, aligning it with how `ValidatingAdmissionPolicy` is already documented:

- Adds `MutatingAdmissionPolicy` to the "Admission control extension points" section (now four special controllers) with a short explanation that it provides in-process declarative mutations, mirroring what `ValidatingAdmissionPolicy` does for validation
- Adds it to the list of default-enabled admission controllers (GA in Kubernetes 1.36)
- Adds a `### MutatingAdmissionPolicy` section (alphabetical position, before `MutatingAdmissionWebhook`) describing its behavior: CEL-based in-process mutations via apply configurations or JSON patches, a lower-latency alternative to mutating webhooks, with a link to the existing dedicated page `/docs/reference/access-authn-authz/mutating-admission-policy/`

### Issue

Closes: #56805