### PR TITLE
[zh-cn] Fix Redis example links in Job tutorial

### DIFF
--- a/content/zh-cn/docs/tasks/job/fine-parallel-processing-work-queue.md
+++ b/content/zh-cn/docs/tasks/job/fine-parallel-processing-work-queue.md
@@ -232,8 +232,8 @@ You could also download [`worker.py`](/examples/application/job/redis/worker.py)
 the container image. Here's an example using Docker to do the image build:
 -->
 你也可以下载 [`worker.py`](/zh-cn/examples/application/job/redis/worker.py)、
-[`rediswq.py`](zh-cn/examples/application/job/redis/rediswq.py) 和
-[`Dockerfile`](zh-cn/examples/application/job/redis/Dockerfile) 文件，然后构建容器镜像。
+[`rediswq.py`](/zh-cn/examples/application/job/redis/rediswq.py) 和
+[`Dockerfile`](/zh-cn/examples/application/job/redis/Dockerfile) 文件，然后构建容器镜像。
 以下是使用 Docker 进行镜像构建的示例：
 
 ```shell


### PR DESCRIPTION
### Description

Adds the missing leading slash to two Chinese Redis example links so they resolve from `/zh-cn/examples/` instead of being appended to the current documentation path.

Validation:
- `git diff --check`
- `PYTHONUTF8=1 python scripts/linkchecker.py -n -f "content/zh-cn/docs/tasks/job/fine-parallel-processing-work-queue.md"`
- Both corrected Chinese example URLs return 200.

The link checker retains its generic `Link may be wrong` warning for `/examples/` links, but the published targets are available.

### Issue

Related to #55886