### PR TITLE
Fix dead kubernetes-client/java example link

### DIFF
--- a/content/en/docs/tasks/administer-cluster/access-cluster-api.md
+++ b/content/en/docs/tasks/administer-cluster/access-cluster-api.md
@@ -244,7 +244,7 @@ to see which versions are supported.
 
 The Java client can use the same [kubeconfig file](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
 as the kubectl CLI does to locate and authenticate to the API server. See this
-[example](https://github.com/kubernetes-client/java/blob/master/examples/examples-release-15/src/main/java/io/kubernetes/client/examples/KubeConfigFileClientExample.java):
+[example](https://github.com/kubernetes-client/java/blob/master/examples/examples-release-latest/src/main/java/io/kubernetes/client/examples/KubeConfigFileClientExample.java):
 
 ```java
 package io.kubernetes.client.examples;


### PR DESCRIPTION
### Description

The Java client example link in this page points at `examples/examples-release-15/...` in the `kubernetes-client/java` repository, which now 404s. That path has been renamed to `examples/examples-release-latest/...`. Updated the link to the working path.

### Issue

Closes: #
