### PR TITLE
Fix PersistentVolume tutorial paths and cleanup

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
+++ b/content/en/docs/tutorials/configuration/configure-persistent-volume-storage.md
@@ -277,7 +277,7 @@ Move index.html into the directory:
 
 ```shell
 # Move index.html from its current location to the html sub-directory
-sudo mv /mnt/data/index.html html
+sudo mv /mnt/data/index.html /mnt/data/html/index.html
 ```
 
 ### Create a new nginx.conf file
@@ -402,6 +402,7 @@ In the shell on your Node, remove the file and directory that you created:
 # as the superuser
 sudo rm /mnt/data/html/index.html
 sudo rm /mnt/data/nginx.conf
+sudo rmdir /mnt/data/html
 sudo rmdir /mnt/data
 ```
 


### PR DESCRIPTION
This PR fixes two command errors in the PersistentVolume tutorial.

#### 1. `mv` uses a relative destination

The tutorial currently runs:

```shell
sudo mv /mnt/data/index.html html
```

Because `html` is a relative path, the result depends on the shell's current working directory. The command can fail when `html` does not exist there, or move the file to an unintended location when it does.

Uses an absolute destination instead:

```shell
sudo mv /mnt/data/index.html /mnt/data/html/index.html
```

#### 2. Cleanup leaves the `html` directory

The tutorial removes the files under `/mnt/data`, then runs `sudo rmdir /mnt/data`. However, `/mnt/data/html` still exists after its contents are removed, so `/mnt/data` is not empty and the final command fails.

Removes the empty `html` directory before removing `/mnt/data`:

```shell
sudo rm /mnt/data/html/index.html
sudo rm /mnt/data/nginx.conf
sudo rmdir /mnt/data/html
sudo rmdir /mnt/data
```

### Issue

No issue filed.
