### PR TITLE
Fix effective init request/limit calculation for sidecar containers

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -322,20 +322,38 @@ validation error is thrown for any container sharing a name with another.
 Given the order of execution for init, sidecar and app containers, the following rules
 for resource usage apply:
 
-* The highest of any particular resource request or limit defined on all init
-  containers is the *effective init request/limit*. If any resource has no
+* Because a sidecar container keeps running once it starts, its resource usage
+  overlaps with every init container that starts after it. For each init
+  container, add its own resource request or limit to the combined requests or
+  limits of any sidecar containers that precede it in the list of init
+  containers. The highest such combined value, across all init containers, is
+  the *effective init request/limit* for that resource. If any resource has no
   resource limit specified this is considered as the highest limit.
-* The Pod's *effective request/limit* for a resource is the higher of:
-  * the sum of all app containers request/limit for a resource
+* The Pod's *effective request/limit* for a resource is the sum of
+[pod overhead](/docs/concepts/scheduling-eviction/pod-overhead/) and the higher of:
+  * the sum of all non-init containers(app and sidecar containers) request/limit for a
+  resource
   * the effective init request/limit for a resource
 * Scheduling is done based on effective requests/limits, which means
   init containers can reserve resources for initialization that are not used
   during the life of the Pod.
 * The QoS (quality of service) tier of the Pod's *effective QoS tier* is the
-  QoS tier for init containers and app containers alike.
+  QoS tier for all init, sidecar and app containers alike.
 
 Quota and limits are applied based on the effective Pod request and
 limit.
+
+{{< note >}}
+For example, take a Pod with these init containers, in order: a sidecar
+container (`restartPolicy: Always`) requesting `100m` CPU, followed by a
+regular init container requesting `200m` CPU; plus one app container
+requesting `100m` CPU. The sidecar is still running while the regular init
+container executes, so the effective init request for that step is
+`100m + 200m = 300m` CPU. That's higher than the sum of the app and sidecar
+container requests (`100m + 100m = 200m`), so the Pod's effective CPU request
+is `300m` CPU (plus any pod overhead), even though no single container
+requests that much.
+{{< /note >}}
 
 ### Init containers and Linux cgroups {#cgroups}
 

--- a/content/en/docs/concepts/workloads/pods/sidecar-containers.md
+++ b/content/en/docs/concepts/workloads/pods/sidecar-containers.md
@@ -140,8 +140,12 @@ If you're editing this section, change both places.
 Given the order of execution for init, sidecar and app containers, the following rules
 for resource usage apply:
 
-* The highest of any particular resource request or limit defined on all init
-  containers is the *effective init request/limit*. If any resource has no
+* Because a sidecar container keeps running once it starts, its resource usage
+  overlaps with every init container that starts after it. For each init
+  container, add its own resource request or limit to the combined requests or
+  limits of any sidecar containers that precede it in the list of init
+  containers. The highest such combined value, across all init containers, is
+  the *effective init request/limit* for that resource. If any resource has no
   resource limit specified this is considered as the highest limit.
 * The Pod's *effective request/limit* for a resource is the sum of
 [pod overhead](/docs/concepts/scheduling-eviction/pod-overhead/) and the higher of:
@@ -156,6 +160,18 @@ for resource usage apply:
 
 Quota and limits are applied based on the effective Pod request and
 limit.
+
+{{< note >}}
+For example, take a Pod with these init containers, in order: a sidecar
+container (`restartPolicy: Always`) requesting `100m` CPU, followed by a
+regular init container requesting `200m` CPU; plus one app container
+requesting `100m` CPU. The sidecar is still running while the regular init
+container executes, so the effective init request for that step is
+`100m + 200m = 300m` CPU. That's higher than the sum of the app and sidecar
+container requests (`100m + 100m = 200m`), so the Pod's effective CPU request
+is `300m` CPU (plus any pod overhead), even though no single container
+requests that much.
+{{< /note >}}
 
 ### Sidecar containers and Linux cgroups {#cgroups}
 


### PR DESCRIPTION
**Fixes #57244**

## Problem

The "Resource sharing within containers" section stated:

> The highest of any particular resource request or limit defined on all init containers is the *effective init request/limit*.

That is wrong once sidecar containers are involved. A sidecar container (an init container with `restartPolicy: Always`) keeps running while the init containers listed after it execute, so its request stacks on top of each of those init containers' own requests — which is what [KEP-753](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/753-sidecar-containers/README.md#resources-calculation-for-scheduling-and-pod-admission) specifies and what the scheduler and quota admission actually do.

For the Pod in the issue (sidecar `100m`, then a regular init container `200m`, plus an app container `100m`), the docs implied an effective CPU request of `200m`, but the real value is `300m`.

## Changes

- Restate the effective init request/limit rule so that, for each init container, the requests/limits of any sidecar containers preceding it are added to its own; the effective init value is the highest such combined value.
- Add a worked example as a note, using the Pod from the issue.
- Sync the shared section on the init containers page with the sidecar containers page. The two copies (marked "If you're editing this section, change both places") had drifted — the init containers copy was missing pod overhead, was missing sidecar containers from the non-init sum, and did not mention sidecar containers in the effective QoS tier statement. Both copies are now identical.

Both `content/en/docs/concepts/workloads/pods/init-containers.md` and `content/en/docs/concepts/workloads/pods/sidecar-containers.md` are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CFMJPvGnthL7qCrDYCu5i