### PR TITLE
[WIP] update authorization and webhook docs with kep-5681

### DIFF
--- a/content/en/docs/reference/access-authn-authz/authorization.md
+++ b/content/en/docs/reference/access-authn-authz/authorization.md
@@ -739,6 +739,8 @@ The API server sends a `SubjectAccessReview` to the webhook authorizer:
 apiVersion: authorization.k8s.io/v1
 kind: SubjectAccessReview
 spec:
+  conditionalAuthorization:
+    enabled: true
   resourceAttributes:
     namespace: ""
     verb: create
@@ -771,6 +773,7 @@ status:
       - id: storage-class-dev-only
         effect: Allow
         condition: "object.spec.storageClassName == 'dev'"
+        type: k8s.io/cel
         description: "User alice can only create PersistentVolumes with storageClassName 'dev'"
 ```
 
@@ -802,6 +805,7 @@ request:
         - id: storage-class-dev-only
           effect: Allow
           condition: "object.spec.storageClassName == 'dev'"
+          type: k8s.io/cel
           description: "User alice can only create PersistentVolumes with storageClassName 'dev'"
   admissionControlData:
     requestKind:
@@ -972,9 +976,11 @@ conditions:
 - id: allow-create-pods
   effect: Allow
   condition: "namespace.metadata.labels['team'] == 'platform' && object.spec.containers.size() <= 5"
+  type: k8s.io/cel
 - id: allow-create-deployments
   effect: Allow
   condition: "namespace.metadata.labels['team'] == 'platform' && object.spec.replicas <= 10"
+  type: k8s.io/cel
 ```
 
 Using NoOpinion, you can factor out the common precondition:
@@ -984,12 +990,15 @@ conditions:
 - id: team-precondition
   effect: NoOpinion
   condition: "namespace.metadata.labels['team'] != 'platform'"
+  type: k8s.io/cel
 - id: allow-create-pods
   effect: Allow
   condition: "object.spec.containers.size() <= 5"
+  type: k8s.io/cel
 - id: allow-create-deployments
   effect: Allow
   condition: "object.spec.replicas <= 10"
+  type: k8s.io/cel
 ```
 
 When `namespace.metadata.labels['team'] != 'platform'`, the NoOpinion condition
@@ -1000,6 +1009,40 @@ normally.
 
 This approach is clearer and more maintainable, especially when you have many Allow
 conditions that share the same precondition.
+
+#### Handling evaluation errors
+
+When a condition fails to evaluate (for example, due to a malformed CEL expression,
+external system timeout, or missing data), the authorizer can communicate this through
+the `evaluationError` field. The error is non-fatal: the authorization system can
+still make a decision based on other conditions or authorizers.
+
+For example, if a webhook encounters an error evaluating conditions, it returns:
+
+```yaml
+apiVersion: authorization.k8s.io/v1alpha1
+kind: AuthorizationConditionsReview
+response:
+  decision:
+    type: NoOpinion
+    reason: "Could not evaluate condition"
+    evaluationError: "unable to access external policy database: connection timeout"
+```
+
+The evaluation error is also reflected in the top-level `SubjectAccessReview` status:
+
+```yaml
+apiVersion: authorization.k8s.io/v1
+kind: SubjectAccessReview
+status:
+  allowed: true
+  reason: "RBAC allowed"
+  evaluationError: "webhook 'policy-checker' timeout, using cached decision"
+```
+
+The presence of `evaluationError` indicates that authorization completed, but with
+partial information. This allows operators to monitor authorization health while
+still serving requests when non-critical authorizers fail.
 
 ## Checking API access
 
@@ -1070,7 +1113,7 @@ SelfSubjectRulesReview
 : A review which returns the set of actions a user can perform within a namespace. Useful for users to quickly summarize their own access, or for UIs to hide/show actions.
 
 AuthorizationConditionsReview
-: ({{< feature-state feature_gate_name="ConditionalAuthorization" >}}) Allows evaluating authorization conditions returned by conditional authorizers. Used internally by the API server during admission, and can be called by aggregated API servers.
+: {{< feature-state feature_gate_name="ConditionalAuthorization" >}} Allows evaluating authorization conditions returned by conditional authorizers. Used internally by the API server during admission, and can be called by aggregated API servers.
 
 These APIs can be queried by creating normal Kubernetes resources, where the response `status`
 field of the returned object is the result of the query. For example:
@@ -1106,9 +1149,11 @@ status:
   denied: false
 {{< /highlight >}}
 
-When the `ConditionalAuthorization` feature is enabled and an authorizer returns
-conditional responses, the status includes a `conditionalDecision` field instead of
-simple `allowed: true` or `denied: true`. For example:
+When the `ConditionalAuthorization` feature is enabled, you can request conditional
+authorization by setting `spec.conditionalAuthorization.enabled: true` in your
+`SelfSubjectAccessReview`. If an authorizer returns a conditional response, the
+status includes a `conditionalDecision` field instead of simple `allowed: true`
+or `denied: true`. For example:
 
 {{< highlight yaml "linenos=false,hl_lines=11-20" >}}
 apiVersion: authorization.k8s.io/v1
@@ -1116,8 +1161,6 @@ kind: SelfSubjectAccessReview
 metadata:
   creationTimestamp: null
 spec:
-  conditionalAuthorization:
-    enabled: true
   resourceAttributes:
     group: ""
     resource: persistentvolumes
@@ -1131,12 +1174,55 @@ status:
       - id: storage-class-restriction
         effect: "Allow"
         condition: object.spec.storageClassName == "dev"
+        type: k8s.io/cel
         description: "User can only create PersistentVolumes with storageClassName 'dev'"
 {{< /highlight >}}
 
 The `conditionalDecision` represents an ordered list of condition sets from different
 authorizers. Each condition set contains one or more conditions that must be
 evaluated against the actual request object during the admission phase.
+
+When multiple authorizers are configured in a chain (using
+[AuthorizationConfiguration](#using-configuration-file-for-authorization)),
+and at least one returns a conditional decision, the response uses `type: Union`
+to show the decision tree from all authorizers:
+
+{{< highlight yaml "linenos=false,hl_lines=14-29" >}}
+apiVersion: authorization.k8s.io/v1
+kind: SelfSubjectAccessReview
+metadata:
+  creationTimestamp: null
+spec:
+  conditionalAuthorization:
+    enabled: true
+  resourceAttributes:
+    group: ""
+    resource: configmaps
+    verb: create
+    namespace: default
+status:
+  allowed: false
+  conditionalDecision:
+    type: Union
+    union:
+    - type: NoOpinion
+      reason: "not a privileged user"
+    - type: ConditionsMap
+      conditionsMap:
+        conditions:
+        - id: allow-safe-prefix
+          effect: Allow
+          condition: object.metadata.name.startsWith('safe-')
+          type: k8s.io/cel
+          description: "only allow configmaps with safe- prefix"
+    - type: NoOpinion
+      reason: "no matching RBAC rules"
+{{< /highlight >}}
+
+The `union` array contains decisions from each authorizer in order. During evaluation,
+if any decision is Deny, the request is denied; if any is Allow, it's allowed; if any
+is ConditionsMap, conditions are evaluated during admission; if all are NoOpinion,
+the request is denied.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/reference/access-authn-authz/authorization.md
+++ b/content/en/docs/reference/access-authn-authz/authorization.md
@@ -52,6 +52,37 @@ on the request, then the request is denied. An overall deny verdict means that
 the API server rejects the request and responds with an HTTP 403 (Forbidden)
 status.
 
+### Conditional authorization {#conditional-authorization}
+
+{{< feature-state feature_gate_name="ConditionalAuthorization" >}}
+
+Starting with Kubernetes v1.37, authorizers can return _conditional_ responses
+in addition to the standard _allow_, _deny_, or _no opinion_ verdicts. A conditional
+response means that the final authorization decision depends on the content of
+the API request or stored object, rather than just metadata like resource name
+or namespace.
+
+Conditional authorization enables more fine-grained access control policies that
+span both the authorization and admission phases. For example, an authorizer can
+express: "allow user Alice to create PersistentVolumes, but only when
+spec.storageClassName is 'dev'".
+
+When an authorizer returns a conditional response:
+
+1. During the **authorization phase**, the authorizer performs partial evaluation
+   of its policies based on available metadata, returning a set of conditions
+   that must be satisfied for the request to be allowed.
+2. During the **admission phase**, the `AuthorizationConditionsEnforcer` admission 
+   controller calls the authorizer back to evaluate the conditions the authorizer 
+   produced in the authorization phase, producing a final allow or deny decision.
+
+Conditional authorization is supported for requests that proceed through admission:
+- `create`, `update`, `patch`, `delete`, `deletecollection` verbs
+- Connect requests (for example, `pods/exec`, `pods/portforward`)
+
+For read requests (`get`, `list`, `watch`) and other operations, authorizers
+must return unconditional (Allow, Deny, NoOpinion) decisions only.
+
 ## Request attributes used in authorization
 
 Kubernetes reviews only the following API request attributes:
@@ -136,7 +167,7 @@ The Kubernetes API server may authorize a request using one of several authoriza
 : A special-purpose authorization mode that grants permissions to kubelets based on the pods they are scheduled to run. To learn more about the Node authorization mode, see [Node Authorization](/docs/reference/access-authn-authz/node/).
 
 `Webhook`
-: Kubernetes [webhook mode](/docs/reference/access-authn-authz/webhook/) for authorization makes a synchronous HTTP callout, blocking the request until the remote HTTP service responds to the query.You can write your own software to handle the callout, or use solutions from the ecosystem.
+: Kubernetes [webhook mode](/docs/reference/access-authn-authz/webhook/) for authorization makes a synchronous HTTP callout, blocking the request until the remote HTTP service responds to the query. You can write your own software to handle the callout, or use solutions from the ecosystem. Webhook authorizers can return [conditional responses](#conditional-authorization) when the `ConditionalAuthorization` feature is enabled.
 
 <a id="warning-always-allow" />
 
@@ -263,6 +294,17 @@ authorizers:
       #   - Deny: reject the request without consulting subsequent authorizers
       # Required, with no default.
       failurePolicy: Deny
+      # When ConditionalAuthorization is enabled, conditionsEndpointKubeConfigContext
+      # specifies the kubeconfig context to use for evaluating authorization conditions.
+      # The authorizer must support evaluating any condition type it returns.
+      # Optional; if unset, conditional authorization is not supported by this webhook.
+      conditionsEndpointKubeConfigContext: authorization-conditions
+      # The API version of the authorization.k8s.io AuthorizationConditionsReview to
+      # send to and expect from the webhook when evaluating conditions.
+      # Only relevant when conditionsEndpointKubeConfigContext is set.
+      # Valid values: v1alpha1
+      # This field has no default.
+      authorizationConditionsReviewVersion: v1alpha1
       connectionInfo:
         # Controls how the webhook should communicate with the server.
         # Valid values:
@@ -396,6 +438,569 @@ that let users make changes to the above areas. These may open privilege escalat
 Consider the consequences of this kind of change when deciding on your authorization controls.
 {{< /caution >}}
 
+## How conditional authorization works {#how-conditional-authorization-works}
+
+{{< feature-state feature_gate_name="ConditionalAuthorization" >}}
+
+When the `ConditionalAuthorization` feature is enabled, the authorization and
+admission phases work together to enforce fine-grained policies:
+
+1. **Authorization phase**: The authorizer performs _partial evaluation_ of its
+   policies based on available metadata (user, verb, resource, namespace, etc.).
+   If the policy cannot be fully evaluated without seeing the request content,
+   the authorizer returns conditions.
+
+2. **Request processing**: If the authorization decision was a conditional allow
+   (meaning the request could be allowed if conditions are met), the API server
+   proceeds with normal request processing, including mutation by admission controllers.
+
+3. **Admission phase**: The `AuthorizationConditionsEnforcer` admission controller
+   (always enabled when the feature is active) evaluates all returned conditions
+   against the fully-mutated request and stored objects. If the conditions evaluate
+   to allow, the request proceeds; otherwise, it's denied.
+
+### Partial evaluation examples
+
+To understand how partial evaluation works, consider an authorizer with these two policies:
+
+- **Policy 1**: "Allow Alice to create ConfigMaps (with any content)"
+- **Policy 2**: "Allow Alice to create PersistentVolumeClaims, but only when
+  `spec.storageClassName == 'dev'`"
+
+Here's how these policies are partially evaluated for different requests during the
+authorization phase:
+
+**Request 1: Alice creates a ConfigMap**
+
+- **Policy 1**: Matches completely (user is Alice, verb is create, resource is ConfigMaps).
+  No request content is needed. → **Allow**
+- **Policy 2**: Does not apply (wrong resource)
+
+Result: The request is **unconditionally allowed** directly at the authorization stage,
+just like without conditional authorization. No admission-phase evaluation is needed.
+
+```mermaid
+graph LR
+    Request["Request:<br/>User: Alice<br/>Verb: create<br/>Resource: ConfigMap"]
+
+    Policy1{"Policy 1:<br/>Alice create ConfigMaps?"}
+    Policy2{"Policy 2:<br/>Alice create PVCs?"}
+
+    Allow[("ALLOW<br/>(unconditional)")]
+
+    Request --> Policy1
+    Policy1 -->|"✓ User matches<br/>✓ Verb matches<br/>✓ Resource matches"| Allow
+    Request -.->|"✗ Resource mismatch"| Policy2
+
+    style Request fill:#e1f5ff,stroke:#333
+    style Policy1 fill:#d4edda,stroke:#333
+    style Policy2 fill:#f8f9fa,stroke:#999,stroke-dasharray: 5 5
+    style Allow fill:#28a745,stroke:#333,color:#fff
+```
+
+**Request 2: Alice creates a PersistentVolumeClaim**
+
+- **Policy 1**: Does not apply (wrong resource)
+- **Policy 2**: Partially matches (user is Alice, verb is create, resource is
+  PersistentVolumeClaims), but the request content (specifically `spec.storageClassName`)
+  is not yet available. → **Conditional Allow** (condition: `object.spec.storageClassName == 'dev'`)
+
+Result: The request proceeds to admission, where the condition is evaluated. If
+`spec.storageClassName` is 'dev', the request is allowed; otherwise, it's denied.
+
+```mermaid
+graph LR
+    Request["Request:<br/>User: Alice<br/>Verb: create<br/>Resource: PVC"]
+
+    Policy1{"Policy 1:<br/>Alice create ConfigMaps?"}
+    Policy2{"Policy 2:<br/>Alice create PVCs?"}
+
+    Conditional[("CONDITIONAL ALLOW<br/>Condition:<br/>object.spec.storageClassName<br/>== 'dev'")]
+
+    Admission["Admission Phase:<br/>Evaluate condition<br/>with full object"]
+
+    AllowResult[("ALLOW")]
+    DenyResult[("DENY")]
+
+    Request -.->|"✗ Resource mismatch"| Policy1
+    Request --> Policy2
+    Policy2 -->|"✓ User matches<br/>✓ Verb matches<br/>✓ Resource matches<br/>? Content unknown"| Conditional
+    Conditional --> Admission
+    Admission -->|"storageClassName<br/>== 'dev'"| AllowResult
+    Admission -->|"storageClassName<br/>!= 'dev'"| DenyResult
+
+    style Request fill:#e1f5ff,stroke:#333
+    style Policy1 fill:#f8f9fa,stroke:#999,stroke-dasharray: 5 5
+    style Policy2 fill:#fff3cd,stroke:#333
+    style Conditional fill:#ffc107,stroke:#333
+    style Admission fill:#e7f3ff,stroke:#333
+    style AllowResult fill:#28a745,stroke:#333,color:#fff
+    style DenyResult fill:#dc3545,stroke:#333,color:#fff
+```
+
+**Request 3: Bob creates a PersistentVolumeClaim**
+
+- **Policy 1**: Does not apply (wrong user)
+- **Policy 2**: Does not apply (wrong user)
+
+Result: The authorizer returns **NoOpinion**. If no other authorizer in the chain
+allows the request, it's rejected with HTTP 403 (Forbidden) at the authorization stage.
+
+```mermaid
+graph LR
+    Request["Request:<br/>User: Bob<br/>Verb: create<br/>Resource: PVC"]
+
+    Policy1{"Policy 1:<br/>Alice create ConfigMaps?"}
+    Policy2{"Policy 2:<br/>Alice create PVCs?"}
+
+    NoOpinion[("NO OPINION")]
+    Deny[("403 FORBIDDEN<br/>(no authorizer allowed)")]
+
+    Request -.->|"✗ User mismatch"| Policy1
+    Request -.->|"✗ User mismatch"| Policy2
+    Policy1 -.-> NoOpinion
+    Policy2 -.-> NoOpinion
+    NoOpinion --> Deny
+
+    style Request fill:#e1f5ff,stroke:#333
+    style Policy1 fill:#f8f9fa,stroke:#999,stroke-dasharray: 5 5
+    style Policy2 fill:#f8f9fa,stroke:#999,stroke-dasharray: 5 5
+    style NoOpinion fill:#6c757d,stroke:#333,color:#fff
+    style Deny fill:#dc3545,stroke:#333,color:#fff
+```
+
+### Example scenario
+
+Consider an admin has configured a webhook authorizer with conditional authorization support:
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthorizationConfiguration
+authorizers:
+ - type: Webhook
+   name: storage-policy-webhook
+   webhook:
+    timeout: 3s
+    subjectAccessReviewVersion: v1
+    failurePolicy: Deny
+    # Endpoint for evaluating authorization conditions
+    # This endpoint receives AuthorizationConditionsReview requests
+    conditionsEndpointKubeConfigContext: authorization-conditions
+    authorizationConditionsReviewVersion: v1alpha1
+    connectionInfo:
+      type: KubeConfigFile
+      kubeConfigFile: /etc/kubernetes/authz-webhook.yaml
+```
+
+The referenced kubeconfig file `/etc/kubernetes/authz-webhook.yaml` contains:
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+- name: storage-webhook
+  cluster:
+    server: https://storage-authz-webhook.example.com/authorize
+    certificate-authority: /etc/kubernetes/pki/webhook-ca.crt
+- name: storage-webhook-conditions
+  cluster:
+    server: https://storage-authz-webhook.example.com/conditionsreview
+    certificate-authority: /etc/kubernetes/pki/webhook-ca.crt
+contexts:
+- name: default
+  context:
+    cluster: storage-webhook
+    user: kube-apiserver
+- name: authorization-conditions
+  context:
+    cluster: storage-webhook-conditions
+    user: kube-apiserver
+current-context: default
+users:
+- name: kube-apiserver
+  user:
+    client-certificate: /etc/kubernetes/pki/apiserver-webhook-client.crt
+    client-key: /etc/kubernetes/pki/apiserver-webhook-client.key
+```
+
+The webhook implements a policy: "allow user Alice to create PersistentVolumes,
+but only when `spec.storageClassName` is 'dev'".
+
+#### Sequence diagrams
+
+##### Successful request with condition satisfied
+
+The following diagram shows a request where the authorization condition is satisfied
+(storageClassName is 'dev'):
+
+```mermaid
+sequenceDiagram
+    participant Alice as Alice<br/>(kubectl client)
+    participant API as API Server
+    participant Webhook as Webhook<br/>Authorizer
+    participant Admission as Admission<br/>Controllers
+    participant Storage as etcd
+
+    Alice->>+API: POST /api/v1/persistentvolumes<br/>(storageClassName: dev)
+
+    rect rgb(240, 248, 255)
+        Note over API,Webhook: Authorization Phase
+        API->>+Webhook: SubjectAccessReview<br/>(user: alice, verb: create, resource: persistentvolumes)
+        Note over Webhook: Partial evaluation:<br/>Cannot check storageClassName yet
+        Webhook-->>-API: Conditional Response<br/>(condition: object.spec.storageClassName == 'dev')
+        Note over API: Store conditions in<br/>request context
+    end
+
+    rect rgb(255, 250, 240)
+        Note over API: Request Processing Phase
+        Note over API: Decode request body<br/>Validate schema
+        API->>Admission: Run mutating admission
+        Admission-->>API: OK
+    end
+
+    rect rgb(240, 255, 240)
+        Note over API,Webhook: Admission Phase - Condition Enforcement
+        API->>+Webhook: AuthorizationConditionsReview<br/>(conditions + full object)
+        Note over Webhook: Evaluate condition:<br/>object.spec.storageClassName == 'dev'<br/>Result: true ✓
+        Webhook-->>-API: Allow<br/>(condition satisfied)
+        API->>Admission: Run other validating admission
+        Admission-->>API: OK
+    end
+
+    API->>Storage: Write PersistentVolume
+    Storage-->>API: Success
+    API-->>-Alice: 201 Created
+```
+
+##### Failed request with condition not satisfied
+
+The following diagram shows a request where the authorization condition is not satisfied
+(storageClassName is 'production' instead of 'dev'):
+
+```mermaid
+sequenceDiagram
+    participant Alice as Alice<br/>(kubectl client)
+    participant API as API Server
+    participant Webhook as Webhook<br/>Authorizer
+    participant Admission as Admission<br/>Controllers
+
+    Alice->>+API: POST /api/v1/persistentvolumes<br/>(storageClassName: production)
+
+    rect rgb(240, 248, 255)
+        Note over API,Webhook: Authorization Phase
+        API->>+Webhook: SubjectAccessReview<br/>(user: alice, verb: create, resource: persistentvolumes)
+        Note over Webhook: Partial evaluation:<br/>Cannot check storageClassName yet
+        Webhook-->>-API: Conditional Response<br/>(condition: object.spec.storageClassName == 'dev')
+        Note over API: Store conditions in<br/>request context
+    end
+
+    rect rgb(255, 250, 240)
+        Note over API: Request Processing Phase
+        Note over API: Decode request body<br/>Validate schema
+        API->>Admission: Run mutating admission
+        Admission-->>API: OK
+    end
+
+    rect rgb(255, 240, 240)
+        Note over API,Webhook: Admission Phase - Condition Enforcement
+        API->>+Webhook: AuthorizationConditionsReview<br/>(conditions + full object)
+        Note over Webhook: Evaluate condition:<br/>object.spec.storageClassName == 'dev'<br/>Actual: 'production'<br/>Result: false ✗
+        Webhook-->>-API: NoOpinion<br/>(no conditions matched)
+        Note over API: No Allow decision<br/>→ Request denied
+    end
+
+    API-->>-Alice: 403 Forbidden<br/>(authorization conditions not satisfied)
+```
+
+#### Step-by-step flow
+
+When Alice attempts to create a PersistentVolume with this manifest:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: my-pv
+spec:
+  capacity:
+    storage: 10Gi
+  storageClassName: dev
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /data
+```
+
+**Step 1: Authorization phase**
+
+The API server sends a `SubjectAccessReview` to the webhook authorizer:
+
+```yaml
+apiVersion: authorization.k8s.io/v1
+kind: SubjectAccessReview
+spec:
+  resourceAttributes:
+    namespace: ""
+    verb: create
+    group: ""
+    version: v1
+    resource: persistentvolumes
+  user: alice
+  groups:
+  - system:authenticated
+  uid: "alice-uid-123"
+```
+
+The webhook examines the request and recognizes that:
+- Alice is trying to create a PersistentVolume (metadata is available)
+- The request body content is not yet available during authorization
+- The policy requires checking `spec.storageClassName`
+
+The webhook returns a **conditional response**:
+
+```yaml
+apiVersion: authorization.k8s.io/v1
+kind: SubjectAccessReview
+status:
+  allowed: false
+  denied: false
+  conditionalDecision:
+    type: ConditionsMap
+    conditionsMap:
+      conditions:
+      - id: storage-class-dev-only
+        effect: Allow
+        condition: "object.spec.storageClassName == 'dev'"
+        description: "User alice can only create PersistentVolumes with storageClassName 'dev'"
+```
+
+Because the response contains a conditional allow (`effect: Allow`), the API server
+proceeds with the request, storing the conditions in the request context.
+
+**Step 2: Request processing**
+
+The request proceeds through the normal request chain:
+- Request body is decoded and validated
+- Mutating admission controllers run (if any). In this example, a mutating admission
+  controller adds the label `storage-tier: standard` to the PersistentVolume.
+- Validating admission controllers begin
+
+**Step 3: Admission phase - condition enforcement**
+
+The `AuthorizationConditionsEnforcer` admission controller runs first among
+validating admission controllers. It extracts the conditions from the request
+context and sends an `AuthorizationConditionsReview` to the webhook:
+
+```yaml
+apiVersion: authorization.k8s.io/v1alpha1
+kind: AuthorizationConditionsReview
+request:
+  decision:
+    type: ConditionsMap
+    conditionsMap:
+      conditions:
+        - id: storage-class-dev-only
+          effect: Allow
+          condition: "object.spec.storageClassName == 'dev'"
+          description: "User alice can only create PersistentVolumes with storageClassName 'dev'"
+  admissionControlData:
+    requestKind:
+      group: ""
+      version: v1
+      kind: PersistentVolume
+    requestResource:
+      group: ""
+      version: v1
+      resource: persistentvolumes
+    name: my-pv
+    namespace: ""
+    operation: CREATE
+    userInfo:
+      username: alice
+      uid: "alice-uid-123"
+      groups:
+      - system:authenticated
+    object:
+      apiVersion: v1
+      kind: PersistentVolume
+      metadata:
+        name: my-pv
+        labels:
+          storage-tier: standard
+      spec:
+        capacity:
+          storage: 10Gi
+        storageClassName: dev
+        accessModes:
+        - ReadWriteOnce
+        hostPath:
+          path: /data
+    oldObject: null
+    options: null
+```
+
+**Step 4: Condition evaluation**
+
+The webhook evaluates the condition against the actual request object:
+- Condition: `object.spec.storageClassName == 'dev'`
+- Actual value: `object.spec.storageClassName` is `'dev'`
+- Result: `true`
+
+Because the condition with `effect: Allow` evaluates to `true`, the webhook
+returns an allow decision:
+
+```yaml
+apiVersion: authorization.k8s.io/v1alpha1
+kind: AuthorizationConditionsReview
+response:
+  decision:
+    type: Allow
+    reason: "Condition 'storage-class-dev-only' evaluated to true"
+```
+
+**Step 5: Request completion**
+
+Since the conditions evaluated to allow, the `AuthorizationConditionsEnforcer`
+allows the request to proceed. Other validating admission controllers run,
+and if all succeed, the PersistentVolume is created in etcd.
+
+#### Alternative scenario: denied request
+
+If Alice had instead tried to create a PersistentVolume with
+`storageClassName: production`:
+
+1. Steps 1-3 would proceed identically
+2. In step 4, the webhook would evaluate:
+   - Condition: `object.spec.storageClassName == 'dev'`
+   - Actual value: `object.spec.storageClassName` is `'production'`
+   - Result: `false`
+
+3. Because no `effect: Allow` conditions evaluated to `true`, the webhook returns:
+
+   ```yaml
+   apiVersion: authorization.k8s.io/v1alpha1
+   kind: AuthorizationConditionsReview
+   response:
+     decision:
+       type: NoOpinion
+       reason: "No Allow conditions matched"
+   ```
+
+4. The `AuthorizationConditionsEnforcer` denies the request with an error message:
+   ```
+   Error from server (Forbidden): persistentvolumes "my-pv" is forbidden:
+   authorization conditions not satisfied: User alice can only create
+   PersistentVolumes with storageClassName 'dev'
+   ```
+
+#### Built-in CEL evaluation
+
+In the examples above, the conditions use CEL (Common Expression Language) expressions like
+`object.spec.storageClassName == 'dev'`. When a webhook returns conditions with
+`type: k8s.io/cel` (or omits the type field for CEL expressions), the API server's
+built-in CEL evaluator can evaluate them in-process without sending an
+`AuthorizationConditionsReview` back to the webhook. This provides better performance
+while maintaining the same security guarantees.
+
+If the webhook had instead returned a custom condition type (for example,
+`type: example.com/custom-policy`), then the `AuthorizationConditionsReview`
+callback to the webhook would be required, as only the webhook knows how to
+evaluate that condition type. However, it is worth noting that a webhook authorizer must support
+evaluating any condition it authors, even if the condition type is `k8s.io/cel`, if the API server 
+does not enable in-process CEL evaluation or in version skew scenarios.
+
+### Condition evaluation
+
+```mermaid
+graph TD
+    Start([Evaluate Conditions]) --> Q1{Any effect=Deny<br/>evaluates to true?}
+
+    Q1 -- Yes --> DENY((DENY))
+    Q1 -- No --> Q2{Any effect=Deny<br/>evaluates to error?}
+
+    Q2 -- Yes --> ERROR((ERROR))
+    Q2 -- No --> Q3{Any effect=NoOpinion<br/>evaluates to true?}
+
+    Q3 -- Yes --> NO_OPINION((NO OPINION))
+    Q3 -- No --> Q4{Any effect=NoOpinion<br/>evaluates to error?}
+
+    Q4 -- Yes --> NO_OPINION
+    Q4 -- No --> Q5{Any effect=Allow<br/>evaluates to true?}
+
+    Q5 -- Yes --> ALLOW((ALLOW))
+    Q5 -- No --> NO_OPINION
+
+    %% Styling
+    style Start fill:#dcf0d1,stroke:#333
+    style Q1 fill:#fce4e4,stroke:#333
+    style Q2 fill:#f9b19e,stroke:#333
+    style Q3 fill:#8e246d,stroke:#333,color:#fff
+    style Q4 fill:#58264e,stroke:#333,color:#fff
+    style Q5 fill:#dcf0d1,stroke:#333
+
+    style DENY fill:#a63228,stroke:#333,color:#fff
+    style ERROR fill:#e64a19,stroke:#333,color:#fff
+    style NO_OPINION fill:#912671,stroke:#333,color:#fff
+    style ALLOW fill:#2e5a3d,stroke:#333,color:#fff
+```
+
+Conditions can have different effects:
+
+- **Deny effect**: If the condition evaluates to `true`, the request is immediately
+  denied, short-circuiting evaluation of other authorizers.
+- **NoOpinion effect**: If the condition evaluates to `true`, this authorizer has
+  no opinion, but other authorizers in the chain may still allow or deny the request.
+  The NoOpinion effect is useful for reducing the influence of Allow conditions by
+  factoring out common preconditions.
+- **Allow effect**: If the condition evaluates to `true`, it contributes to allowing
+  the request (unless overridden by deny conditions).
+
+Multiple authorizers can return conditions for the same request. They are evaluated
+in order, and the same short-circuiting logic applies as in the authorization phase.
+
+#### Understanding NoOpinion effect
+
+The NoOpinion effect is useful for factoring out common preconditions from multiple
+Allow conditions. Instead of repeating the same precondition in every Allow condition,
+you can express it once as a NoOpinion condition.
+
+For example, suppose you want to allow certain operations only when a namespace has
+a specific label. Without NoOpinion, you would need to repeat this check:
+
+```yaml
+conditions:
+- id: allow-create-pods
+  effect: Allow
+  condition: "namespace.metadata.labels['team'] == 'platform' && object.spec.containers.size() <= 5"
+- id: allow-create-deployments
+  effect: Allow
+  condition: "namespace.metadata.labels['team'] == 'platform' && object.spec.replicas <= 10"
+```
+
+Using NoOpinion, you can factor out the common precondition:
+
+```yaml
+conditions:
+- id: team-precondition
+  effect: NoOpinion
+  condition: "namespace.metadata.labels['team'] != 'platform'"
+- id: allow-create-pods
+  effect: Allow
+  condition: "object.spec.containers.size() <= 5"
+- id: allow-create-deployments
+  effect: Allow
+  condition: "object.spec.replicas <= 10"
+```
+
+When `namespace.metadata.labels['team'] != 'platform'`, the NoOpinion condition
+evaluates to true, causing this authorizer to have no opinion (effectively overriding
+all the Allow conditions). When the label equals 'platform', the NoOpinion condition
+evaluates to false and is ignored, allowing the Allow conditions to be evaluated
+normally.
+
+This approach is clearer and more maintainable, especially when you have many Allow
+conditions that share the same precondition.
+
 ## Checking API access
 
 `kubectl` provides the `auth can-i` subcommand for quickly querying the API authorization layer.
@@ -464,6 +1069,9 @@ LocalSubjectAccessReview
 SelfSubjectRulesReview
 : A review which returns the set of actions a user can perform within a namespace. Useful for users to quickly summarize their own access, or for UIs to hide/show actions.
 
+AuthorizationConditionsReview
+: ({{< feature-state feature_gate_name="ConditionalAuthorization" >}}) Allows evaluating authorization conditions returned by conditional authorizers. Used internally by the API server during admission, and can be called by aggregated API servers.
+
 These APIs can be queried by creating normal Kubernetes resources, where the response `status`
 field of the returned object is the result of the query. For example:
 
@@ -497,6 +1105,38 @@ status:
   allowed: true
   denied: false
 {{< /highlight >}}
+
+When the `ConditionalAuthorization` feature is enabled and an authorizer returns
+conditional responses, the status includes a `conditionalDecision` field instead of
+simple `allowed: true` or `denied: true`. For example:
+
+{{< highlight yaml "linenos=false,hl_lines=11-20" >}}
+apiVersion: authorization.k8s.io/v1
+kind: SelfSubjectAccessReview
+metadata:
+  creationTimestamp: null
+spec:
+  conditionalAuthorization:
+    enabled: true
+  resourceAttributes:
+    group: ""
+    resource: persistentvolumes
+    verb: create
+status:
+  allowed: false
+  conditionalDecision:
+    type: ConditionsMap
+    conditionsMap:
+      conditions:
+      - id: storage-class-restriction
+        effect: "Allow"
+        condition: object.spec.storageClassName == "dev"
+        description: "User can only create PersistentVolumes with storageClassName 'dev'"
+{{< /highlight >}}
+
+The `conditionalDecision` represents an ordered list of condition sets from different
+authorizers. Each condition set contains one or more conditions that must be
+evaluated against the actual request object during the admission phase.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/reference/access-authn-authz/authorization.md
+++ b/content/en/docs/reference/access-authn-authz/authorization.md
@@ -56,7 +56,7 @@ status.
 
 {{< feature-state feature_gate_name="ConditionalAuthorization" >}}
 
-Starting with Kubernetes v1.37, authorizers can return _conditional_ responses
+Starting with Kubernetes v1.38, authorizers can return _conditional_ responses
 in addition to the standard _allow_, _deny_, or _no opinion_ verdicts. A conditional
 response means that the final authorization decision depends on the content of
 the API request or stored object, rather than just metadata like resource name
@@ -82,6 +82,11 @@ Conditional authorization is supported for requests that proceed through admissi
 
 For read requests (`get`, `list`, `watch`) and other operations, authorizers
 must return unconditional (Allow, Deny, NoOpinion) decisions only.
+
+To use conditional authorization, the API server must enable the
+`authorization.k8s.io/v1alpha1` API extensions group
+(`--runtime-config=authorization.k8s.io/v1alpha1=true`), which provides the
+`AuthorizationConditionsReview` API used to evaluate conditions during the admission phase.
 
 ## Request attributes used in authorization
 
@@ -294,17 +299,24 @@ authorizers:
       #   - Deny: reject the request without consulting subsequent authorizers
       # Required, with no default.
       failurePolicy: Deny
-      # When ConditionalAuthorization is enabled, conditionsEndpointKubeConfigContext
-      # specifies the kubeconfig context to use for evaluating authorization conditions.
-      # The authorizer must support evaluating any condition type it returns.
-      # Optional; if unset, conditional authorization is not supported by this webhook.
-      conditionsEndpointKubeConfigContext: authorization-conditions
-      # The API version of the authorization.k8s.io AuthorizationConditionsReview to
-      # send to and expect from the webhook when evaluating conditions.
-      # Only relevant when conditionsEndpointKubeConfigContext is set.
-      # Valid values: v1alpha1
-      # This field has no default.
-      authorizationConditionsReviewVersion: v1alpha1
+      # conditionsReview enables conditional authorization support for this webhook.
+      # When set, the webhook authorizer may return conditional (ConditionsMap / Union)
+      # responses, which are evaluated via the AuthorizationConditionsReview API.
+      # Optional; if omitted, this webhook only supports unconditional
+      # (Allow / Deny / NoOpinion) decisions.
+      conditionsReview:
+        # kubeConfigContextName is the name of the context within the webhook's
+        # kubeconfig file to use for AuthorizationConditionsReview requests.
+        # May only be set when connectionInfo.type = KubeConfigFile.
+        # Optional; if unset, the default kubeconfig context is used, meaning the API
+        # server sends both SubjectAccessReview and AuthorizationConditionsReview
+        # payloads to the same endpoint, which must distinguish them via TypeMeta.
+        kubeConfigContextName: authorization-conditions
+        # The API version of the authorization.k8s.io AuthorizationConditionsReview to
+        # send to and expect from the webhook when evaluating conditions.
+        # Valid values: v1alpha1
+        # Required (no default) when conditionsReview is set.
+        version: v1alpha1
       connectionInfo:
         # Controls how the webhook should communicate with the server.
         # Valid values:
@@ -585,8 +597,9 @@ authorizers:
     failurePolicy: Deny
     # Endpoint for evaluating authorization conditions
     # This endpoint receives AuthorizationConditionsReview requests
-    conditionsEndpointKubeConfigContext: authorization-conditions
-    authorizationConditionsReviewVersion: v1alpha1
+    conditionsReview:
+      kubeConfigContextName: authorization-conditions
+      version: v1alpha1
     connectionInfo:
       type: KubeConfigFile
       kubeConfigFile: /etc/kubernetes/authz-webhook.yaml
@@ -739,8 +752,13 @@ The API server sends a `SubjectAccessReview` to the webhook authorizer:
 apiVersion: authorization.k8s.io/v1
 kind: SubjectAccessReview
 spec:
-  conditionalAuthorization:
-    enabled: true
+  authorizationOptions:
+    handledDecisionTypes:
+    - Allow
+    - Deny
+    - NoOpinion
+    - ConditionsMap
+    - Union
   resourceAttributes:
     namespace: ""
     verb: create
@@ -769,15 +787,14 @@ status:
   conditionalDecision:
     type: ConditionsMap
     conditionsMap:
-      conditions:
+      allowConditions:
       - id: storage-class-dev-only
-        effect: Allow
         condition: "object.spec.storageClassName == 'dev'"
-        type: k8s.io/cel
+        type: authorizer.kubernetes.io/cel
         description: "User alice can only create PersistentVolumes with storageClassName 'dev'"
 ```
 
-Because the response contains a conditional allow (`effect: Allow`), the API server
+Because the response contains a conditional allow (an `allowConditions` entry), the API server
 proceeds with the request, storing the conditions in the request context.
 
 **Step 2: Request processing**
@@ -801,13 +818,12 @@ request:
   decision:
     type: ConditionsMap
     conditionsMap:
-      conditions:
+      allowConditions:
         - id: storage-class-dev-only
-          effect: Allow
           condition: "object.spec.storageClassName == 'dev'"
-          type: k8s.io/cel
+          type: authorizer.kubernetes.io/cel
           description: "User alice can only create PersistentVolumes with storageClassName 'dev'"
-  admissionControlData:
+  admissionRequest:
     requestKind:
       group: ""
       version: v1
@@ -850,7 +866,7 @@ The webhook evaluates the condition against the actual request object:
 - Actual value: `object.spec.storageClassName` is `'dev'`
 - Result: `true`
 
-Because the condition with `effect: Allow` evaluates to `true`, the webhook
+Because the `allowConditions` entry evaluates to `true`, the webhook
 returns an allow decision:
 
 ```yaml
@@ -859,7 +875,9 @@ kind: AuthorizationConditionsReview
 response:
   decision:
     type: Allow
-    reason: "Condition 'storage-class-dev-only' evaluated to true"
+    allow:
+      reason: "Condition 'storage-class-dev-only' evaluated to true"
+  uid: authorizer-123
 ```
 
 **Step 5: Request completion**
@@ -879,7 +897,7 @@ If Alice had instead tried to create a PersistentVolume with
    - Actual value: `object.spec.storageClassName` is `'production'`
    - Result: `false`
 
-3. Because no `effect: Allow` conditions evaluated to `true`, the webhook returns:
+3. Because no `allowConditions` evaluated to `true`, the webhook returns:
 
    ```yaml
    apiVersion: authorization.k8s.io/v1alpha1
@@ -887,31 +905,34 @@ If Alice had instead tried to create a PersistentVolume with
    response:
      decision:
        type: NoOpinion
-       reason: "No Allow conditions matched"
+       noOpinion:
+         reason: "No Allow conditions matched"
+     uid: authorizer-123
    ```
 
 4. The `AuthorizationConditionsEnforcer` denies the request with an error message:
    ```
-   Error from server (Forbidden): persistentvolumes "my-pv" is forbidden:
-   authorization conditions not satisfied: User alice can only create
-   PersistentVolumes with storageClassName 'dev'
+   Error from server (Forbidden): persistentvolumes "my-pv" is forbidden: 
+   User "alice" cannot create resource "persistentvolumes" in API group "" 
+   at the cluster scope: User alice can only create PersistentVolumes with
+   storageClassName 'dev'
    ```
 
 #### Built-in CEL evaluation
 
 In the examples above, the conditions use CEL (Common Expression Language) expressions like
-`object.spec.storageClassName == 'dev'`. When a webhook returns conditions with
-`type: k8s.io/cel` (or omits the type field for CEL expressions), the API server's
-built-in CEL evaluator can evaluate them in-process without sending an
-`AuthorizationConditionsReview` back to the webhook. This provides better performance
-while maintaining the same security guarantees.
+`object.spec.storageClassName == 'dev'`, indicated by `type: authorizer.kubernetes.io/cel`
+(the type field may be omitted for CEL expressions).
 
-If the webhook had instead returned a custom condition type (for example,
-`type: example.com/custom-policy`), then the `AuthorizationConditionsReview`
-callback to the webhook would be required, as only the webhook knows how to
-evaluate that condition type. However, it is worth noting that a webhook authorizer must support
-evaluating any condition it authors, even if the condition type is `k8s.io/cel`, if the API server 
-does not enable in-process CEL evaluation or in version skew scenarios.
+Currently, the API server evaluates conditions by sending an `AuthorizationConditionsReview`
+back to the webhook regardless of the condition `type`. In the future, conditions using the
+built-in `authorizer.kubernetes.io/cel` type may be evaluated in-process by the API server's
+built-in CEL evaluator, avoiding the callback and improving performance while maintaining the
+same security guarantees. Custom condition types (for example, `type: example.com/custom-policy`)
+would always require the callback, since only the webhook knows how to evaluate them.
+
+Because of this, a webhook authorizer must be able to evaluate any condition it authors —
+including `authorizer.kubernetes.io/cel` conditions — via the `AuthorizationConditionsReview` API.
 
 ### Condition evaluation
 
@@ -948,16 +969,18 @@ graph TD
     style ALLOW fill:#2e5a3d,stroke:#333,color:#fff
 ```
 
-Conditions can have different effects:
+A condition's effect is determined by which list it appears in within `conditionsMap`
+(`allowConditions`, `denyConditions`, or `noOpinionConditions`), rather than by a field
+on the condition itself:
 
-- **Deny effect**: If the condition evaluates to `true`, the request is immediately
-  denied, short-circuiting evaluation of other authorizers.
-- **NoOpinion effect**: If the condition evaluates to `true`, this authorizer has
-  no opinion, but other authorizers in the chain may still allow or deny the request.
-  The NoOpinion effect is useful for reducing the influence of Allow conditions by
-  factoring out common preconditions.
-- **Allow effect**: If the condition evaluates to `true`, it contributes to allowing
-  the request (unless overridden by deny conditions).
+- **Deny** (a condition in `denyConditions`): If the condition evaluates to `true`, the
+  request is immediately denied, short-circuiting evaluation of other authorizers.
+- **NoOpinion** (a condition in `noOpinionConditions`): If the condition evaluates to
+  `true`, this authorizer has no opinion, but other authorizers in the chain may still
+  allow or deny the request. The NoOpinion effect is useful for reducing the influence
+  of Allow conditions by factoring out common preconditions.
+- **Allow** (a condition in `allowConditions`): If the condition evaluates to `true`, it
+  contributes to allowing the request (unless overridden by deny conditions).
 
 Multiple authorizers can return conditions for the same request. They are evaluated
 in order, and the same short-circuiting logic applies as in the authorization phase.
@@ -972,33 +995,31 @@ For example, suppose you want to allow certain operations only when a namespace 
 a specific label. Without NoOpinion, you would need to repeat this check:
 
 ```yaml
-conditions:
-- id: allow-create-pods
-  effect: Allow
-  condition: "namespace.metadata.labels['team'] == 'platform' && object.spec.containers.size() <= 5"
-  type: k8s.io/cel
-- id: allow-create-deployments
-  effect: Allow
-  condition: "namespace.metadata.labels['team'] == 'platform' && object.spec.replicas <= 10"
-  type: k8s.io/cel
+conditionsMap:
+  allowConditions:
+  - id: allow-create-pods
+    condition: "namespace.metadata.labels['team'] == 'platform' && object.spec.containers.size() <= 5"
+    type: authorizer.kubernetes.io/cel
+  - id: allow-create-deployments
+    condition: "namespace.metadata.labels['team'] == 'platform' && object.spec.replicas <= 10"
+    type: authorizer.kubernetes.io/cel
 ```
 
 Using NoOpinion, you can factor out the common precondition:
 
 ```yaml
-conditions:
-- id: team-precondition
-  effect: NoOpinion
-  condition: "namespace.metadata.labels['team'] != 'platform'"
-  type: k8s.io/cel
-- id: allow-create-pods
-  effect: Allow
-  condition: "object.spec.containers.size() <= 5"
-  type: k8s.io/cel
-- id: allow-create-deployments
-  effect: Allow
-  condition: "object.spec.replicas <= 10"
-  type: k8s.io/cel
+conditionsMap:
+  noOpinionConditions:
+  - id: team-precondition
+    condition: "namespace.metadata.labels['team'] != 'platform'"
+    type: authorizer.kubernetes.io/cel
+  allowConditions:
+  - id: allow-create-pods
+    condition: "object.spec.containers.size() <= 5"
+    type: authorizer.kubernetes.io/cel
+  - id: allow-create-deployments
+    condition: "object.spec.replicas <= 10"
+    type: authorizer.kubernetes.io/cel
 ```
 
 When `namespace.metadata.labels['team'] != 'platform'`, the NoOpinion condition
@@ -1025,8 +1046,9 @@ kind: AuthorizationConditionsReview
 response:
   decision:
     type: NoOpinion
-    reason: "Could not evaluate condition"
-    evaluationError: "unable to access external policy database: connection timeout"
+    noOpinion:
+      reason: "Could not evaluate condition"
+      evaluationError: "unable to access external policy database: connection timeout"
 ```
 
 The evaluation error is also reflected in the top-level `SubjectAccessReview` status:
@@ -1150,17 +1172,24 @@ status:
 {{< /highlight >}}
 
 When the `ConditionalAuthorization` feature is enabled, you can request conditional
-authorization by setting `spec.conditionalAuthorization.enabled: true` in your
-`SelfSubjectAccessReview`. If an authorizer returns a conditional response, the
-status includes a `conditionalDecision` field instead of simple `allowed: true`
-or `denied: true`. For example:
+authorization by setting `spec.authorizationOptions.handledDecisionTypes` to
+include the conditional decision types in your `SelfSubjectAccessReview`. If an 
+authorizer returns a conditional response, the status includes a `conditionalDecision` 
+field instead of simple `allowed: true` or `denied: true`. For example:
 
-{{< highlight yaml "linenos=false,hl_lines=11-20" >}}
+{{< highlight yaml "linenos=false,hl_lines=6-12 17-26" >}}
 apiVersion: authorization.k8s.io/v1
 kind: SelfSubjectAccessReview
 metadata:
   creationTimestamp: null
 spec:
+  authorizationOptions:
+    handledDecisionTypes:
+    - Allow
+    - Deny
+    - NoOpinion
+    - ConditionsMap
+    - Union
   resourceAttributes:
     group: ""
     resource: persistentvolumes
@@ -1170,13 +1199,24 @@ status:
   conditionalDecision:
     type: ConditionsMap
     conditionsMap:
-      conditions:
+      allowConditions:
       - id: storage-class-restriction
-        effect: "Allow"
         condition: object.spec.storageClassName == "dev"
-        type: k8s.io/cel
+        type: authorizer.kubernetes.io/cel
         description: "User can only create PersistentVolumes with storageClassName 'dev'"
 {{< /highlight >}}
+
+The `authorizationOptions.handledDecisionTypes` field behaves the same way here as it does for
+webhook [conditional authorization requests](/docs/reference/access-authn-authz/webhook/#conditional-authorization-requests):
+
+- If you **omit** `authorizationOptions` (or set `handledDecisionTypes` to only the unconditional
+  types `Allow`, `Deny`, and `NoOpinion`), the review only reports unconditional results. You never
+  receive a `conditionalDecision`, even if an authorizer would have returned one — instead, it must
+  fail closed to a safe unconditional decision (`Deny` if any `Deny` conditions were present,
+  otherwise `NoOpinion`).
+- If you **include** the conditional types (`ConditionsMap` and `Union`) in `handledDecisionTypes`,
+  the `status` may contain a `conditionalDecision` describing the conditions that must hold for the
+  request to be allowed during admission.
 
 The `conditionalDecision` represents an ordered list of condition sets from different
 authorizers. Each condition set contains one or more conditions that must be
@@ -1187,42 +1227,54 @@ When multiple authorizers are configured in a chain (using
 and at least one returns a conditional decision, the response uses `type: Union`
 to show the decision tree from all authorizers:
 
-{{< highlight yaml "linenos=false,hl_lines=14-29" >}}
+{{< highlight yaml "linenos=false,hl_lines=20-40" >}}
 apiVersion: authorization.k8s.io/v1
-kind: SelfSubjectAccessReview
+kind: SubjectAccessReview
 metadata:
   creationTimestamp: null
 spec:
-  conditionalAuthorization:
-    enabled: true
   resourceAttributes:
     group: ""
     resource: configmaps
     verb: create
     namespace: default
+  authorizationOptions:
+    handledDecisionTypes:
+    - Allow
+    - Deny
+    - NoOpinion
+    - ConditionsMap
+    - Union
 status:
   allowed: false
   conditionalDecision:
     type: Union
     union:
-    - type: NoOpinion
-      reason: "not a privileged user"
-    - type: ConditionsMap
-      conditionsMap:
-        conditions:
-        - id: allow-safe-prefix
-          effect: Allow
-          condition: object.metadata.name.startsWith('safe-')
-          type: k8s.io/cel
-          description: "only allow configmaps with safe- prefix"
-    - type: NoOpinion
-      reason: "no matching RBAC rules"
+    - authorizerName: privileged-check.example.com
+      decision:
+        type: NoOpinion
+        noOpinion:
+          reason: "not a privileged user"
+    - authorizerName: allow.example.com
+      decision:
+        type: ConditionsMap
+        conditionsMap:
+          allowConditions:
+          - id: allow-safe-prefix
+            condition: object.metadata.name.startsWith('safe-')
+            type: authorizer.kubernetes.io/cel
+            description: "only allow configmaps with safe- prefix"
+    - authorizerName: rbac.example.com
+      decision:
+        type: NoOpinion
+        noOpinion:
+          reason: "no matching RBAC rules"
 {{< /highlight >}}
 
 The `union` array contains decisions from each authorizer in order. During evaluation,
 if any decision is Deny, the request is denied; if any is Allow, it's allowed; if any
-is ConditionsMap, conditions are evaluated during admission; if all are NoOpinion,
-the request is denied.
+is ConditionsMap, conditions are evaluated during admission; if all are NoOpinion, the
+authorizer chain has no opinion and the request is denied unless another authorizer allows it.
 
 ## {{% heading "whatsnext" %}}
 

--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -109,41 +109,12 @@ compatibility promises for beta objects and check the "apiVersion" field of the
 request to ensure correct deserialization. Additionally, the API Server must
 enable the `authorization.k8s.io/v1beta1` API extensions group (`--runtime-config=authorization.k8s.io/v1beta1=true`).
 
-### Conditional authorization requests {#conditional-authorization-requests}
+### Basic authorization requests {#basic-authorization-requests}
 
-{{< feature-state feature_gate_name="ConditionalAuthorization" >}}
-
-When the `ConditionalAuthorization` feature is enabled, the `SubjectAccessReview`
-request may include a `conditionalAuthorization` field in the spec, indicating
-that the client supports receiving conditional responses:
-
-```json
-{
-  "apiVersion": "authorization.k8s.io/v1",
-  "kind": "SubjectAccessReview",
-  "spec": {
-    "conditionalAuthorization": {
-      "enabled": true
-    },
-    "resourceAttributes": {
-      "namespace": "dev",
-      "verb": "create",
-      "group": "",
-      "resource": "persistentvolumes"
-    },
-    "user": "alice",
-    "groups": ["developers"]
-  }
-}
-```
-
-The `conditionalAuthorization` field controls whether conditional responses are supported:
-- If the field is **omitted** (null/not present), the client does not support conditional authorization,
-  and authorizers must only return unconditional (Allow, Deny, NoOpinion) decisions.
-- If the field is **present** with `enabled: false`, the client does not support conditional authorization
-  for this request, and authorizers must only return unconditional decisions.
-- If the field is **present** with `enabled: true`, the client supports conditional authorization,
-  and authorizers may return conditional (ConditionsMap, Union) or unconditional responses.
+For standard (non-conditional) authorization, the `SubjectAccessReview` request
+contains only the core authorization attributes (user, verb, resource, namespace)
+without the `conditionalAuthorization` field. The webhook must respond with an
+unconditional decision: Allow, Deny, or NoOpinion.
 
 An example request body:
 
@@ -217,6 +188,42 @@ The webhook would return:
 }
 ```
 
+### Conditional authorization requests {#conditional-authorization-requests}
+
+{{< feature-state feature_gate_name="ConditionalAuthorization" >}}
+
+When the `ConditionalAuthorization` feature is enabled, the `SubjectAccessReview`
+request may include a `conditionalAuthorization` field in the spec, indicating
+that the client supports receiving conditional responses:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1",
+  "kind": "SubjectAccessReview",
+  "spec": {
+    "conditionalAuthorization": {
+      "enabled": true
+    },
+    "resourceAttributes": {
+      "namespace": "dev",
+      "verb": "create",
+      "group": "",
+      "resource": "persistentvolumes"
+    },
+    "user": "alice",
+    "groups": ["developers"]
+  }
+}
+```
+
+The `conditionalAuthorization` field controls whether conditional responses are supported:
+- If the field is **omitted** (null/not present), the client does not support conditional authorization,
+  and authorizers must only return unconditional (Allow, Deny, NoOpinion) decisions.
+- If the field is **present** with `enabled: false`, the client does not support conditional authorization
+  for this request, and authorizers must only return unconditional decisions.
+- If the field is **present** with `enabled: true`, the client supports conditional authorization,
+  and authorizers may return conditional (ConditionsMap, Union) or unconditional responses.
+
 ### Conditional responses {#conditional-responses}
 
 {{< feature-state feature_gate_name="ConditionalAuthorization" >}}
@@ -265,6 +272,61 @@ When conditions are returned, they are evaluated during the admission phase agai
 the actual request and stored objects. If the webhook returns a condition type that
 Kubernetes cannot evaluate natively, Kubernetes will call back to the webhook using
 the `AuthorizationConditionsReview` API.
+
+#### Union responses
+
+When multiple authorizers are configured in a chain (for example, using the
+[AuthorizationConfiguration](/docs/reference/access-authn-authz/authorization/#using-configuration-file-for-authorization)
+file), and at least one returns a conditional decision, the combined response uses
+`type: Union` to represent the decision tree from all authorizers:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1",
+  "kind": "SubjectAccessReview",
+  "status": {
+    "allowed": false,
+    "denied": false,
+    "conditionalDecision": {
+      "type": "Union",
+      "union": [
+        {
+          "type": "NoOpinion",
+          "reason": "not a privileged user"
+        },
+        {
+          "type": "ConditionsMap",
+          "conditionsMap": {
+            "conditions": [
+              {
+                "id": "allow-safe-prefix",
+                "effect": "Allow",
+                "condition": "object.metadata.name.startsWith('safe-')",
+                "type": "k8s.io/cel",
+                "description": "only allow configmaps with safe- prefix"
+              }
+            ]
+          }
+        },
+        {
+          "type": "NoOpinion",
+          "reason": "no matching RBAC rules"
+        }
+      ]
+    }
+  }
+}
+```
+
+The `union` array contains decisions from each authorizer in the configured chain,
+in order. During evaluation:
+- If any decision is `Deny`, the request is denied (short-circuit)
+- If any decision is `Allow`, the request is allowed (short-circuit)
+- If any decision is `ConditionsMap`, conditions are evaluated during admission
+- If all decisions are `NoOpinion`, the request is denied
+
+The Union type provides full transparency into how the authorization decision was
+made across the entire authorizer chain.
 
 Access to non-resource paths are sent as:
 
@@ -442,6 +504,27 @@ The response must contain:
   - `type`: One of `Allow`, `Deny`, or `NoOpinion`
   - `reason`: Optional explanation of the decision
   - `evaluationError`: Optional error message if evaluation failed
+
+If the webhook encounters an error while evaluating conditions, it can return
+a decision with an `evaluationError`:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1alpha1",
+  "kind": "AuthorizationConditionsReview",
+  "response": {
+    "decision": {
+      "type": "NoOpinion",
+      "reason": "Could not evaluate condition",
+      "evaluationError": "unable to access external policy database: connection timeout"
+    }
+  }
+}
+```
+
+The `evaluationError` field allows the webhook to communicate non-fatal errors
+that occurred during evaluation. The API server may still allow the request if
+other authorizers in the chain grant access.
 
 For further information, refer to the
 [SubjectAccessReview API documentation](/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1/)

--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -58,6 +58,43 @@ contexts:
   name: webhook
 ```
 
+When using the [AuthorizationConfiguration](/docs/reference/access-authn-authz/authorization/#using-configuration-file-for-authorization)
+file format and the `ConditionalAuthorization` feature is enabled, you can configure
+a webhook to support conditional authorization by specifying the
+`conditionsEndpointKubeConfigContext` field. This tells the API server where to
+send `AuthorizationConditionsReview` requests to evaluate conditions:
+
+```yaml
+# In the same kubeconfig file referenced by the AuthorizationConfiguration
+clusters:
+  - name: name-of-remote-authz-service
+    cluster:
+      certificate-authority: /path/to/ca.pem
+      server: https://authz.example.com/authorize
+  - name: name-of-remote-authz-conditions
+    cluster:
+      certificate-authority: /path/to/ca.pem
+      # Endpoint for evaluating authorization conditions
+      server: https://authz.example.com/evaluate-conditions
+
+users:
+  - name: name-of-api-server
+    user:
+      client-certificate: /path/to/cert.pem
+      client-key: /path/to/key.pem
+
+current-context: webhook
+contexts:
+- context:
+    cluster: name-of-remote-authz-service
+    user: name-of-api-server
+  name: webhook
+- context:
+    cluster: name-of-remote-authz-conditions
+    user: name-of-api-server
+  name: authorization-conditions
+```
+
 ## Request Payloads
 
 When faced with an authorization decision, the API Server POSTs a JSON-
@@ -71,6 +108,42 @@ as other Kubernetes API objects. Implementers should be aware of looser
 compatibility promises for beta objects and check the "apiVersion" field of the
 request to ensure correct deserialization. Additionally, the API Server must
 enable the `authorization.k8s.io/v1beta1` API extensions group (`--runtime-config=authorization.k8s.io/v1beta1=true`).
+
+### Conditional authorization requests {#conditional-authorization-requests}
+
+{{< feature-state feature_gate_name="ConditionalAuthorization" >}}
+
+When the `ConditionalAuthorization` feature is enabled, the `SubjectAccessReview`
+request may include a `conditionalAuthorization` field in the spec, indicating
+that the client supports receiving conditional responses:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1",
+  "kind": "SubjectAccessReview",
+  "spec": {
+    "conditionalAuthorization": {
+      "enabled": true
+    },
+    "resourceAttributes": {
+      "namespace": "dev",
+      "verb": "create",
+      "group": "",
+      "resource": "persistentvolumes"
+    },
+    "user": "alice",
+    "groups": ["developers"]
+  }
+}
+```
+
+The `conditionalAuthorization` field controls whether conditional responses are supported:
+- If the field is **omitted** (null/not present), the client does not support conditional authorization,
+  and authorizers must only return unconditional (Allow, Deny, NoOpinion) decisions.
+- If the field is **present** with `enabled: false`, the client does not support conditional authorization
+  for this request, and authorizers must only return unconditional decisions.
+- If the field is **present** with `enabled: true`, the client supports conditional authorization,
+  and authorizers may return conditional (ConditionsMap, Union) or unconditional responses.
 
 An example request body:
 
@@ -127,9 +200,9 @@ request is forbidden. The webhook would return:
 }
 ```
 
-The second method denies immediately, short-circuiting evaluation by other 
-configured authorizers. This should only be used by webhooks that have 
-detailed knowledge of the full authorizer configuration of the cluster. 
+The second method denies immediately, short-circuiting evaluation by other
+configured authorizers. This should only be used by webhooks that have
+detailed knowledge of the full authorizer configuration of the cluster.
 The webhook would return:
 
 ```json
@@ -143,6 +216,55 @@ The webhook would return:
   }
 }
 ```
+
+### Conditional responses {#conditional-responses}
+
+{{< feature-state feature_gate_name="ConditionalAuthorization" >}}
+
+When the `ConditionalAuthorization` feature is enabled and the client indicates
+support for conditions in the request, webhooks can return conditional responses.
+A conditional response means the final authorization decision depends on the
+content of the request or stored object.
+
+To return a conditional response, the webhook sets `allowed: false` and `denied: false`,
+and provides a `conditionalDecision` containing the conditions to evaluate:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1",
+  "kind": "SubjectAccessReview",
+  "status": {
+    "conditionalDecision": {
+      "type": "ConditionsMap",
+      "conditionsMap": {
+        "conditions": [
+          {
+            "id": "storage-class-dev",
+            "effect": "Allow",
+            "condition": "object.spec.storageClassName == 'dev'",
+            "type": "k8s.io/cel",
+            "description": "Only allow creating PersistentVolumes with storageClassName 'dev'"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Each condition has:
+- `id`: A unique identifier for the condition within the authorizer's scope (validated as a Kubernetes label key)
+- `effect`: One of `Allow`, `Deny`, or `NoOpinion`, indicating how a `true` evaluation should be treated
+- `condition`: The condition expression to evaluate. Optional if the `id` alone is enough for the authorizer to know how to evaluate the condition.
+- `type`: Describes the type/format/language of the condition (formatted as a Kubernetes label key). Optional. Common types include:
+  - `k8s.io/cel`: Common Expression Language (CEL) expressions
+  - Custom types defined by the authorizer (e.g., `mycompany.com/policy-engine`)
+- `description`: Optional human-readable description shown as an error message or for debugging
+
+When conditions are returned, they are evaluated during the admission phase against
+the actual request and stored objects. If the webhook returns a condition type that
+Kubernetes cannot evaluate natively, Kubernetes will call back to the webhook using
+the `AuthorizationConditionsReview` API.
 
 Access to non-resource paths are sent as:
 
@@ -211,6 +333,115 @@ Non-resource paths include: `/api`, `/apis`, `/metrics`,
 and `/version` to discover what resources and versions are present on the server.
 Access to other non-resource paths can be disallowed without restricting access
 to the REST api.
+
+## AuthorizationConditionsReview API {#authorization-conditions-review}
+
+{{< feature-state feature_gate_name="ConditionalAuthorization" >}}
+
+When a webhook authorizer returns conditional responses, Kubernetes needs to evaluate
+those conditions during the admission phase. For conditions using the built-in
+`k8s.io/cel` type, Kubernetes can evaluate them in-process. For custom condition types
+or when webhooks need to perform the evaluation themselves, Kubernetes calls back to
+the webhook.
+
+Webhooks that support conditional authorization must implement the
+`AuthorizationConditionsReview` API at the endpoint specified by
+`conditionsEndpointKubeConfigContext` in the webhook configuration. If this endpoint
+is not configured, the webhook cannot return conditional responses.
+
+### Request format
+
+The API server POSTs a JSON-serialized `AuthorizationConditionsReview` request:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1alpha1",
+  "kind": "AuthorizationConditionsReview",
+  "request": {
+    "decision": {
+      "type": "ConditionsMap",
+      "conditionsMap": {
+        "conditions": [
+          {
+            "id": "storage-class-restriction",
+            "effect": "Allow",
+            "condition": "object.spec.storageClassName == 'dev'",
+            "type": "k8s.io/cel",
+            "description": "User can only create PVs with storageClassName 'dev'"
+          }
+        ]
+      }
+    },
+    "admissionControlData": {
+      "requestKind": {
+        "group": "",
+        "version": "v1",
+        "kind": "PersistentVolume"
+      },
+      "requestResource": {
+        "group": "",
+        "version": "v1",
+        "resource": "persistentvolumes"
+      },
+      "name": "my-pv",
+      "namespace": "",
+      "operation": "CREATE",
+      "userInfo": {
+        "username": "alice",
+        "uid": "alice-uid-123",
+        "groups": ["system:authenticated"]
+      },
+      "object": {
+        "apiVersion": "v1",
+        "kind": "PersistentVolume",
+        "metadata": { "name": "my-pv" },
+        "spec": { "storageClassName": "dev" }
+      },
+      "oldObject": null,
+      "options": null
+    }
+  }
+}
+```
+
+The request includes:
+- `decision`: The conditional decision that needs to be evaluated, containing:
+  - `type`: The decision type (e.g., `ConditionsMap`, `Union`)
+  - `conditionsMap`: Map of conditions to evaluate (when type is `ConditionsMap`)
+- `admissionControlData`: Contains fields similar to those in [AdmissionReview](/docs/reference/access-authn-authz/extensible-admission-controllers/#request), including:
+  - `requestKind`: The fully-qualified type of the original API request (group, version, kind)
+  - `requestResource`: The fully-qualified resource of the original API request (group, version, resource)
+  - `name`: The name of the object being accessed
+  - `namespace`: The namespace associated with the request (empty for cluster-scoped resources)
+  - `operation`: The operation being performed (`CREATE`, `UPDATE`, `DELETE`, `CONNECT`)
+  - `userInfo`: Information about the requesting user (username, uid, groups)
+  - `object`: The request object (for `CREATE`, `UPDATE`, `CONNECT`)
+  - `oldObject`: The stored object (for `UPDATE`, `DELETE`)
+  - `options`: Operation-specific options
+  - `dryRun`: Optional. Whether modifications will not be persisted (defaults to false)
+
+### Response format
+
+The webhook evaluates the conditions and returns a concrete decision:
+
+```json
+{
+  "apiVersion": "authorization.k8s.io/v1alpha1",
+  "kind": "AuthorizationConditionsReview",
+  "response": {
+    "decision": {
+      "type": "Allow",
+      "reason": "Condition 'storage-class-restriction' evaluated to true"
+    }
+  }
+}
+```
+
+The response must contain:
+- `decision`: The final authorization decision after evaluating conditions
+  - `type`: One of `Allow`, `Deny`, or `NoOpinion`
+  - `reason`: Optional explanation of the decision
+  - `evaluationError`: Optional error message if evaluation failed
 
 For further information, refer to the
 [SubjectAccessReview API documentation](/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1/)

--- a/content/en/docs/reference/access-authn-authz/webhook.md
+++ b/content/en/docs/reference/access-authn-authz/webhook.md
@@ -61,7 +61,7 @@ contexts:
 When using the [AuthorizationConfiguration](/docs/reference/access-authn-authz/authorization/#using-configuration-file-for-authorization)
 file format and the `ConditionalAuthorization` feature is enabled, you can configure
 a webhook to support conditional authorization by specifying the
-`conditionsEndpointKubeConfigContext` field. This tells the API server where to
+`.conditionsReview.kubeConfigContextName` field. This tells the API server where to
 send `AuthorizationConditionsReview` requests to evaluate conditions:
 
 ```yaml
@@ -112,9 +112,10 @@ enable the `authorization.k8s.io/v1beta1` API extensions group (`--runtime-confi
 ### Basic authorization requests {#basic-authorization-requests}
 
 For standard (non-conditional) authorization, the `SubjectAccessReview` request
-contains only the core authorization attributes (user, verb, resource, namespace)
-without the `conditionalAuthorization` field. The webhook must respond with an
-unconditional decision: Allow, Deny, or NoOpinion.
+contains only the core authorization attributes (user, verb, resource, namespace), 
+with the `authorizationOptions` field either omitted or with `handledDecisionTypes` 
+set to only the unconditional types (`Allow`, `Deny`, `NoOpinion`). The webhook 
+must respond with an unconditional decision: Allow, Deny, or NoOpinion.
 
 An example request body:
 
@@ -193,36 +194,44 @@ The webhook would return:
 {{< feature-state feature_gate_name="ConditionalAuthorization" >}}
 
 When the `ConditionalAuthorization` feature is enabled, the `SubjectAccessReview`
-request may include a `conditionalAuthorization` field in the spec, indicating
-that the client supports receiving conditional responses:
+request may include an `authorizationOptions` field in the spec, indicating
+which conditional responses the client supports receiving:
 
 ```json
 {
-  "apiVersion": "authorization.k8s.io/v1",
-  "kind": "SubjectAccessReview",
-  "spec": {
-    "conditionalAuthorization": {
-      "enabled": true
-    },
-    "resourceAttributes": {
-      "namespace": "dev",
-      "verb": "create",
-      "group": "",
-      "resource": "persistentvolumes"
-    },
-    "user": "alice",
-    "groups": ["developers"]
+    "apiVersion": "authorization.k8s.io/v1",
+    "kind": "SubjectAccessReview",
+    "spec": {
+      "authorizationOptions": {
+        "handledDecisionTypes": ["Allow", "Deny", "NoOpinion", "ConditionsMap", "Union"]
+      },
+      "resourceAttributes": {
+        "namespace": "dev",
+        "verb": "create",
+        "group": "",
+        "resource": "persistentvolumes"
+      },
+      "user": "alice",
+      "groups": ["developers"]
+    }
   }
-}
 ```
 
-The `conditionalAuthorization` field controls whether conditional responses are supported:
-- If the field is **omitted** (null/not present), the client does not support conditional authorization,
-  and authorizers must only return unconditional (Allow, Deny, NoOpinion) decisions.
-- If the field is **present** with `enabled: false`, the client does not support conditional authorization
-  for this request, and authorizers must only return unconditional decisions.
-- If the field is **present** with `enabled: true`, the client supports conditional authorization,
-  and authorizers may return conditional (ConditionsMap, Union) or unconditional responses.
+The `authorizationOptions` field controls whether conditional responses are supported. Instead of an on/off boolean, 
+the client declares the decision types it can handle via `authorizationOptions.handledDecisionTypes` (a set), 
+and support is determined by whether that set includes the conditional types:
+
+- If the field is **omitted** (null/not present), the client defaults to handling only the unconditional 
+  decision types `{Allow, Deny, NoOpinion}`, so authorizers must only return unconditional decisions.
+- If the field is **present** but `handledDecisionTypes` does not include both `ConditionsMap` and 
+  `Union` (e.g. it is just `[Allow, Deny, NoOpinion]`), the client does not support conditional authorization for 
+  this request, and authorizers must only return unconditional decisions.
+- If the field is **present** and `handledDecisionTypes` is a superset of `{Allow, Deny, NoOpinion, 
+  ConditionsMap, Union}`, the client supports conditional authorization, and authorizers may return conditional 
+  (`ConditionsMap`, `Union`) or unconditional responses.
+
+If an authorizer would return a conditional decision but the client did not opt in, it must fail closed to a safe 
+unconditional decision (`Deny` if any `Deny` conditions were present, otherwise `NoOpinion`).
 
 ### Conditional responses {#conditional-responses}
 
@@ -238,35 +247,43 @@ and provides a `conditionalDecision` containing the conditions to evaluate:
 
 ```json
 {
-  "apiVersion": "authorization.k8s.io/v1",
-  "kind": "SubjectAccessReview",
-  "status": {
-    "conditionalDecision": {
-      "type": "ConditionsMap",
-      "conditionsMap": {
-        "conditions": [
-          {
-            "id": "storage-class-dev",
-            "effect": "Allow",
-            "condition": "object.spec.storageClassName == 'dev'",
-            "type": "k8s.io/cel",
-            "description": "Only allow creating PersistentVolumes with storageClassName 'dev'"
-          }
-        ]
+    "apiVersion": "authorization.k8s.io/v1",
+    "kind": "SubjectAccessReview",
+    "status": {
+      "allowed": false,
+      "conditionalDecision": {
+        "type": "ConditionsMap",
+        "conditionsMap": {
+          "allowConditions": [
+            {
+              "id": "storage-class-dev",
+              "condition": "object.spec.storageClassName == 'dev'",
+              "description": "Only allow creating PersistentVolumes with storageClassName 'dev'"
+            }
+          ]
+        }
       }
     }
   }
-}
 ```
 
 Each condition has:
 - `id`: A unique identifier for the condition within the authorizer's scope (validated as a Kubernetes label key)
-- `effect`: One of `Allow`, `Deny`, or `NoOpinion`, indicating how a `true` evaluation should be treated
 - `condition`: The condition expression to evaluate. Optional if the `id` alone is enough for the authorizer to know how to evaluate the condition.
 - `type`: Describes the type/format/language of the condition (formatted as a Kubernetes label key). Optional. Common types include:
-  - `k8s.io/cel`: Common Expression Language (CEL) expressions
+  - `authorizer.kubernetes.io/cel`: Common Expression Language (CEL) expressions
   - Custom types defined by the authorizer (e.g., `mycompany.com/policy-engine`)
 - `description`: Optional human-readable description shown as an error message or for debugging
+
+The example above omits `type`, which is valid because `type` is optional: when it is
+absent, the authorizer is responsible for knowing how to evaluate the condition. Setting
+`type` explicitly (for example, `authorizer.kubernetes.io/cel`) is recommended when you
+want to declare the condition language, as shown in the
+[`AuthorizationConditionsReview` request](#authorization-conditions-review) example below.
+
+A condition's _effect_ is determined by which list it appears in within `conditionsMap`
+(`allowConditions`, `denyConditions`, or `noOpinionConditions`), not by a field on the
+condition itself.
 
 When conditions are returned, they are evaluated during the admission phase against
 the actual request and stored objects. If the webhook returns a condition type that
@@ -282,40 +299,52 @@ file), and at least one returns a conditional decision, the combined response us
 
 ```json
 {
-  "apiVersion": "authorization.k8s.io/v1",
-  "kind": "SubjectAccessReview",
-  "status": {
-    "allowed": false,
-    "denied": false,
-    "conditionalDecision": {
-      "type": "Union",
-      "union": [
-        {
-          "type": "NoOpinion",
-          "reason": "not a privileged user"
-        },
-        {
-          "type": "ConditionsMap",
-          "conditionsMap": {
-            "conditions": [
-              {
-                "id": "allow-safe-prefix",
-                "effect": "Allow",
-                "condition": "object.metadata.name.startsWith('safe-')",
-                "type": "k8s.io/cel",
-                "description": "only allow configmaps with safe- prefix"
+    "apiVersion": "authorization.k8s.io/v1",
+    "kind": "SubjectAccessReview",
+    "status": {
+      "allowed": false,
+      "denied": false,
+      "conditionalDecision": {
+        "type": "Union",
+        "union": [
+          {
+            "authorizerName": "privileged-check.example.com",
+            "decision": {
+              "type": "NoOpinion",
+              "noOpinion": {
+                "reason": "not a privileged user"
               }
-            ]
+            }
+          },
+          {
+            "authorizerName": "allow.example.com",
+            "decision": {
+              "type": "ConditionsMap",
+              "conditionsMap": {
+                "allowConditions": [
+                  {
+                    "id": "allow-safe-prefix",
+                    "condition": "object.metadata.name.startsWith('safe-')",
+                    "type": "authorizer.kubernetes.io/cel",
+                    "description": "only allow configmaps with safe- prefix"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "authorizerName": "rbac.example.com",
+            "decision": {
+              "type": "NoOpinion",
+              "noOpinion": {
+                "reason": "no matching RBAC rules"
+              }
+            }
           }
-        },
-        {
-          "type": "NoOpinion",
-          "reason": "no matching RBAC rules"
-        }
-      ]
+        ]
+      }
     }
   }
-}
 ```
 
 The `union` array contains decisions from each authorizer in the configured chain,
@@ -323,7 +352,7 @@ in order. During evaluation:
 - If any decision is `Deny`, the request is denied (short-circuit)
 - If any decision is `Allow`, the request is allowed (short-circuit)
 - If any decision is `ConditionsMap`, conditions are evaluated during admission
-- If all decisions are `NoOpinion`, the request is denied
+- If all decisions are `NoOpinion`, the authorizer chain has no opinion, and the request is denied unless another authorizer allows it
 
 The Union type provides full transparency into how the authorization decision was
 made across the entire authorizer chain.
@@ -401,15 +430,20 @@ to the REST api.
 {{< feature-state feature_gate_name="ConditionalAuthorization" >}}
 
 When a webhook authorizer returns conditional responses, Kubernetes needs to evaluate
-those conditions during the admission phase. For conditions using the built-in
-`k8s.io/cel` type, Kubernetes can evaluate them in-process. For custom condition types
-or when webhooks need to perform the evaluation themselves, Kubernetes calls back to
-the webhook.
+those conditions during the admission phase. Currently, the API server evaluates
+conditions by calling back to the webhook via the `AuthorizationConditionsReview` API,
+regardless of the condition `type`. In the future, conditions using the built-in
+`authorizer.kubernetes.io/cel` type may be evaluated in-process by the API server,
+while custom condition types would still require a callback to the webhook.
 
 Webhooks that support conditional authorization must implement the
 `AuthorizationConditionsReview` API at the endpoint specified by
-`conditionsEndpointKubeConfigContext` in the webhook configuration. If this endpoint
+`.conditionsReview.kubeConfigContextName` in the webhook configuration. If this endpoint
 is not configured, the webhook cannot return conditional responses.
+
+Additionally, the API server must enable the `authorization.k8s.io/v1alpha1` API extensions
+group (`--runtime-config=authorization.k8s.io/v1alpha1=true`), which provides the
+`AuthorizationConditionsReview` API used to evaluate conditions.
 
 ### Request format
 
@@ -423,18 +457,17 @@ The API server POSTs a JSON-serialized `AuthorizationConditionsReview` request:
     "decision": {
       "type": "ConditionsMap",
       "conditionsMap": {
-        "conditions": [
+        "allowConditions": [
           {
             "id": "storage-class-restriction",
-            "effect": "Allow",
             "condition": "object.spec.storageClassName == 'dev'",
-            "type": "k8s.io/cel",
+            "type": "authorizer.kubernetes.io/cel",
             "description": "User can only create PVs with storageClassName 'dev'"
           }
         ]
       }
     },
-    "admissionControlData": {
+    "admissionRequest": {
       "requestKind": {
         "group": "",
         "version": "v1",
@@ -470,7 +503,7 @@ The request includes:
 - `decision`: The conditional decision that needs to be evaluated, containing:
   - `type`: The decision type (e.g., `ConditionsMap`, `Union`)
   - `conditionsMap`: Map of conditions to evaluate (when type is `ConditionsMap`)
-- `admissionControlData`: Contains fields similar to those in [AdmissionReview](/docs/reference/access-authn-authz/extensible-admission-controllers/#request), including:
+- `admissionRequest`: Contains fields similar to those in [AdmissionReview](/docs/reference/access-authn-authz/extensible-admission-controllers/#request), including:
   - `requestKind`: The fully-qualified type of the original API request (group, version, kind)
   - `requestResource`: The fully-qualified resource of the original API request (group, version, resource)
   - `name`: The name of the object being accessed
@@ -493,17 +526,23 @@ The webhook evaluates the conditions and returns a concrete decision:
   "response": {
     "decision": {
       "type": "Allow",
-      "reason": "Condition 'storage-class-restriction' evaluated to true"
-    }
+      "allow": {
+        "reason": "Condition 'storage-class-restriction' evaluated to true"
+      }
+    },
+    "uid": "authorizer-123"
   }
 }
 ```
 
 The response must contain:
-- `decision`: The final authorization decision after evaluating conditions
-  - `type`: One of `Allow`, `Deny`, or `NoOpinion`
-  - `reason`: Optional explanation of the decision
-  - `evaluationError`: Optional error message if evaluation failed
+- `response`: Wraps the evaluation result, containing:
+  - `decision`: The final authorization decision after evaluating conditions
+    - `type`: One of `Allow`, `Deny`, or `NoOpinion`
+    - `allow` / `deny` / `noOpinion`: The decision member matching `type`, each containing:
+      - `reason`: Optional explanation of the decision
+      - `evaluationError`: Optional error message if evaluation failed
+  - `uid`: An identifier for the response
 
 If the webhook encounters an error while evaluating conditions, it can return
 a decision with an `evaluationError`:
@@ -515,9 +554,12 @@ a decision with an `evaluationError`:
   "response": {
     "decision": {
       "type": "NoOpinion",
-      "reason": "Could not evaluate condition",
-      "evaluationError": "unable to access external policy database: connection timeout"
-    }
+      "noOpinion": {
+        "reason": "Could not evaluate condition",
+        "evaluationError": "unable to access external policy database: connection timeout"
+      }
+    },
+    "uid": "authorizer-123"
   }
 }
 ```

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ConditionalAuthorization.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ConditionalAuthorization.md
@@ -1,0 +1,14 @@
+---
+title: ConditionalAuthorization
+content_type: feature_gate
+_build:
+  list: never
+  render: false
+
+stages:
+  - stage: alpha
+    defaultValue: false
+    fromVersion: "1.37"
+---
+Allows authorizers to return conditional responses where the final authorization decision depends on the content of the API request or stored object.
+See [Conditional authorization](/docs/reference/access-authn-authz/authorization/#conditional-authorization) for more details.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/ConditionalAuthorization.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/ConditionalAuthorization.md
@@ -8,7 +8,7 @@ _build:
 stages:
   - stage: alpha
     defaultValue: false
-    fromVersion: "1.37"
+    fromVersion: "1.38"
 ---
 Allows authorizers to return conditional responses where the final authorization decision depends on the content of the API request or stored object.
 See [Conditional authorization](/docs/reference/access-authn-authz/authorization/#conditional-authorization) for more details.


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Replaces https://github.com/kubernetes/website/pull/56134 so we can use dev-1.38 branch as base.
This is a draft PR for some of the docs changes required for KEP-5681 Conditional Authorization. 

Specifically, it adds authorisation changes in https://kubernetes.io/docs/reference/access-authn-authz/authorization/ and webhook changes in https://kubernetes.io/docs/reference/access-authn-authz/webhook/ . 

Information obtained from https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/5681-conditional-authorization/README.md . 

It is a work in progress, so I am welcome to any suggestions or advice. 

<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue [NO ISSUE]

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #56134