### PR TITLE
Clarify container restart examples

### DIFF
--- a/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
+++ b/content/en/docs/concepts/workloads/pods/pod-lifecycle.md
@@ -438,8 +438,8 @@ spec:
     command: ['sh', '-c', 'echo "Keep restarting" && sleep 1800 && exit 1']
 ```
 
-A Pod with `Always` restart policy with an init container that only execute once. If the init
-container fails, the Pod fails. This allows the Pod to fail if the initialization failed,
+Another example: A Pod with `Always` restart policy with an init container that only execute once.
+If the init container fails, the Pod fails. This allows the Pod to fail if the initialization failed,
 but also keep running once the initialization succeeds:
 
 ```yaml
@@ -460,8 +460,8 @@ spec:
     command: ['sh', '-c', 'sleep 1800 && exit 0']
 ```
 
-A Pod with Never restart policy with a container that ignores and restarts on specific exit codes.
-This is useful to differentiate between restartable errors and non-restartable errors:
+Last example: A Pod with Never restart policy with a container that ignores and restarts on specific
+exit codes. This is useful to differentiate between restartable errors and non-restartable errors:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
### Description

In `Concepts > Workloads > Pods > Pod Lifecycle`, I'm proposing to make more explicit the fact that we are giving more examples.
I got confused when reading this part. Maybe it's because I'm a non-native speaker, but I had to re-read the sentence multiple times to understand it was stating another example.

I ran it locally to make sure it looked ok.

<img width="760" height="935" alt="image" src="https://github.com/user-attachments/assets/3afb9b3e-b50a-4246-b2e7-c7e08a360022" />