### PR TITLE
docs: update CSI CBT beta blog fixups

### DIFF
--- a/content/en/blog/_posts/2026/csi-changed-block-tracking-beta.md
+++ b/content/en/blog/_posts/2026/csi-changed-block-tracking-beta.md
@@ -2,7 +2,6 @@
 layout: blog
 title: 'Kubernetes Changed Block Tracking API - Beta Differences'
 draft: true
-date: 2026-07-07T10:00:00-08:00
 slug: csi-changed-block-tracking-beta
 author: >
    [Prasad Ghangal](https://github.com/PrasadG193) (Veeam Kasten)
@@ -10,7 +9,7 @@ author: >
 
 Changed Block Tracking (CBT) support for CSI drivers
 [shipped as Alpha](/blog/2025/09/25/csi-changed-block-tracking/) in
-September 2025. With the March `v1.0.0` release of the
+September 2025. With the March 2026 `v1.0.0` release of the
 [external-snapshot-metadata](https://github.com/kubernetes-csi/external-snapshot-metadata)
 project, the feature moved to **Beta**.
 
@@ -20,15 +19,17 @@ Kubernetes, the
 the motivation, the three primary components (the CSI `SnapshotMetadata`
 gRPC service, the SnapshotMetadataService CRD, and the
 `external-snapshot-metadata` sidecar), and a walkthrough of how to use the
-API. This post focuses on what is different in Beta.
+API. CBT currently applies to block volumes; file-volume and network
+file-share changed-list tracking is not covered by this feature. This post
+focuses on what is different in Beta.
 
 ## What's new in Beta
 
-The main change in this release is the promotion of the
+The main change in that release was the promotion of the
 SnapshotMetadataService CRD from `v1alpha1` to `v1beta1`. The CRD used to
 advertise a driver's metadata service now serves
 `cbt.storage.k8s.io/v1beta1`. The schema itself is unchanged, but this
-release **removes** `v1alpha1` (rather than serving it alongside the new version).
+release **removed** `v1alpha1` (rather than serving it alongside the new version).
 If you are upgrading from Alpha, you need to:
 
 - Re-apply the CRD definition shipped with `v1.0.0`.
@@ -76,7 +77,7 @@ clients and the iterator package is very welcome.
 - The [CSI developer
   documentation](https://kubernetes-csi.github.io/docs/external-snapshot-metadata.html)
   for snapshot metadata.
-- [KEP-3314](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3314-csi-changed-block-tracking).
+- [KEP-3314](https://www.kubernetes.dev/resources/keps/3314/).
 - The
   [external-snapshot-metadata](https://github.com/kubernetes-csi/external-snapshot-metadata)
   repository.


### PR DESCRIPTION


<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Refresh stale release wording, preserve the block-volume scope, and correct the supporting links so the beta announcement matches the current CSI CBT documentation.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
- Revise the title and stale present-tense wording.
- Clarify that v1alpha1 support was removed in external-snapshot-metadata v1.0.0.
- Update the KEP link.
ref: https://github.com/kubernetes/website/pull/54615/changes
The merged CSI Changed Block Tracking beta blog still has a few stale review fixups.

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #57400  