### PR TITLE
Refactor concurrencyPolicy paragraph to remove repetition

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/cron-jobs.md
+++ b/content/en/docs/concepts/workloads/controllers/cron-jobs.md
@@ -139,9 +139,6 @@ The spec may specify only one of the following concurrency policies:
 * `Replace`: If it is time for a new Job run and the previous Job run hasn't finished yet, the
   CronJob replaces the currently running Job run with a new Job run
 
-Note that concurrency policy only applies to the Jobs created by the same CronJob.
-If there are multiple CronJobs, their respective Jobs are always allowed to run concurrently.
-
 ### Schedule suspension
 
 You can suspend execution of Jobs for a CronJob, by setting the optional `.spec.suspend` field


### PR DESCRIPTION
### Description
The section about [concurrencyPolicy of CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) seems to repeat the fact that the policy applies only to Jobs created by that CronJob. First in 
> [...] concurrent executions of a Job that is created by this CronJob`[...]

 and then additionally in  the note statement: 

> [...] applies to the Jobs created by the same CronJob [...]

Of course the note is not wrong (maybe it was added to emphasis this point ?) But when reading the CronJob documentation the content of the note seems obvious thus the removal to make the paragraph a little bit more concise.

Thanks for looking into this in advance.
