### PR TITLE
Fix RBAC subjects link pointing to FlowSchema instead of RBAC Subject

### DIFF
--- a/content/en/docs/reference/kubernetes-api/rbac/cluster-role-binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/rbac/cluster-role-binding-v1.md
@@ -52,7 +52,7 @@ ClusterRoleBinding references a ClusterRole, but not contain it.  It can referen
       <td>roleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.</td>
     </tr>
     <tr>
-      <td><code>subjects</code><br/><em><a href="{{< ref "../flowcontrol/flow-schema-v1#Subject" >}}">Subject array</a></em></td>
+      <td><code>subjects</code><br/><em><a href="{{< ref "../definitions/subject-v1-rbac#Subject" >}}">Subject array</a></em></td>
       <td>subjects holds references to the objects the role applies to.</td>
     </tr>
   </tbody>

--- a/content/en/docs/reference/kubernetes-api/rbac/role-binding-v1.md
+++ b/content/en/docs/reference/kubernetes-api/rbac/role-binding-v1.md
@@ -52,7 +52,7 @@ RoleBinding references a role, but does not contain it.  It can reference a Role
       <td>roleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.</td>
     </tr>
     <tr>
-      <td><code>subjects</code><br/><em><a href="{{< ref "../flowcontrol/flow-schema-v1#Subject" >}}">Subject array</a></em></td>
+      <td><code>subjects</code><br/><em><a href="{{< ref "../definitions/subject-v1-rbac#Subject" >}}">Subject array</a></em></td>
       <td>subjects holds references to the objects the role applies to.</td>
     </tr>
   </tbody>


### PR DESCRIPTION
**Fixes #56576**

On the RoleBinding and ClusterRoleBinding API reference pages, the `subjects` field linked to FlowSchema's `Subject` type (`flowcontrol.apiserver.k8s.io`) instead of RBAC's own `Subject` (`rbac.authorization.k8s.io/v1`). The two are unrelated types: the RBAC one carries `apiGroup`, `kind`, `name` and `namespace`, which the FlowSchema one does not.

Both links now point at the existing RBAC Subject page, `content/en/docs/reference/kubernetes-api/definitions/subject-v1-rbac.md`, whose `{#Subject}` anchor follows the `../definitions/<name>#<Anchor>` pattern used throughout these generated pages. Nothing in the repo linked to that page before this change.

One line changed in each of the two files.

**Note for reviewers:** these files are `auto_generated: true`. This patches the generated output, so unless the same mapping is corrected in `kubernetes-sigs/reference-docs`, the fix will be lost on the next regeneration. On the issue, @shafiankhan asked whether this belongs here or upstream and did not get an answer, so happy to redo this against reference-docs if that is preferred.

**AI assistance:** AI was used to check the validity, and the changes are according to the procedures.