### PR TITLE
[zh-cn] Fix kubeadm certificate guide link

### DIFF
--- a/content/zh-cn/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
+++ b/content/zh-cn/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md
@@ -245,7 +245,7 @@ Alternatively, it is possible to use kubeadm phase commands to automate this pro
 - 请注意，一些文件如 `pki/sa.*`、`pki/front-proxy-ca.*` 和 `pki/etc/ca.*`
   在控制平面各节点上是相同的，你可以一次性生成它们并[手动将其分发](/zh-cn/docs/setup/production-environment/tools/kubeadm/high-availability/#manual-certs)到将执行
   `kubeadm join` 的节点，或者你可以使用 `kubeadm init` 的
-  [`--upload-certs`](/zh-cn/docs/setup/product-environment/tools/kubeadm/high-availability/#stacked-control-plane-and-etcd-nodes)
+  [`--upload-certs`](/zh-cn/docs/setup/production-environment/tools/kubeadm/high-availability/#stacked-control-plane-and-etcd-nodes)
   和 `kubeadm join` 的 `--certificate-key` 特性来执行自动分发。
 
 <!--


### PR DESCRIPTION
## What this PR does

Fixes a broken link in `content/zh-cn/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md`.

The `--upload-certs` link used the misspelled `product-environment` path, which returns 404. It now points to the existing `production-environment` high-availability guide and its `stacked-control-plane-and-etcd-nodes` section.

## Validation

- `git diff --check`
- `PYTHONUTF8=1 python scripts/linkchecker.py -n -f 'content/zh-cn/docs/tasks/administer-cluster/kubeadm/kubeadm-certs.md'`
- Confirmed the corrected URL returns HTTP 200

This PR intentionally changes one file only. Related to #55886.