### PR TITLE
Update documentation for NodeInclusionPolicyInPodTopologySpread removal in v1.38

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
+++ b/content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md
@@ -65,8 +65,8 @@ spec:
       whenUnsatisfiable: <string>
       labelSelector: <object>
       matchLabelKeys: <list> # optional; beta since v1.27
-      nodeAffinityPolicy: [Honor|Ignore] # optional; beta since v1.26
-      nodeTaintsPolicy: [Honor|Ignore] # optional; beta since v1.26
+      nodeAffinityPolicy: [Honor|Ignore] # optional
+      nodeTaintsPolicy: [Honor|Ignore] # optional
   ### other Pod fields go here
 ```
 
@@ -187,12 +187,6 @@ your cluster. Those fields are:
 
   If this value is null, the behavior is equivalent to the Honor policy.
 
-  {{< note >}}
-  The `nodeAffinityPolicy` became beta in 1.26 and graduated to GA in 1.33.
-  It's enabled by default in beta, you can disable it by disabling the
-  `NodeInclusionPolicyInPodTopologySpread` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
-  {{< /note >}}
-
 - **nodeTaintsPolicy** indicates how we will treat node taints when calculating
   pod topology spread skew. Options are:
   - Honor: nodes without taints, along with tainted nodes for which the incoming pod
@@ -200,12 +194,6 @@ your cluster. Those fields are:
   - Ignore: node taints are ignored. All nodes are included.
 
   If this value is null, the behavior is equivalent to the Ignore policy.
-
-  {{< note >}}
-  The `nodeTaintsPolicy` became beta in 1.26 and graduated to GA in 1.33.
-  It's enabled by default in beta, you can disable it by disabling the
-  `NodeInclusionPolicyInPodTopologySpread` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/).
-  {{< /note >}}
 
 When a Pod defines more than one `topologySpreadConstraint`, those constraints are
 combined using a logical AND operation: the kube-scheduler looks for a node for the incoming Pod

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/NodeInclusionPolicyInPodTopologySpread.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/NodeInclusionPolicyInPodTopologySpread.md
@@ -16,8 +16,10 @@ stages:
     toVersion: "1.32"
   - stage: stable
     defaultValue: true
-    locked: true
     fromVersion: "1.33"
+    toVersion: "1.37"
+
+removed: true
 ---
 Enable using `nodeAffinityPolicy` and `nodeTaintsPolicy` in
 [Pod topology spread constraints](/docs/concepts/scheduling-eviction/topology-spread-constraints/)


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
/sig scheduling
/sig docs

#### What this PR does / why we need it:
In Kubernetes v1.38, the `NodeInclusionPolicyInPodTopologySpread` feature gate was removed following its GA graduation in v1.33 (see https://github.com/kubernetes/kubernetes/pull/141788).

This PR updates the documentation in the `kubernetes/website` repository against the `dev-1.38` branch:
1. Updates `content/en/docs/reference/command-line-tools-reference/feature-gates/NodeInclusionPolicyInPodTopologySpread.md` to set `toVersion: "1.37"` on the `stable` stage and mark `removed: true`.
2. Updates `content/en/docs/concepts/scheduling-eviction/topology-spread-constraints.md` to remove references to the removed feature gate and simplify example YAML comments.

AI was used to help draft the documentation changes, and the author carefully reviewed the code and content before creating this PR.

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/kubernetes/pull/141788

#### Special notes for your reviewer:
/cc @pacoxu @kerthcet

#### Does this PR introduce a user-facing change?
```release-note
NONE
```