### PR TITLE
Clarify log file locations in Troubleshooting Clusters page

### DIFF
--- a/content/en/docs/tasks/debug/debug-cluster/_index.md
+++ b/content/en/docs/tasks/debug/debug-cluster/_index.md
@@ -235,10 +235,29 @@ of the relevant log files.  On systemd-based systems, you may need to use `journ
   {{<glossary_tooltip text="controllers" term_id="controller">}}, with the notable exception of scheduling
   (the kube-scheduler handles scheduling).
 
+The exact location of the control plane component log files depends on how your cluster
+was provisioned: some deployment tools write them directly to `/var/log`, while others
+run the components as static Pods (or containers) and place their logs under
+`/var/log/pods` and `/var/log/containers`, possibly using the `/var/log/kube-apiserver.log`-style
+names above as symlinks. On systemd-based systems, you may also need `journalctl`.
+
 ### Worker Nodes
 
 * `/var/log/kubelet.log` - logs from the kubelet, responsible for running containers on the node
 * `/var/log/kube-proxy.log` - logs from `kube-proxy`, which is responsible for directing traffic to Service endpoints
+
+As with the control plane components, kube-proxy is often run as a static Pod, so its
+logs may live under `/var/log/pods` and `/var/log/containers` rather than at
+`/var/log/kube-proxy.log` directly. For the logs of the containers running on the node
+(and for kube-proxy when it runs as a Pod), look in:
+
+* `/var/log/pods/<namespace>_<pod-name>_<pod-uid>/<container-name>/` - one directory per
+  Pod, containing the log files of each of its containers
+* `/var/log/containers/` - symlinks to the individual container log files under
+  `/var/log/pods`, named `<pod-name>_<namespace>_<container-name>-<container-id>.log`
+
+For more details on these directories and on how container logs work, see
+[Logging Architecture](/docs/concepts/cluster-administration/logging/).
 
 ## Cluster failure modes
 


### PR DESCRIPTION
### Description

Clarifies the "Looking at logs" section of the Troubleshooting Clusters page, per #54872:

- Notes that the exact location of control plane component logs depends on the provisioning method: some tools write directly to `/var/log` (the paths already listed), while others run components as static Pods and write logs under `/var/log/pods` and `/var/log/containers`, possibly with the listed names as symlinks
- Adds the two directories where container logs actually live on nodes:
  - `/var/log/pods/<namespace>_<pod-name>_<pod-uid>/<container-name>/`
  - `/var/log/containers/` (symlinks to the files under `/var/log/pods`)
- Notes that kube-proxy frequently runs as a static Pod, so its logs are often under those directories rather than at the listed `/var/log/kube-proxy.log` path
- Links to the Logging Architecture concept page for details

The reporter correctly observed that the documented paths do not match what is found on real clusters, where logs for pods and (static-Pod) control plane components live under `/var/log/pods` and `/var/log/containers`.

### Issue

Closes: #54872