### PR TITLE
Restore authentication API reference pages

### DIFF
--- a/content/en/docs/reference/kubernetes-api/authentication-resources/_index.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/_index.md
@@ -1,0 +1,17 @@
+---
+content_type: "api_reference"
+title: "Authentication Resources"
+weight: 65
+auto_generated: true
+---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/self-subject-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/self-subject-review-v1.md
@@ -1,0 +1,114 @@
+---
+api_metadata:
+  apiVersion: "authentication.k8s.io/v1"
+  import: "k8s.io/api/authentication/v1"
+  kind: "SelfSubjectReview"
+content_type: "api_reference"
+description: "SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request."
+title: "SelfSubjectReview"
+weight: 6
+auto_generated: true
+---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+`apiVersion: authentication.k8s.io/v1`
+
+`import "k8s.io/api/authentication/v1"`
+
+## SelfSubjectReview {#SelfSubjectReview}
+
+SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request. When using impersonation, users will receive the user info of the user being impersonated.  If impersonation or request header authentication is used, any extra keys will have their case ignored and returned as lowercase.
+
+<hr>
+
+- **apiVersion**: authentication.k8s.io/v1
+
+- **kind**: SelfSubjectReview
+
+- **metadata** (<a href="{{< ref "../definitions/object-meta-v1-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  metadata is standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **status** (<a href="{{< ref "../authentication-resources/self-subject-review-v1#SelfSubjectReviewStatus" >}}">SelfSubjectReviewStatus</a>)
+
+  status is filled in by the server with the user attributes.
+
+## SelfSubjectReviewStatus {#SelfSubjectReviewStatus}
+
+SelfSubjectReviewStatus is filled by the kube-apiserver and sent back to a user.
+
+<hr>
+
+- **userInfo** (UserInfo)
+
+  userInfo is a set of attributes belonging to the user making this request.
+
+  <a name="UserInfo"></a>
+  *UserInfo holds the information about the user needed to implement the user.Info interface.*
+
+  - **userInfo.extra** (map[string][]string)
+
+    extra is any additional information provided by the authenticator.
+
+  - **userInfo.groups** ([]string)
+
+    *Atomic: will be replaced during a merge*
+    
+    groups is the names of groups this user is a part of.
+
+  - **userInfo.uid** (string)
+
+    uid is a unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.
+
+  - **userInfo.username** (string)
+
+    username is the name that uniquely identifies this user among all active users.
+
+## Operations {#Operations}
+
+<hr>
+
+### `create` create a SelfSubjectReview
+
+#### HTTP Request
+
+POST /apis/authentication.k8s.io/v1/selfsubjectreviews
+
+#### Parameters
+
+- **body**: <a href="{{< ref "../authentication-resources/self-subject-review-v1#SelfSubjectReview" >}}">SelfSubjectReview</a>, required
+
+  
+
+- **dryRun** (*in query*): string
+
+
+- **fieldManager** (*in query*): string
+
+
+- **fieldValidation** (*in query*): string
+
+
+- **pretty** (*in query*): string
+
+
+#### Response
+
+200 (<a href="{{< ref "../authentication-resources/self-subject-review-v1#SelfSubjectReview" >}}">SelfSubjectReview</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/self-subject-review-v1#SelfSubjectReview" >}}">SelfSubjectReview</a>): Created
+
+202 (<a href="{{< ref "../authentication-resources/self-subject-review-v1#SelfSubjectReview" >}}">SelfSubjectReview</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/token-request-v1.md
@@ -1,0 +1,150 @@
+---
+api_metadata:
+  apiVersion: "authentication.k8s.io/v1"
+  import: "k8s.io/api/authentication/v1"
+  kind: "TokenRequest"
+content_type: "api_reference"
+description: "TokenRequest requests a token for a given service account."
+title: "TokenRequest"
+weight: 2
+auto_generated: true
+---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+`apiVersion: authentication.k8s.io/v1`
+
+`import "k8s.io/api/authentication/v1"`
+
+## TokenRequest {#TokenRequest}
+
+TokenRequest requests a token for a given service account.
+
+<hr>
+
+- **apiVersion**: authentication.k8s.io/v1
+
+- **kind**: TokenRequest
+
+- **metadata** (<a href="{{< ref "../definitions/object-meta-v1-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequestSpec" >}}">TokenRequestSpec</a>)
+
+  spec holds information about the request being evaluated
+
+- **status** (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequestStatus" >}}">TokenRequestStatus</a>)
+
+  status is filled in by the server and indicates whether the token can be authenticated.
+
+## TokenRequestSpec {#TokenRequestSpec}
+
+TokenRequestSpec contains client provided parameters of a token request.
+
+<hr>
+
+- **audiences** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
+  audiences are the intendend audiences of the token. A recipient of a token must identify themself with an identifier in the list of audiences of the token, and otherwise should reject the token. A token issued for multiple audiences may be used to authenticate against any of the audiences listed but implies a high degree of trust between the target audiences.
+
+- **boundObjectRef** (BoundObjectReference)
+
+  boundObjectRef is a reference to an object that the token will be bound to. The token will only be valid for as long as the bound object exists. NOTE: The API server's TokenReview endpoint will validate the BoundObjectRef, but other audiences may not. Keep ExpirationSeconds small if you want prompt revocation.
+
+  <a name="BoundObjectReference"></a>
+  *BoundObjectReference is a reference to an object that a token is bound to.*
+
+  - **boundObjectRef.apiVersion** (string)
+
+    apiVersion is API version of the referent.
+
+  - **boundObjectRef.kind** (string)
+
+    kind of the referent. Valid kinds are 'Pod' and 'Secret'.
+
+  - **boundObjectRef.name** (string)
+
+    name of the referent.
+
+  - **boundObjectRef.uid** (string)
+
+    uid of the referent.
+
+- **expirationSeconds** (int64)
+
+  expirationSeconds is the requested duration of validity of the request. The token issuer may return a token with a different validity duration so a client needs to check the 'expiration' field in a response.
+
+## TokenRequestStatus {#TokenRequestStatus}
+
+TokenRequestStatus is the result of a token request.
+
+<hr>
+
+- **expirationTimestamp** (Time)
+
+  expirationTimestamp is the time of expiration of the returned token.
+
+  <a name="Time"></a>
+  *Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.*
+
+- **token** (string)
+
+  token is the opaque bearer token.
+
+## Operations {#Operations}
+
+<hr>
+
+### `create` create token of a ServiceAccount
+
+#### HTTP Request
+
+POST /api/v1/namespaces/{namespace}/serviceaccounts/{name}/token
+
+#### Parameters
+
+- **name** (*in path*): string, required
+
+  name of the TokenRequest
+
+- **namespace** (*in path*): string, required
+
+
+- **body**: <a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>, required
+
+  
+
+- **dryRun** (*in query*): string
+
+
+- **fieldManager** (*in query*): string
+
+
+- **fieldValidation** (*in query*): string
+
+
+- **pretty** (*in query*): string
+
+
+#### Response
+
+200 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): Created
+
+202 (<a href="{{< ref "../authentication-resources/token-request-v1#TokenRequest" >}}">TokenRequest</a>): Accepted
+
+401: Unauthorized
+

--- a/content/en/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
+++ b/content/en/docs/reference/kubernetes-api/authentication-resources/token-review-v1.md
@@ -1,0 +1,148 @@
+---
+api_metadata:
+  apiVersion: "authentication.k8s.io/v1"
+  import: "k8s.io/api/authentication/v1"
+  kind: "TokenReview"
+content_type: "api_reference"
+description: "TokenReview attempts to authenticate a token to a known user."
+title: "TokenReview"
+weight: 3
+auto_generated: true
+---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the 
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+`apiVersion: authentication.k8s.io/v1`
+
+`import "k8s.io/api/authentication/v1"`
+
+## TokenReview {#TokenReview}
+
+TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.
+
+<hr>
+
+- **apiVersion**: authentication.k8s.io/v1
+
+- **kind**: TokenReview
+
+- **metadata** (<a href="{{< ref "../definitions/object-meta-v1-meta#ObjectMeta" >}}">ObjectMeta</a>)
+
+  metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+- **spec** (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReviewSpec" >}}">TokenReviewSpec</a>), required
+
+  spec holds information about the request being evaluated
+
+- **status** (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReviewStatus" >}}">TokenReviewStatus</a>)
+
+  status is filled in by the server and indicates whether the request can be authenticated.
+
+## TokenReviewSpec {#TokenReviewSpec}
+
+TokenReviewSpec is a description of the token authentication request.
+
+<hr>
+
+- **token** (string), required
+
+  token is the opaque bearer token.
+
+- **audiences** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
+  audiences is a list of the identifiers that the resource server presented with the token identifies as. Audience-aware token authenticators will verify that the token was intended for at least one of the audiences in this list. If no audiences are provided, the audience will default to the audience of the Kubernetes apiserver.
+
+## TokenReviewStatus {#TokenReviewStatus}
+
+TokenReviewStatus is the result of the token authentication request.
+
+<hr>
+
+- **audiences** ([]string)
+
+  *Atomic: will be replaced during a merge*
+  
+  audiences are audience identifiers chosen by the authenticator that are compatible with both the TokenReview and token. An identifier is any identifier in the intersection of the TokenReviewSpec audiences and the token's audiences. A client of the TokenReview API that sets the spec.audiences field should validate that a compatible audience identifier is returned in the status.audiences field to ensure that the TokenReview server is audience aware. If a TokenReview returns an empty status.audience field where status.authenticated is "true", the token is valid against the audience of the Kubernetes API server.
+
+- **authenticated** (boolean)
+
+  authenticated indicates that the token was associated with a known user.
+
+- **error** (string)
+
+  error indicates that the token couldn't be checked
+
+- **user** (UserInfo)
+
+  user is the UserInfo associated with the provided token.
+
+  <a name="UserInfo"></a>
+  *UserInfo holds the information about the user needed to implement the user.Info interface.*
+
+  - **user.extra** (map[string][]string)
+
+    extra is any additional information provided by the authenticator.
+
+  - **user.groups** ([]string)
+
+    *Atomic: will be replaced during a merge*
+    
+    groups is the names of groups this user is a part of.
+
+  - **user.uid** (string)
+
+    uid is a unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.
+
+  - **user.username** (string)
+
+    username is the name that uniquely identifies this user among all active users.
+
+## Operations {#Operations}
+
+<hr>
+
+### `create` create a TokenReview
+
+#### HTTP Request
+
+POST /apis/authentication.k8s.io/v1/tokenreviews
+
+#### Parameters
+
+- **body**: <a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>, required
+
+  
+
+- **dryRun** (*in query*): string
+
+
+- **fieldManager** (*in query*): string
+
+
+- **fieldValidation** (*in query*): string
+
+
+- **pretty** (*in query*): string
+
+
+#### Response
+
+200 (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>): OK
+
+201 (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>): Created
+
+202 (<a href="{{< ref "../authentication-resources/token-review-v1#TokenReview" >}}">TokenReview</a>): Accepted
+
+401: Unauthorized
+


### PR DESCRIPTION
### Description

Restores the missing `authentication.k8s.io` API reference pages, which were dropped as part of the switch to the gen-apidocs markdown backend in commit 7dffa41ae2.

- Adds `content/en/docs/reference/kubernetes-api/authentication-resources/` with `token-request-v1.md`, `token-review-v1.md`, `self-subject-review-v1.md` and the group `_index.md`
- These three kinds are the only authentication.k8s.io resources not regenerated elsewhere in the migration: ServiceAccount now lives under `core/`, and CertificateSigningRequest / ClusterTrustBundle / PodCertificateRequest under `certificates/`, so they are intentionally **not** restored here to avoid duplicates
- The authorization group was already regenerated as `rbac/` plus `definitions/` pages, so only the authentication group needs restoring
- `group-versions.md` already lists `authentication.k8s.io | v1`, confirming this group is still served and was missed unintentionally
- Content is restored from the pre-migration state (v1.36, commit d405670c62) with three link-target adaptations to the new tree:
  - `../common-definitions/object-meta#ObjectMeta` → `../definitions/object-meta-v1-meta#ObjectMeta` (matching how new pages link ObjectMeta)
  - `../common-parameters/common-parameters#<param>` links removed (the new generated pages render common query parameters as plain text without cross-links, and no common-parameters page exists in the new tree)
- `_index.md` follows the new front matter style (`content_type: "api_reference"`, `auto_generated: true`) with weight 65, placing the group between apps (60) and autoscaling (70) in the sidebar
- All remaining `{{< ref >}}` targets verified to resolve

This restores the pages linked from [service-accounts-admin#tokenrequest-api](/docs/reference/access-authn-authz/service-accounts-admin/#tokenrequest-api) and referenced by the [api-eviction glossary](/docs/concepts/scheduling-eviction/api-eviction/), which currently point to dead URLs.

### Issue

Closes: #57313