### PR TITLE
Repair links to the removed authentication-resources API reference pages

### DIFF
--- a/content/en/docs/concepts/configuration/secret.md
+++ b/content/en/docs/concepts/configuration/secret.md
@@ -193,7 +193,7 @@ Pods.
 
 In Kubernetes v1.22 and later, the recommended approach is to obtain a
 short-lived, automatically rotating ServiceAccount token by using the
-[`TokenRequest`](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
+[`TokenRequest`](/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume)
 API instead. You can get these short-lived tokens using the following methods:
 
 * Call the `TokenRequest` API either directly or by using an API client like

--- a/content/en/docs/concepts/security/service-accounts.md
+++ b/content/en/docs/concepts/security/service-accounts.md
@@ -166,7 +166,7 @@ If you need the credentials for a ServiceAccount to mount in a non-standard
 location, or for an audience that isn't the API server, use one of the
 following methods:
 
-* [TokenRequest API](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
+* [TokenRequest API](/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume)
   (recommended): Request a short-lived service account token from within
   your own *application code*. The token expires automatically and can rotate
   upon expiration.
@@ -288,7 +288,7 @@ For more information about the authentication process, refer to
 If you have services of your own that need to validate Kubernetes service
 account credentials, you can use the following methods:
 
-* [TokenReview API](/docs/reference/kubernetes-api/authentication-resources/token-review-v1/)
+* [TokenReview API](/docs/reference/kubernetes-api/definitions/token-review-v1-authentication/)
   (recommended)
 * OIDC discovery
 
@@ -328,4 +328,4 @@ used in your application and nowhere else.
 
 * Learn how to [manage your ServiceAccounts as a cluster administrator](/docs/reference/access-authn-authz/service-accounts-admin/).
 * Learn how to [assign a ServiceAccount to a Pod](/docs/tasks/configure-pod-container/configure-service-account/).
-* Read the [ServiceAccount API reference](/docs/reference/kubernetes-api/authentication-resources/service-account-v1/).
+* Read the [ServiceAccount API reference](/docs/reference/kubernetes-api/core/service-account-v1/).

--- a/content/en/docs/reference/access-authn-authz/authentication.md
+++ b/content/en/docs/reference/access-authn-authz/authentication.md
@@ -1901,7 +1901,7 @@ you see the user details and properties for the user that was impersonated.
 
 This example response did not show all the available fields; not all
 authentication mechanisms fill in every available field.
-See the [SelfSubjectReview API reference](/docs/reference/kubernetes-api/authentication-resources/self-subject-review-v1/)
+See the [SelfSubjectReview API reference](/docs/reference/kubernetes-api/definitions/self-subject-review-v1-authentication/)
 to see which fields are available.
 
 Here is another example that also includes the `uid` and `extra` fields:

--- a/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
+++ b/content/en/docs/reference/access-authn-authz/certificate-signing-requests.md
@@ -33,7 +33,7 @@ There is also support for distributing [trust bundles](#cluster-trust-bundles).
 {{< feature-state for_k8s_version="v1.19" state="stable" >}}
 
 
-A [CertificateSigningRequest](/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1/)
+A [CertificateSigningRequest](/docs/reference/kubernetes-api/certificates/certificate-signing-request-v1/)
 (CSR) resource is used to request that a certificate be signed
 by a denoted signer, after which the request may be approved or denied before
 finally being signed.

--- a/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
+++ b/content/en/docs/reference/access-authn-authz/extensible-admission-controllers.md
@@ -234,7 +234,7 @@ As an alternative to the manual credential management described in
 [Authenticate API servers](#authenticate-apiservers), the `kube-apiserver` can
 issue short-lived, scoped ServiceAccount tokens for authenticating to admission
 webhooks. This mechanism uses the
-[TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
+[TokenRequest](/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume)
 API to issue tokens that are bound to a specific webhook configuration and
 scoped to particular API groups.
 

--- a/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
+++ b/content/en/docs/reference/access-authn-authz/service-accounts-admin.md
@@ -292,8 +292,7 @@ could then be mounted into running Pods.
 
 In more recent versions, including Kubernetes v{{< skew currentVersion >}}, API credentials
 are [obtained directly](#bound-service-account-token-volume) using the
-[TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API,
-and are mounted into Pods using a projected volume.
+`TokenRequest` API, and are mounted into Pods using a projected volume.
 The tokens obtained using this method have bounded lifetimes, and are automatically
 invalidated when the Pod they are mounted into is deleted.
 
@@ -305,7 +304,7 @@ the Kubernetes control plane automatically populates the token into that Secret.
 
 {{< note >}}
 Although the manual mechanism for creating a long-lived ServiceAccount token exists,
-using [TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
+using `TokenRequest`
 to obtain short-lived API access tokens is recommended instead.
 {{< /note >}}
 
@@ -473,7 +472,7 @@ administrator can configure this value through the
 
 {{< feature-state for_k8s_version="v1.22" state="stable" >}}
 
-You use the [TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
+You use the `TokenRequest`
 subresource of a ServiceAccount to obtain a time-bound token for that ServiceAccount.
 You don't need to call this to obtain an API token for use within a container, since
 the kubelet sets this up for you using a _projected volume_.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/APIServerWebhookAuthenticationToken.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/APIServerWebhookAuthenticationToken.md
@@ -16,4 +16,4 @@ for authenticating to
 These tokens are bound to a specific ValidatingWebhookConfiguration or
 MutatingWebhookConfiguration and are scoped to particular API groups
 via attestation claims in the
-[TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API.
+[TokenRequest](/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume) API.

--- a/content/en/docs/setup/best-practices/certificates.md
+++ b/content/en/docs/setup/best-practices/certificates.md
@@ -130,7 +130,7 @@ the load balancer stable IP and/or DNS name, `kubernetes`, `kubernetes.default`,
 `kubernetes.default.svc.cluster`, `kubernetes.default.svc.cluster.local`)
 
 where `kind` maps to one or more of the x509 key usage, which is also documented in the
-`.spec.usages` of a [CertificateSigningRequest](/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1#CertificateSigningRequest)
+`.spec.usages` of a [CertificateSigningRequest](/docs/reference/kubernetes-api/certificates/certificate-signing-request-v1#CertificateSigningRequest)
 type:
 
 | kind   | Key usage                                                                       |

--- a/content/en/docs/tasks/configure-pod-container/configure-service-account.md
+++ b/content/en/docs/tasks/configure-pod-container/configure-service-account.md
@@ -206,7 +206,7 @@ Versions of Kubernetes before v1.22 automatically created long term credentials 
 accessing the Kubernetes API. This older mechanism was based on creating token Secrets
 that could then be mounted into running Pods. In more recent versions, including
 Kubernetes v{{< skew currentVersion >}}, API credentials are obtained directly by using the
-[TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API,
+[TokenRequest](/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume) API,
 and are mounted into Pods using a
 [projected volume](/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume).
 The tokens obtained using this method have bounded lifetimes, and are automatically
@@ -214,7 +214,7 @@ invalidated when the Pod they are mounted into is deleted.
 
 You can still manually create a service account token Secret; for example,
 if you need a token that never expires. However, using the
-[TokenRequest](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
+[TokenRequest](/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume)
 subresource to obtain a token to access the API is recommended instead.
 {{< /note >}}
 
@@ -285,7 +285,7 @@ If you view the ServiceAccount using:
 ` kubectl get serviceaccount build-robot -o yaml`
 
 You can't see the `build-robot-secret` Secret in the ServiceAccount API objects
-[`.secrets`](/docs/reference/kubernetes-api/authentication-resources/service-account-v1/) field
+[`.secrets`](/docs/reference/kubernetes-api/core/service-account-v1/) field
 because that field is only populated with auto-generated Secrets.
 {{< /note >}}
 

--- a/content/en/docs/tasks/tls/certificate-issue-client-csr.md
+++ b/content/en/docs/tasks/tls/certificate-issue-client-csr.md
@@ -71,7 +71,7 @@ Encode the CSR document using this command:
 cat myuser.csr | base64 | tr -d "\n"
 ```
 
-Create a [CertificateSigningRequest](/docs/reference/kubernetes-api/authentication-resources/certificate-signing-request-v1/)
+Create a [CertificateSigningRequest](/docs/reference/kubernetes-api/certificates/certificate-signing-request-v1/)
 and submit it to a Kubernetes cluster via kubectl. Below is a snippet of shell that you can use to generate the
 CertificateSigningRequest.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it

As of the v1.36 API reference migration (to the gen-apidocs markdown backend), the legacy `authentication-resources` URLs were removed and the generator did not emit the authentication/authorization group pages. Sixteen links across ten English docs pages still pointed at the dead URLs — for example, [service-accounts-admin #tokenrequest-api](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#tokenrequest-api) links `TokenRequest` to a page that now redirects into the storage CSI docs (kubernetes/website#57313).

This PR repoints those links at the pages that document the same API today:

| Old target (`authentication-resources/...`) | New target |
| --- | --- |
| `token-review-v1/` | `/docs/reference/kubernetes-api/definitions/token-review-v1-authentication/` |
| `self-subject-review-v1/` | `/docs/reference/kubernetes-api/definitions/self-subject-review-v1-authentication/` |
| `service-account-v1/` | `/docs/reference/kubernetes-api/core/service-account-v1/` |
| `certificate-signing-request-v1/` (+ anchor variant) | `/docs/reference/kubernetes-api/certificates/certificate-signing-request-v1/` |
| `token-request-v1/` | TokenRequest API usage docs: `/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume` |

For the three `TokenRequest` mentions inside `service-accounts-admin.md` itself (where linking to that same page's anchor would be self-referential), the links become inline code spans. A mention of the historical 1.22 blog post is left untouched.

There is no TokenRequest definitions page on `main` today (see the note below), which is why TokenRequest links go to the canonical usage documentation instead.

#### Which issue(s) this PR fixes

Fixes #57313

#### Special notes for your reviewer

- The root cause (the generator skipping create-only resources such as TokenRequest, TokenReview, SelfSubjectReview and the SubjectAccessReview family) is fixed upstream in kubernetes-sigs/reference-docs#473. Once that lands and the API reference is regenerated, the missing `authentication/` and `authorization/` group directories return, and these links can be upgraded to the new per-resource pages if desired.
- Follow-up to the closed #57362: as discussed there, the pages themselves must come from the upstream generator rather than being hand-restored; this PR only repairs the inbound links so readers are not stranded in the meantime.
- Link count check: `grep -rn "authentication-resources" content/en/docs --include="*.md"` returns 0 after this PR (was 16).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```