### PR TITLE
Fix small typos in the 'managing-tls-in-a-cluster' page

### DIFF
--- a/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
+++ b/content/en/docs/tasks/tls/managing-tls-in-a-cluster.md
@@ -50,7 +50,7 @@ chain and adding the parsed certificates to the `RootCAs` field in the
 [`tls.Config`](https://pkg.go.dev/crypto/tls#Config) struct.
 
 {{< note >}}
-Even though the custom CA certificate may be included in the filesystem (in the
+Even though the root CA certificate may be included in the filesystem (in the
 ConfigMap `kube-root-ca.crt`),
 you should not use that certificate authority for any purpose other than to verify internal
 Kubernetes endpoints. An example of an internal Kubernetes endpoint is the
@@ -68,7 +68,7 @@ The following section demonstrates how to create a TLS certificate for a
 Kubernetes service accessed through DNS.
 
 {{< note >}}
-This tutorial uses CFSSL: Cloudflare's PKI and TLS toolkit See the Cloudflare blog
+This tutorial uses CFSSL: Cloudflare's PKI and TLS toolkit. See the Cloudflare blog
 article [Introducing CFSSL - CloudFlare's PKI toolkit](https://blog.cloudflare.com/introducing-cfssl/) for more information.
 {{< /note >}}
 


### PR DESCRIPTION
<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
### Description
While going through this docs page
https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/
I noticed two possible small typos.
- mention of `custom CA` where possibly `root CA` was meant
  - I think that is correct, as otherwise the note doesn't make sense to me
- . (dot) missing in a note about `cfssl`

I built the container based Hugo server and the page renders as expected there.

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->