### PR TITLE
Update the version data on some SIG Network feature gates

### DIFF
--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableAllocatorDualWrite.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableAllocatorDualWrite.md
@@ -17,6 +17,9 @@ stages:
   - stage: stable
     defaultValue: true
     fromVersion: "1.34"
+    toVersion: "1.38"
+
+removed: true
 
 ---
 You can enable the `MultiCIDRServiceAllocator` feature gate. The API server supports migration

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableNodeKubeProxyVersion.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/DisableNodeKubeProxyVersion.md
@@ -24,7 +24,11 @@ stages:
   - stage: deprecated
     defaultValue: true
     fromVersion: "1.33"
-
+    toVersion: "1.36"
+  - stage: deprecated
+    defaultValue: true
+    locked: true
+    fromVersion: "1.36"
 
 ---
 Disable setting the `kubeProxyVersion` field of the Node.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/MultiCIDRServiceAllocator.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/MultiCIDRServiceAllocator.md
@@ -18,5 +18,8 @@ stages:
     defaultValue: true
     locked: true
     fromVersion: "1.33"
+    toVersion: "1.38"
+
+removed: true
 ---
 Track IP address allocations for Service cluster IPs using IPAddress objects.

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/NFTablesProxyMode.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/NFTablesProxyMode.md
@@ -18,5 +18,8 @@ stages:
     defaultValue: true
     locked: true
     fromVersion: "1.33"
+    toVersion: "1.38"
+
+removed: true
 ---
 Allow running kube-proxy in [nftables mode](/docs/reference/networking/virtual-ips/#proxy-mode-nftables).

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/PreferSameTrafficDistribution.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/PreferSameTrafficDistribution.md
@@ -19,6 +19,9 @@ stages:
   defaultValue: true
   locked: true
   fromVersion: "1.35"
+  toVersion: "1.38"
+
+removed: true
 ---
 Allows usage of the values `PreferSameZone` and `PreferSameNode` in
 the Service [`trafficDistribution`](/docs/reference/networking/virtual-ips/#traffic-distribution)

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/RelaxedDNSSearchValidation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/RelaxedDNSSearchValidation.md
@@ -18,7 +18,9 @@ stages:
     locked: true
     defaultValue: true
     fromVersion: "1.34"
+    toVersion: "1.37"
 
+removed: false
 ---
 Relax the server side validation for the DNS search string
 (`.spec.dnsConfig.searches`) for containers. For example,

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictIPCIDRValidation.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/StrictIPCIDRValidation.md
@@ -13,6 +13,11 @@ stages:
   - stage: beta
     defaultValue: true
     fromVersion: "1.36"
+    toVersion: "1.37"
+  - stage: stable
+    defaultValue: true
+    locked: true
+    fromVersion: "1.38"
 ---
 Use stricter validation for fields containing IP addresses and CIDR values.
 

--- a/content/en/docs/reference/command-line-tools-reference/feature-gates/TopologyAwareHints.md
+++ b/content/en/docs/reference/command-line-tools-reference/feature-gates/TopologyAwareHints.md
@@ -22,6 +22,9 @@ stages:
     defaultValue: true
     locked: true
     fromVersion: "1.33"
+    toVersion: "1.36"
+
+removed: true
 ---
 Enables topology aware routing based on topology hints
 in EndpointSlices. See [Topology Aware


### PR DESCRIPTION
Went to update the `PreferSameTrafficDistribution` feature gate to reflect https://github.com/kubernetes/kubernetes/pull/141733 and discovered that we previously also failed to clean up a bunch of other feature gates...