### PR TITLE
[KEP-5440] Graduate mutable suspended Job features to stable

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/job.md
+++ b/content/en/docs/concepts/workloads/controllers/job.md
@@ -1006,9 +1006,10 @@ the Job to true; later, when you want to resume it again, update it to false.
 Creating a Job with `.spec.suspend` set to true will create it in the suspended
 state.
 
-In Kubernetes 1.35 or later the `.status.startTime` field is cleared on Job suspension
-when the [MutableSchedulingDirectivesForSuspendedJobs](#mutable-scheduling-directives-for-suspended-jobs)
-feature gate is enabled.
+In Kubernetes v1.38 and later, the `.status.startTime` field is cleared when a Job
+is suspended. In Kubernetes v1.35 through v1.37, this behavior depends on the
+[MutableSchedulingDirectivesForSuspendedJobs](#mutable-scheduling-directives-for-suspended-jobs)
+feature gate, which is enabled by default starting in Kubernetes v1.36.
 
 When a Job is resumed from suspension, its `.status.startTime` field will be
 reset to the current time. This means that the `.spec.activeDeadlineSeconds`
@@ -1127,11 +1128,17 @@ tolerations, labels, annotations and [scheduling gates](/docs/concepts/schedulin
 
 {{< feature-state feature_gate_name="MutableSchedulingDirectivesForSuspendedJobs" >}}
 
-In Kubernetes 1.34 or earlier mutating of Pod's scheduling directives is allowed only for
-suspended Jobs that have never been unsuspended before. In Kubernetes 1.35, this is allowed
-for any suspended Jobs when the `MutableSchedulingDirectivesForSuspendedJobs` feature gate is enabled.
+In Kubernetes v1.34 or earlier, you can update Pod scheduling directives only for
+a suspended Job that has never been unsuspended. Starting with Kubernetes v1.35,
+you can also update scheduling directives after a running Job is suspended and
+its active Pods have terminated.
 
-Additionally, this feature gate enables clearing of the `.status.startTime` field on [Job suspension](#suspending-a-job).
+In Kubernetes v1.35 through v1.37, this behavior depends on the
+`MutableSchedulingDirectivesForSuspendedJobs` feature gate. Starting with
+Kubernetes v1.38, the feature is stable and always enabled.
+
+This behavior also clears the `.status.startTime` field when the
+[Job is suspended](#suspending-a-job).
 
 ### Mutable Pod resources for suspended Jobs
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MutablePodResourcesForSuspendedJobs.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MutablePodResourcesForSuspendedJobs.md
@@ -13,7 +13,11 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.36"
-removed: false
+    toVersion: "1.37"
+  - stage: stable
+    defaultValue: true
+    locked: true
+    fromVersion: "1.38"
 ---
 Enable the ability to patch pod templates for suspended Jobs, in order to change requests or limits for infrastructure resources.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MutableSchedulingDirectivesForSuspendedJobs.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MutableSchedulingDirectivesForSuspendedJobs.md
@@ -13,7 +13,11 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.36"
-removed: false
+    toVersion: "1.37"
+  - stage: stable
+    defaultValue: true
+    locked: true
+    fromVersion: "1.38"
 ---
 Enable the ability to patch pod templates for suspended Jobs, in order to change the pod scheduling directives.
 


### PR DESCRIPTION
### Description

Graduate `MutablePodResourcesForSuspendedJobs` and `MutableSchedulingDirectivesForSuspendedJobs` to Stable in Kubernetes v1.38. The lifecycle metadata preserves Alpha history, records Beta through v1.37, and marks both gates enabled and locked from v1.38.

Update the Job documentation so it no longer implies that v1.38 users must manually enable a locked GA gate, and clarify that active Pods must have terminated before scheduling directives can be updated. This documentation PR introduces no new API or usage workflow.

Validation: `git diff --check` and scope/shortcode checks passed. Verified the wording against the core PR's Job strategy and controller. `make build` stopped at the uninitialized `api-ref-generator` submodule; Hugo is also unavailable locally.

Kept as a draft pending the Stable KEP and core GA PRs:
- https://github.com/kubernetes/enhancements/pull/6307
- https://github.com/kubernetes/kubernetes/pull/141784

### Issue

Related to https://github.com/kubernetes/enhancements/issues/5440

/sig apps
/sig docs
