### PR TITLE
[zh-cn] Fix relative seccomp documentation link

### DIFF
--- a/content/zh-cn/docs/concepts/security/cloud-native-security.md
+++ b/content/zh-cn/docs/concepts/security/cloud-native-security.md
@@ -300,7 +300,7 @@ To protect your compute at runtime, you can:
 5. 使用提供安全限制的
    {{< glossary_tooltip text="容器运行时" term_id="container-runtime" >}}。
 6. 在 Linux 节点上，使用 Linux 安全模式，例如 [AppArmor](/zh-cn/docs/tutorials/security/apparmor/)
-  或者 [seccomp](zh-cn/docs/tutorials/security/seccomp/)。
+  或者 [seccomp](/zh-cn/docs/tutorials/security/seccomp/)。
 
 <!--
 ### Runtime protection: storage {#protection-runtime-storage}


### PR DESCRIPTION
## What this PR does

Fixes the `seccomp` link in `content/zh-cn/docs/concepts/security/cloud-native-security.md`. The link was missing the leading slash, so it was resolved as a relative path and produced a broken URL.

The link now points to `/zh-cn/docs/tutorials/security/seccomp/`, which is the existing Chinese documentation page and returns HTTP 200.

## Validation

- `git diff --check`
- `PYTHONUTF8=1 python scripts/linkchecker.py -n -f 'content/zh-cn/docs/concepts/security/cloud-native-security.md'`

This PR intentionally changes one file only. Related to #55886.