### PR TITLE
Fix broken links in the pod-level resource managers blog post

### DIFF
--- a/content/en/blog/_posts/2026/pod-level-resource-managers.md
+++ b/content/en/blog/_posts/2026/pod-level-resource-managers.md
@@ -7,7 +7,7 @@ author: Kevin Torres Martinez (Google)
 ---
 
 Kubernetes v1.36 introduces
-[Pod-Level Resource Managers](/docs/concepts/workloads/resource-managers/#pod-level-resource-managers)
+[Pod-Level Resource Managers](/docs/concepts/resource-management/resource-managers/#pod-level-resource-managers)
 as an alpha feature, bringing a more flexible and powerful resource management
 model to performance-sensitive workloads. This enhancement extends the kubelet's
 Topology, CPU, and Memory Managers to support pod-level resource specifications
@@ -195,7 +195,7 @@ have introduced several new kubelet metrics when the feature gate is enabled:
 
 While this feature opens up new possibilities, there are a few things to keep in
 mind during its alpha phase. Be sure to review the
-[Limitations and caveats](/docs/concepts/workloads/resource-managers/#limitations-and-caveats)
+[Limitations and caveats](/docs/concepts/resource-management/pod-level-resource-managers/#limitations-and-caveats)
 in the official documentation for full details on compatibility, requirements,
 and downgrade instructions.
 
@@ -204,7 +204,7 @@ and downgrade instructions.
 For a deep dive into the technical details and configuration of this feature,
 check out the official concept documentation:
 
-*   [Pod-level resource managers](/docs/concepts/workloads/resource-managers/#pod-level-resource-managers)
+*   [Pod-level resource managers](/docs/concepts/resource-management/pod-level-resource-managers/)
 
 To learn more about the overall pod-level resources feature and how to assign
 resources to pods, see:


### PR DESCRIPTION
### Description

Three links in this blog post point at `/docs/concepts/workloads/resource-managers/`, a path that no longer exists (moved to `/docs/concepts/resource-management/resource-managers/` per the redirect in `static/_redirects.base`). Two of the three are worse than a stale path: the "limitations and caveats" and "deep dive into the technical details" links were never pointing at content that lives on that general overview page at all. Both belong on the dedicated `pod-level-resource-managers` concept page instead, which has a `## Limitations and caveats` heading and is the actual deep-dive page the surrounding blog text describes. Updated the first link to the moved path, and the other two to the dedicated page.


