### PR TITLE
docs: register deprecated pod.alpha/beta init-container annotations

### DIFF
--- a/content/en/docs/reference/labels-annotations-taints/_index.md
+++ b/content/en/docs/reference/labels-annotations-taints/_index.md
@@ -1092,6 +1092,54 @@ Starting in v1.17, this label is deprecated in favor of
 [topology.kubernetes.io/zone](#topologykubernetesiozone).
 {{< /note >}}
 
+### pod.alpha.kubernetes.io/init-containers (deprecated) {#pod-alpha-kubernetes-io-init-containers}
+
+Type: Annotation
+
+Used on: Pod
+
+This annotation was used during early prototyping of init containers to specify
+container definitions that must run to completion before the Pod's main containers start.
+Support for this annotation was removed in Kubernetes v1.8 in favor of the
+[`initContainers`](/docs/concepts/workloads/pods/init-containers/) field in the Pod spec.
+The API server drops this annotation from any Pod on which it is set.
+
+### pod.alpha.kubernetes.io/init-container-statuses (deprecated) {#pod-alpha-kubernetes-io-init-container-statuses}
+
+Type: Annotation
+
+Used on: Pod
+
+This annotation was used during early prototyping of init containers to report the
+status of a Pod's init containers.
+Support for this annotation was removed in Kubernetes v1.8 in favor of the
+`initContainerStatuses` field of Pod `.status`.
+The API server drops this annotation from any Pod on which it is set.
+
+### pod.beta.kubernetes.io/init-containers (deprecated) {#pod-beta-kubernetes-io-init-containers}
+
+Type: Annotation
+
+Used on: Pod
+
+This annotation was used during the beta stage of init containers to specify
+container definitions that must run to completion before the Pod's main containers start.
+Support for this annotation was removed in Kubernetes v1.8 in favor of the
+[`initContainers`](/docs/concepts/workloads/pods/init-containers/) field in the Pod spec.
+The API server drops this annotation from any Pod on which it is set.
+
+### pod.beta.kubernetes.io/init-container-statuses (deprecated) {#pod-beta-kubernetes-io-init-container-statuses}
+
+Type: Annotation
+
+Used on: Pod
+
+This annotation was used during the beta stage of init containers to report the
+status of a Pod's init containers.
+Support for this annotation was removed in Kubernetes v1.8 in favor of the
+`initContainerStatuses` field of Pod `.status`.
+The API server drops this annotation from any Pod on which it is set.
+
 ### pv.kubernetes.io/bind-completed {#pv-kubernetesiobind-completed}
 
 Type: Annotation


### PR DESCRIPTION
### Description

Register the four legacy init-container annotations on the Kubernetes labels/annotations/taints reference page:

- `pod.alpha.kubernetes.io/init-containers`
- `pod.alpha.kubernetes.io/init-container-statuses`
- `pod.beta.kubernetes.io/init-containers`
- `pod.beta.kubernetes.io/init-container-statuses`

Each entry marks the annotation as deprecated, notes that support was removed in Kubernetes v1.8, and points readers to the modern replacements (`spec.initContainers` and `status.initContainerStatuses`).

Wording is grounded in the current source of truth in kubernetes/kubernetes at [`pkg/api/pod/util.go`](https://github.com/kubernetes/kubernetes/blob/master/pkg/api/pod/util.go), where `DropInitContainerAnnotations` deletes exactly these four keys and its comment states: *"Support for these annotations was removed in v1.8 in favor of the Spec.InitContainers field."*

Section placement is alphabetical, immediately before `pv.kubernetes.io/bind-completed`.

### Issue

Closes: #42792

<!--
 Hello!

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.
-->
