### PR TITLE
[zh-cn] Fix malformed node autoscaling link

### DIFF
--- a/content/zh-cn/docs/concepts/workloads/autoscaling.md
+++ b/content/zh-cn/docs/concepts/workloads/autoscaling.md
@@ -272,4 +272,4 @@ for more information.
   - [HorizontalPodAutoscaler 演练](/zh-cn/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/)
 - [调整分配给容器的 CPU 和内存资源](/zh-cn/docs/tasks/configure-pod-container/resize-container-resources/)
 - [自动扩缩集群 DNS 服务](/zh-cn/docs/tasks/administer-cluster/dns-horizontal-autoscaling/)
-- 了解[节点自动扩缩]((/zh-cn/docs/concepts/cluster-administration/node-autoscaling/))
+- 了解[节点自动扩缩](/zh-cn/docs/concepts/cluster-administration/node-autoscaling/)


### PR DESCRIPTION
## What this PR does

Fixes a malformed link in `content/zh-cn/docs/concepts/workloads/autoscaling.md`.

The Node autoscaling link had an extra opening parenthesis:

```text
((/zh-cn/docs/concepts/cluster-administration/node-autoscaling/))
```

It now uses the valid Markdown link form:

```text
(/zh-cn/docs/concepts/cluster-administration/node-autoscaling/)
```

## Validation

- `git diff --check`
- `PYTHONUTF8=1 python scripts/linkchecker.py -n -f 'content/zh-cn/docs/concepts/workloads/autoscaling.md'`
- Confirmed the target URL returns HTTP 200

The link checker still reports the pre-existing missing Chinese VerticalPodAutoscaler page; this PR does not change that unrelated link. This PR intentionally changes one file only. Related to #55886.