### PR TITLE
docs: fix feature state rendering for filesystem signals

### DIFF
--- a/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
+++ b/content/en/docs/concepts/scheduling-eviction/node-pressure-eviction.md
@@ -136,8 +136,8 @@ These identifiers describe the filesystems as the kubelet observes them. They do
 not always mean three different mount points: in common layouts, two or all
 three identifiers can refer to the same underlying filesystem.
 
-{{<note>}}
 {{< feature-state feature_gate_name="KubeletSeparateDiskGC" >}}
+{{<note>}}
 The _split image filesystem_ feature adds new eviction signals, thresholds, and
 metrics for `containerfs`. To use `containerfs`, the Kubernetes release
 v{{< skew currentVersion >}} requires the `KubeletSeparateDiskGC`


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
Fix the rendering of the `KubeletSeparateDiskGC` feature state in the filesystem signals section of the node-pressure eviction documentation.

The `feature-state` shortcode was nested inside the `note` shortcode, which caused the feature-state content to render incorrectly as raw HTML.

Move the `feature-state` shortcode outside the `note` block so that the feature state is rendered correctly.
<!--
 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.
-->

### Issue
Fixes #57415

## Testing

- Ran `git diff --check`
- Verified the documentation locally using the Kubernetes website development server with `make container-serve`
- Confirmed the feature-state component renders correctly in the filesystem signals section
<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

