### PR TITLE
docs: correct taint and toleration glossary entries

### DIFF
--- a/content/en/docs/reference/glossary/taint.md
+++ b/content/en/docs/reference/glossary/taint.md
@@ -3,13 +3,13 @@ title: Taint
 id: taint
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A property applied to a node or node group with required `key` and `effect` fields and optional `value` and `timeAdded` fields. Taints prevent the scheduling of Pods on nodes or node groups.
+  A property applied to a node or node group. A taint has required `key` and `effect` fields and an optional `value`.
 
 aka:
 tags:
 - fundamental
 ---
- A property applied to a {{< glossary_tooltip text="node" term_id="node" >}} or node group with required `key` and `effect` fields and optional `value` and `timeAdded` fields. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on nodes or node groups.
+A property applied to a {{< glossary_tooltip text="node" term_id="node" >}} or node group. A taint has required `key` and `effect` fields and an optional `value`.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/taint.md
+++ b/content/en/docs/reference/glossary/taint.md
@@ -3,13 +3,13 @@ title: Taint
 id: taint
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A core object consisting of three required properties: key, value, and effect. Taints prevent the scheduling of pods on nodes or node groups.
+  A property applied to a node or node group that uses three fields: key, value, and effect. The key and effect fields are required. Taints prevent the scheduling of Pods on nodes or node groups.
 
 aka:
 tags:
 - fundamental
 ---
- A core object consisting of three required properties: key, value, and effect. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on {{< glossary_tooltip text="nodes" term_id="node" >}} or node groups.
+ A property applied to a {{< glossary_tooltip text="node" term_id="node" >}} or node group that uses three fields: key, value, and effect. The key and effect fields are required. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on nodes or node groups.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/taint.md
+++ b/content/en/docs/reference/glossary/taint.md
@@ -3,13 +3,13 @@ title: Taint
 id: taint
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A property applied to a node or node group that uses three fields: key, value, and effect. The key and effect fields are required. Taints prevent the scheduling of Pods on nodes or node groups.
+  A property applied to a node or node group with required `key` and `effect` fields and optional `value` and `timeAdded` fields. Taints prevent the scheduling of Pods on nodes or node groups.
 
 aka:
 tags:
 - fundamental
 ---
- A property applied to a {{< glossary_tooltip text="node" term_id="node" >}} or node group that uses three fields: key, value, and effect. The key and effect fields are required. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on nodes or node groups.
+ A property applied to a {{< glossary_tooltip text="node" term_id="node" >}} or node group with required `key` and `effect` fields and optional `value` and `timeAdded` fields. Taints prevent the scheduling of {{< glossary_tooltip text="Pods" term_id="pod" >}} on nodes or node groups.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/toleration.md
+++ b/content/en/docs/reference/glossary/toleration.md
@@ -3,13 +3,13 @@ title: Toleration
 id: toleration
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A property applied to a Pod that allows scheduling onto nodes or node groups with matching taints. The key, operator, value, and effect fields define the match, and tolerationSeconds controls how long a NoExecute taint is tolerated.
+  A property applied to a Pod that allows scheduling onto nodes or node groups with matching taints. The `key`, `operator`, `value`, and `effect` fields define the match, and `tolerationSeconds` controls how long a `NoExecute` taint is tolerated.
 
 aka:
 tags:
 - fundamental
 ---
- A property applied to a {{< glossary_tooltip text="Pod" term_id="pod" >}} that allows scheduling onto nodes or node groups with matching {{< glossary_tooltip text="taints" term_id="taint" >}}. The key, operator, value, and effect fields define the match, and tolerationSeconds controls how long a NoExecute taint is tolerated.
+ A property applied to a {{< glossary_tooltip text="Pod" term_id="pod" >}} that allows scheduling onto nodes or node groups with matching {{< glossary_tooltip text="taints" term_id="taint" >}}. The `key`, `operator`, `value`, and `effect` fields define the match, and `tolerationSeconds` controls how long a `NoExecute` taint is tolerated.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/toleration.md
+++ b/content/en/docs/reference/glossary/toleration.md
@@ -3,13 +3,13 @@ title: Toleration
 id: toleration
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A property applied to a Pod that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of Pods on nodes or node groups that have a matching taint.
+  A property applied to a Pod that allows scheduling onto nodes or node groups with matching taints. The key, operator, value, and effect fields define the match, and tolerationSeconds controls how long a NoExecute taint is tolerated.
 
 aka:
 tags:
 - fundamental
 ---
- A property applied to a {{< glossary_tooltip text="Pod" term_id="pod" >}} that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of Pods on nodes or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
+ A property applied to a {{< glossary_tooltip text="Pod" term_id="pod" >}} that allows scheduling onto nodes or node groups with matching {{< glossary_tooltip text="taints" term_id="taint" >}}. The key, operator, value, and effect fields define the match, and tolerationSeconds controls how long a NoExecute taint is tolerated.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/toleration.md
+++ b/content/en/docs/reference/glossary/toleration.md
@@ -3,14 +3,13 @@ title: Toleration
 id: toleration
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have a matching taint.
+  A property applied to a Pod that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of Pods on nodes or node groups that have a matching taint.
 
 aka:
 tags:
-- core-object
 - fundamental
 ---
- A core object consisting of three required properties: key, value, and effect. Tolerations enable the scheduling of pods on nodes or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
+ A property applied to a {{< glossary_tooltip text="Pod" term_id="pod" >}} that uses four fields: key, operator, value, and effect. Tolerations enable the scheduling of Pods on nodes or node groups that have matching {{< glossary_tooltip text="taints" term_id="taint" >}}.
 
 <!--more-->
 

--- a/content/en/docs/reference/glossary/toleration.md
+++ b/content/en/docs/reference/glossary/toleration.md
@@ -3,13 +3,13 @@ title: Toleration
 id: toleration
 full_link: /docs/concepts/scheduling-eviction/taint-and-toleration/
 short_description: >
-  A property applied to a Pod that allows scheduling onto nodes or node groups with matching taints. The `key`, `operator`, `value`, and `effect` fields define the match, and `tolerationSeconds` controls how long a `NoExecute` taint is tolerated.
+  A property applied to a Pod. Its `key`, `operator`, `value`, and `effect` fields define which taints the Pod tolerates.
 
 aka:
 tags:
 - fundamental
 ---
- A property applied to a {{< glossary_tooltip text="Pod" term_id="pod" >}} that allows scheduling onto nodes or node groups with matching {{< glossary_tooltip text="taints" term_id="taint" >}}. The `key`, `operator`, `value`, and `effect` fields define the match, and `tolerationSeconds` controls how long a `NoExecute` taint is tolerated.
+A property applied to a {{< glossary_tooltip text="Pod" term_id="pod" >}}. Its `key`, `operator`, `value`, and `effect` fields define which {{< glossary_tooltip text="taints" term_id="taint" >}} the Pod tolerates.
 
 <!--more-->
 


### PR DESCRIPTION
### Description

Correct the Taint and Toleration glossary entries so that they no longer describe these properties as core Kubernetes objects. Clarify their main fields and which Taint fields are required while keeping both definitions concise.

This PR was written in part with the assistance of generative AI. I reviewed the changes and take responsibility for their accuracy.

### Issue

Closes: #51383
