### PR TITLE
Document clearly that fsGroup does not apply to hostPath volumes

### DIFF
--- a/content/en/docs/concepts/storage/volumes.md
+++ b/content/en/docs/concepts/storage/volumes.md
@@ -405,6 +405,13 @@ accessible by root. You then either need to run your process as root in a
 [privileged container](/docs/tasks/configure-pod-container/security-context/)
 or modify the file permissions on the host to read from or write to a `hostPath` volume.
 
+{{< caution >}}
+`fsGroup` and `fsGroupChangePolicy` do **not** apply to `hostPath` volumes. The kubelet
+never changes the ownership of a host directory or file, so the volume retains its
+pre-existing ownership. For `fsGroup`-managed ownership on a node directory, use a
+[`local` PersistentVolume](#local) instead.
+{{< /caution >}}
+
 #### hostPath configuration example
 
 {{< tabs name="hostpath_examples" >}}

--- a/content/en/docs/tasks/configure-pod-container/security-context.md
+++ b/content/en/docs/tasks/configure-pod-container/security-context.md
@@ -835,6 +835,12 @@ applied to Volumes as follows:
   [Ownership Management design document](https://git.k8s.io/design-proposals-archive/storage/volume-ownership-management.md)
   for more details.
 
+  {{< note >}}
+  [`hostPath`](/docs/concepts/storage/volumes/#hostpath) volumes don't support ownership
+  management, so `fsGroup` and `fsGroupChangePolicy` have no effect on them. For `fsGroup`-managed ownership on a node directory, use a
+  [`local` PersistentVolume](/docs/concepts/storage/volumes/#local) instead.
+  {{< /note >}}
+
 * `seLinuxOptions`: Volumes that support SELinux labeling are relabeled to be accessible
   by the label specified under `seLinuxOptions`. Usually you only
   need to set the `level` section. This sets the


### PR DESCRIPTION
### Description

`fsGroup` and `fsGroupChangePolicy` silently have no effect on `hostPath` volumes-- the kubelet never chowns a host directory, unlike managed volume types.  This is documented for ephemeral volume types, but not for `hostPath`, so users hit it by trial and error.

This adds a caution o the `hostPath` volume type docs and a note tot he security condext docs' `fsGroup` discussion.  Both point the user to `local` PersistentVolumes as the `fsGroup`-managed alternative.

### Issue

Ref kubernetes/kubernetes#138411

This is docs-only clarification of expected behavior.  See the triage from @wilmerdooley on that issue.