### PR TITLE
docs: document the VPA Helm chart installation method

### DIFF
--- a/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
+++ b/content/en/docs/concepts/workloads/autoscaling/vertical-pod-autoscale.md
@@ -45,6 +45,15 @@ The VerticalPodAutoscaler is defined as a {{< glossary_tooltip text="Custom Reso
 
 The current stable API version is `autoscaling.k8s.io/v1`. More details about the VPA installation and API can be found in the [VPA GitHub repository](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler).
 
+A Helm chart is also available for installing VPA:
+
+```shell
+helm repo add autoscalers https://kubernetes.github.io/autoscaler
+helm upgrade -i vertical-pod-autoscaler autoscalers/vertical-pod-autoscaler
+```
+
+The chart is under active development and not yet recommended for production use; see the [chart source](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler) for its current status and configurable values.
+
 ## How does a VerticalPodAutoscaler work?
 
 {{< figure


### PR DESCRIPTION
### Description

The Vertical Pod Autoscaler concepts page linked out to the VPA GitHub repository for installation details but did not mention that a Helm chart is available, even though the chart has existed in the autoscaler repository for a while. This adds the Helm install command directly, along with a note that the chart is still under active development and not yet recommended for production, linking to the chart source for its current status and configurable values.

Tested locally: ran a full `hugo` build against this branch, it completes with no errors on this page or elsewhere.

### Issue

Closes: kubernetes/autoscaler#9407
