### PR TITLE
Fix repeated words and misspellings in English docs

### DIFF
--- a/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
+++ b/content/en/docs/concepts/extend-kubernetes/api-extension/custom-resources.md
@@ -266,7 +266,7 @@ Installing an Aggregated API server always involves running a new Deployment.
 Custom resources consume storage space in the same way that ConfigMaps do. Creating too many
 custom resources may overload your API server's storage space.
 
-Custom resources are placed into storage based upon the the current storage
+Custom resources are placed into storage based upon the current storage
 version of the resource, defined in the CRD spec. Any update to a custom
 resource will use the currently defined storage version to store the resource.
 All other versions either need to have all the fields of that version or define

--- a/content/en/docs/concepts/resource-management/dynamic-resource-allocation/device-taints.md
+++ b/content/en/docs/concepts/resource-management/dynamic-resource-allocation/device-taints.md
@@ -90,7 +90,7 @@ To support tainting a specific hardware instance, CEL selectors can be used in a
 to match a vendor-specific unique ID attribute, if the driver supports one for its hardware.
 
 The taint applies as long as the DeviceTaintRule exists.
-It can be modified and and removed at any time.
+It can be modified and removed at any time.
 Here is one example of a DeviceTaintRule for a fictional DRA driver:
 
 ```yaml

--- a/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
+++ b/content/en/docs/concepts/workloads/workload-api/disruption-and-priority.md
@@ -79,8 +79,8 @@ the PodGroup will not be scheduled with `all pods in a single pod group should h
 
 When the [PodGroupPreemptionPolicy](/docs/reference/command-line-tools-reference/feature-gates/podgroup-preemption-policy/)
 feature gate is enabled, PodGroup has also `preemptionPolicy` field. This field is also taken from the PriorirtyClass.
-It is an authoratitive field for all pods in the group and it decides whether the PodGroup can perform a preemption of
-lower priority pods and pod groups to accomodate a place for itself.  When the feature gate is enabled all pods in the PodGroup
+It is an authoritative field for all pods in the group and it decides whether the PodGroup can perform a preemption of
+lower priority pods and pod groups to accommodate a place for itself.  When the feature gate is enabled all pods in the PodGroup
 must have the same `preemptionPolicy` as PodGroup. Otherwise the PodGroup will not be scheduled with
 `all pods in a single pod group should have the same preemption policy as the pod group's preemption policy` error.
 When PodGroup has `preemptionPolicy: Never` it will not perform workload aware preemption.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableKubeletCloudCredentialProviders.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableKubeletCloudCredentialProviders.md
@@ -22,5 +22,5 @@ stages:
 removed: true
 ---
 Enabling the feature gate deactivated the legacy in-tree functionality within the
-kubelet, that allowed the kubelet to to authenticate to a cloud provider container registry
+kubelet, that allowed the kubelet to authenticate to a cloud provider container registry
 for container image pulls.

--- a/content/en/docs/reference/node/kubelet-files.md
+++ b/content/en/docs/reference/node/kubelet-files.md
@@ -197,7 +197,7 @@ AppArmor profiles are loaded via the node operating system rather then reference
 
 A lock file for the kubelet; typically `/var/run/kubelet.lock`. The kubelet uses this to ensure
 that two different kubelets don't try to run in conflict with each other.
-You can configure the path to the lock file using the the `--lock-file` kubelet command line argument.
+You can configure the path to the lock file using the `--lock-file` kubelet command line argument.
 
 If two kubelets on the same node use a different value for the lock file path, they will not be able to
 detect a conflict when both are running.

--- a/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md
@@ -433,7 +433,7 @@ and `scp` using that other user instead.
 
 The `admin.conf` file gives the user _superuser_ privileges over the cluster.
 This file should be used sparingly. For normal users, it's recommended to
-generate an unique credential to which you grant privileges. You can do
+generate a unique credential to which you grant privileges. You can do
 this with the `kubeadm kubeconfig user --client-name <CN>`
 command. That command will print out a KubeConfig file to STDOUT which you
 should save to a file and distribute to your user. After that, grant

--- a/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/dual-stack-support.md
@@ -47,7 +47,7 @@ sudo sysctl --system
 ```
 
 
-You need to have an IPv4 and and IPv6 address range to use. Cluster operators typically
+You need to have an IPv4 and IPv6 address range to use. Cluster operators typically
 use private address ranges for IPv4. For IPv6, a cluster operator typically chooses a global
 unicast address block from within `2000::/3`, using a range that is assigned to the operator.
 You don't have to route the cluster's IP address ranges to the public internet.

--- a/content/en/docs/tutorials/cluster-management/admission-policies.md
+++ b/content/en/docs/tutorials/cluster-management/admission-policies.md
@@ -121,7 +121,7 @@ the validation failure in both the API response body and the HTTP `Warning:` hea
 
 #### MutatingAdmissionPolicyBinding {#policy-actions-mutating}
 
-For MutatingAdmissionPolicyBinding, the the action is always to mutate the object.
+For MutatingAdmissionPolicyBinding, the action is always to mutate the object.
 
 You can use a JSON Patch or a Kubernetes _apply configuration_.
 


### PR DESCRIPTION
Small prose corrections found while reading through the English docs. Each is a duplicated word, a wrong article, or a misspelling.

| Page | Change |
| --- | --- |
| `setup/production-environment/tools/kubeadm/dual-stack-support.md` | "an IPv4 and and IPv6 address range" to "an IPv4 and IPv6 address range" |
| `concepts/extend-kubernetes/api-extension/custom-resources.md` | "based upon the the current storage version" to "the current storage version" |
| `concepts/resource-management/dynamic-resource-allocation/device-taints.md` | "modified and and removed" to "modified and removed" |
| `tutorials/cluster-management/admission-policies.md` | "the the action is always to mutate" to "the action is always to mutate" |
| `reference/command-line-tools-reference/feature-gates/DisableKubeletCloudCredentialProviders.md` | "the kubelet to to authenticate" to "the kubelet to authenticate" |
| `reference/node/kubelet-files.md` | "using the the `--lock-file`" to "using the `--lock-file`" |
| `setup/production-environment/tools/kubeadm/create-cluster-kubeadm.md` | "generate an unique credential" to "generate a unique credential" |
| `concepts/workloads/workload-api/disruption-and-priority.md` | "authoratitive" to "authoritative", and "accomodate" to "accommodate" |

Nine lines changed across eight files, prose only. No auto-generated pages are touched, so nothing here is at risk of being overwritten by a regeneration.

**AI assistance:** AI was used to check the validity, and the changes are according to the procedures.