### PR TITLE
[ko] Translate and update Kubernetes security documentation

### DIFF
--- a/content/ko/docs/concepts/security/_index.md
+++ b/content/ko/docs/concepts/security/_index.md
@@ -2,5 +2,137 @@
 title: "보안"
 weight: 85
 description: >
-  클라우드 네이티브 워크로드를 안전하게 유지하기 위한 개념
+  클라우드 네이티브 워크로드를 안전하게 유지하기 위한 개념.
+simple_list: true
 ---
+
+쿠버네티스 문서의 이 섹션은 워크로드를 더 안전하게 실행하는 방법과
+쿠버네티스 클러스터의 보안을 유지하는 데 필수적인 사항을
+배우는 데 도움을 주는 것을 목표로 한다.
+
+쿠버네티스는 클라우드 네이티브 아키텍처를 기반으로 하며,
+클라우드 네이티브 정보 보안 모범 사례에 대한
+{{< glossary_tooltip text="CNCF" term_id="cncf" >}}의 조언을 따른다.
+
+[클라우드 네이티브 보안과 쿠버네티스](/docs/concepts/security/cloud-native-security/)를 읽고
+클러스터와 그 위에서 실행하는 애플리케이션을 보호하는 방법을
+더 넓은 맥락에서 알아본다.
+
+## 쿠버네티스 보안 메커니즘 {#security-mechanisms}
+
+쿠버네티스는 여러 API와 보안 제어 수단을 제공하며, 정보 보안 관리의 일부로
+사용할 수 있는 [정책](#policies)을 정의하는 방법도 제공한다.
+
+### 컨트롤 플레인 보호 {#control-plane-protection}
+
+모든 쿠버네티스 클러스터의 핵심 보안 메커니즘은
+[쿠버네티스 API에 대한 접근 제어](/docs/concepts/security/controlling-access)이다.
+
+쿠버네티스에서는 컨트롤 플레인 내부 및 컨트롤 플레인과 클라이언트 사이의
+[전송 중 데이터 암호화](/docs/tasks/tls/managing-tls-in-a-cluster/)를 위해
+TLS를 구성하고 사용해야 한다.
+쿠버네티스 컨트롤 플레인에 저장된 데이터의
+[저장 데이터 암호화](/docs/tasks/administer-cluster/encrypt-data/)도 활성화할 수 있다. 이는 자체 워크로드의
+저장 데이터를 암호화하는 것과 별개이며, 워크로드의 데이터 암호화도 고려할 만하다.
+
+### 시크릿 {#secrets}
+
+[시크릿(Secret)](/docs/concepts/configuration/secret/) API는 기밀성이 필요한
+구성 값에 대한 기본적인 보호를 제공한다.
+
+### 워크로드 보호 {#workload-protection}
+
+[파드 시큐리티 표준](/docs/concepts/security/pod-security-standards/)을 적용하여
+파드와 컨테이너를 적절하게 격리한다. 필요한 경우
+[런타임클래스(RuntimeClass)](/docs/concepts/containers/runtime-class)를 사용하여 사용자 정의 격리를
+정의할 수도 있다.
+
+[네트워크 정책](/docs/concepts/services-networking/network-policies/)을 사용하면 파드 간 또는
+파드와 클러스터 외부 네트워크 간의 네트워크 트래픽을 제어할 수 있다.
+
+더 넓은 생태계에서 제공하는 보안 제어 수단을 배포하여 파드, 컨테이너 및 그 안에서
+실행되는 이미지에 대한 예방 또는 탐지 제어를 구현할 수 있다.
+
+### 어드미션 컨트롤 {#admission-control}
+
+[어드미션 컨트롤러](/docs/reference/access-authn-authz/admission-controllers/)는
+쿠버네티스 API 요청을 가로채고, 요청의 특정 필드를 기준으로
+요청을 검증하거나 변형할 수 있는 플러그인이다. 이 컨트롤러를 신중하게 설계하면
+버전 업데이트에 따라 쿠버네티스 API가 변경될 때 의도하지 않은 중단을
+방지하는 데 도움이 된다. 설계 시 고려 사항은
+[어드미션 웹훅 모범 사례](/docs/concepts/cluster-administration/admission-webhooks-good-practices/)를 참고한다.
+
+### 감사 {#auditing}
+
+쿠버네티스 [감사 로깅](/docs/tasks/debug/debug-cluster/audit/)은 클러스터에서 수행된
+작업의 순서를 문서화하는 보안 관련 기록을 시간순으로 제공한다.
+클러스터는 사용자, 쿠버네티스 API를 사용하는 애플리케이션,
+컨트롤 플레인 자체에서 발생한 활동을 감사한다.
+
+## 클라우드 제공자 보안 {#cloud-provider-security}
+
+{{% thirdparty-content vendor="true" %}}
+
+자체 하드웨어나 다른 클라우드 제공자에서 쿠버네티스 클러스터를 실행한다면,
+해당 문서에서 보안 모범 사례를 확인한다.
+다음은 주요 클라우드 제공자의 보안 문서 링크이다.
+
+{{< table caption="클라우드 제공자 보안" >}}
+
+IaaS 제공자        | 링크 |
+-------------------- | ------------ |
+Alibaba Cloud | https://www.alibabacloud.com/trust-center |
+Amazon Web Services | https://aws.amazon.com/security |
+Google Cloud Platform | https://cloud.google.com/security |
+Huawei Cloud | https://www.huaweicloud.com/intl/en-us/securecenter/overallsafety |
+IBM Cloud | https://www.ibm.com/cloud/security |
+Microsoft Azure | https://docs.microsoft.com/en-us/azure/security/azure-security |
+Oracle Cloud Infrastructure | https://www.oracle.com/security |
+Tencent Cloud | https://www.tencentcloud.com/solutions/data-security-and-information-protection |
+VMware vSphere | https://www.vmware.com/solutions/security/hardening-guides |
+
+{{< /table >}}
+
+## 정책 {#policies}
+
+[네트워크폴리시(NetworkPolicy)](/docs/concepts/services-networking/network-policies/)
+(네트워크 패킷 필터링에 대한 선언적 제어)나
+[ValidatingAdmissionPolicy](/docs/reference/access-authn-authz/validating-admission-policy/)
+(쿠버네티스 API를 사용하여 수행할 수 있는 변경에 대한 선언적 제한)와 같은
+쿠버네티스 기본 메커니즘을 사용하여 보안 정책을 정의할 수 있다.
+
+또한 쿠버네티스를 둘러싼 더 넓은 생태계의
+정책 구현을 활용할 수도 있다. 쿠버네티스는 확장 메커니즘을 제공하여
+생태계의 프로젝트가 소스 코드 리뷰, 컨테이너 이미지 승인,
+API 접근 제어, 네트워킹 등에 대한 자체 정책 제어를
+구현할 수 있도록 한다.
+
+정책 메커니즘과 쿠버네티스에 대한 자세한 내용은
+[정책](/docs/concepts/policy/)을 읽는다.
+
+## {{% heading "whatsnext" %}}
+
+관련된 쿠버네티스 보안 주제를 알아본다.
+
+* [클러스터 보안 강화](/docs/tasks/administer-cluster/securing-a-cluster/)
+* 쿠버네티스의 [알려진 취약점](/docs/reference/issues-security/official-cve-feed/)
+  및 추가 정보 링크
+* 컨트롤 플레인의 [전송 중 데이터 암호화](/docs/tasks/tls/managing-tls-in-a-cluster/)
+* [저장 데이터 암호화](/docs/tasks/administer-cluster/encrypt-data/)
+* [쿠버네티스 API에 대한 접근 제어](/docs/concepts/security/controlling-access)
+* 파드의 [네트워크 정책](/docs/concepts/services-networking/network-policies/)
+* [쿠버네티스의 시크릿](/docs/concepts/configuration/secret/)
+* [파드 시큐리티 표준](/docs/concepts/security/pod-security-standards/)
+* [런타임클래스](/docs/concepts/containers/runtime-class)
+
+배경을 알아본다.
+
+<!-- if changing this, also edit the front matter of content/en/docs/concepts/security/cloud-native-security.md to match; check the no_list setting -->
+* [클라우드 네이티브 보안과 쿠버네티스](/docs/concepts/security/cloud-native-security/)
+
+자격증을 취득한다.
+
+* [공인 쿠버네티스 보안 전문가(Certified Kubernetes Security Specialist)](https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/)
+  자격증 및 공식 교육 과정.
+
+이 섹션에서 더 읽어본다.

--- a/content/ko/docs/concepts/security/pod-security-standards.md
+++ b/content/ko/docs/concepts/security/pod-security-standards.md
@@ -1,54 +1,54 @@
 ---
 # reviewers:
-# - 
-title: 파드 시큐리티 스탠다드
+# - tallclair
+title: 파드 시큐리티 표준
 description: >
-  파드 시큐리티 스탠다드에 정의된 여러 가지 정책 레벨에 대한 세부사항
+  파드 시큐리티 표준에 정의된 여러 정책 수준을 자세히 살펴본다.
 content_type: concept
-weight: 10
+weight: 15
 ---
 
 <!-- overview -->
 
-파드 시큐리티 스탠다드에서는 보안 범위를 넓게 다루기 위해 세 가지 _정책을_ 정의한다.
-이러한 정책은 _점증적이며_ 매우 허용적인 것부터 매우 제한적인 것까지 있다.
-이 가이드는 각 정책의 요구사항을 간략히 설명한다.
+파드 시큐리티 표준은 보안 범위를 폭넓게 다루기 위해 세 가지 _정책_ 을
+정의한다. 이 정책은 _누적적_ 이며, 매우 허용적인 수준부터 매우 제한적인 수준까지 있다.
+이 가이드는 각 정책의 요구 사항을 간략히 설명한다.
 
 | 프로필 | 설명 |
 | ------ | ----------- |
-| <strong style="white-space: nowrap">특권(Privileged)</strong> | 무제한 정책으로, 가장 넓은 범위의 권한 수준을 제공한다. 이 정책은 알려진 권한 상승(privilege escalations)을 허용한다. |
-| <strong style="white-space: nowrap">기본(Baseline)</strong> | 알려진 권한 상승을 방지하는 최소한의 제한 정책이다. 기본(최소로 명시된) 파드 구성을 허용한다. |
-| <strong style="white-space: nowrap">제한(Restricted)</strong> | 엄격히 제한된 정책으로 현재 파드 하드닝 모범 사례를 따른다. |
+| <strong style="white-space: nowrap">특권(Privileged)</strong> | 제한이 없는 정책으로, 가능한 가장 넓은 권한 수준을 제공한다. 이 정책은 알려진 권한 상승(privilege escalation)을 허용한다. |
+| <strong style="white-space: nowrap">기본(Baseline)</strong> | 알려진 권한 상승을 방지하는 최소한의 제한 정책이다. 기본(최소한으로 지정된) 파드 구성을 허용한다. |
+| <strong style="white-space: nowrap">제한(Restricted)</strong> | 현재의 파드 보안 강화 모범 사례를 따르는 엄격하게 제한된 정책이다. |
 
 <!-- body -->
 
-## 프로필 세부사항
+## 프로필 상세 {#profile-details}
 
-### 특권(Privileged) {#privileged}
+### 특권 {#privileged}
 
-**_특권_ 정책은 의도적으로 열려있으며 전적으로 제한이 없다.** 이러한 종류의 정책은
-권한이 있고 신뢰할 수 있는 사용자가 관리하는 시스템 및 인프라 수준의 워크로드를 대상으로 한다. 
+**_특권_ 정책은 의도적으로 개방되어 있으며 아무런 제한이 없다.** 이 유형의 정책은
+일반적으로 특권을 가진(privileged), 신뢰할 수 있는 사용자가 관리하는 시스템 및 인프라 수준의 워크로드를 대상으로 한다.
 
-특권 정책은 제한 사항이 없는 것으로 정의한다. 기본으로 허용하는 메커니즘(예를 들면, gatekeeper)은 당연히 특권 정책일 수 있다.
-반대로, 기본적으로 거부하는 메커니즘(예를 들면, 파드 시큐리티 폴리시)의 경우 특권 정책은
-모든 제한 사항을 비활성화해야 한다.
+특권 정책은 제한이 없는 것으로 정의된다. 특권 보안 정책이 적용되는 파드를
+정의하면 해당 파드는 일반적인 컨테이너 격리 메커니즘을 우회할 수 있다.
+예를 들어 노드의 호스트 네트워크에 접근하는 파드를 정의할 수 있다.
 
-### 기본(Baseline) {#baseline}
+### 기본 {#baseline}
 
-**_기본_ 정책은 알려진 권한 상승을 방지하면서 일반적인 컨테이너 워크로드에 대해 정책 채택을 쉽게 하는 것을 목표로 한다.**
-이 정책은 일반적인(non-critical) 애플리케이션의 운영자 및 개발자를 대상으로 한다.
-아래 명시한 제어 방식은 다음과 같이
-강행되거나 금지되어야 한다.
+**_기본_ 정책은 알려진 권한 상승을 방지하면서 일반적인 컨테이너화된 워크로드에
+쉽게 적용할 수 있도록 하는 것을 목표로 한다.** 이 정책은 중요도가 높지 않은 애플리케이션의
+운영자와 개발자를 대상으로 한다. 아래에 나열된 제어 사항을
+적용하거나 금지해야 한다.
 
 {{< note >}}
-다음 표에서 와일드카드(`*`)는 리스트에 포함된 모든 요소들을 가리킨다. 
-예를 들어, `spec.containers[*].securityContext`는 시큐리티 컨텍스트 오브젝트에 _정의되어 있는 모든 컨테이너를_ 가리킨다. 
-정의된 컨테이너 중 하나라도 요구사항을 충족시키지 못한다면, 파드 전체가 
-검증 과정에서 실패한다.
+이 표에서 와일드카드(`*`)는 목록의 모든 요소를 나타낸다. 예를 들어,
+`spec.containers[*].securityContext`는 _정의된 모든 컨테이너_ 의
+시큐리티 컨텍스트 오브젝트를 가리킨다. 나열된 컨테이너 중 하나라도 요구 사항을
+충족하지 못하면 파드 전체의 검증이 실패한다.
 {{< /note >}}
 
 <table>
-	<caption style="display:none">기본(Baseline) 정책 명세서</caption>
+	<caption style="display:none">기본 정책 명세</caption>
 	<tbody>
 		<tr>
 			<th>제어</th>
@@ -57,7 +57,7 @@ weight: 10
 		<tr>
 			<td style="white-space: nowrap">호스트 프로세스</td>
 			<td>
-				<p>윈도우 파드는 <a href="/docs/tasks/configure-pod-container/create-hostprocess-pod">호스트 프로세스 컨테이너</a>를 실행할 권한을 제공하며, 이는 윈도우 노드에 대한 특권 접근을 가능하게 한다. 기본 정책에서의 호스트에 대한 특권 접근은 허용되지 않는다. {{< feature-state for_k8s_version="v1.23" state="beta" >}}</p>
+				<p>윈도우 파드는 윈도우 호스트 머신에 대한 특권 접근을 가능하게 하는 <a href="/docs/tasks/configure-pod-container/create-hostprocess-pod">호스트 프로세스 컨테이너</a>를 실행할 수 있다. 기본 정책에서는 호스트에 대한 특권 접근을 허용하지 않는다. {{< feature-state for_k8s_version="v1.26" state="stable" >}}</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.securityContext.windowsOptions.hostProcess</code></li>
@@ -67,7 +67,7 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>false</code></li>
 				</ul>
 			</td>
@@ -75,7 +75,7 @@ weight: 10
 		<tr>
 			<td style="white-space: nowrap">호스트 네임스페이스</td>
 			<td>
-				<p>호스트 네임스페이스 공유는 금지된다.</p>
+				<p>호스트 네임스페이스 공유를 허용해서는 안 된다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.hostNetwork</code></li>
@@ -84,7 +84,7 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>false</code></li>
 				</ul>
 			</td>
@@ -92,7 +92,7 @@ weight: 10
 		<tr>
 			<td style="white-space: nowrap">특권 컨테이너</td>
 			<td>
-				<p>특권 파드(Privileged Pods)는 대부분의 보안 메커니즘을 비활성화하므로 금지된다.</p>
+				<p>특권 파드는 대부분의 보안 메커니즘을 비활성화하므로 허용해서는 안 된다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.containers[*].securityContext.privileged</code></li>
@@ -101,15 +101,15 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>false</code></li>
 				</ul>
 			</td>
 		</tr>
 		<tr>
-			<td style="white-space: nowrap">기능(Capabilities)</td>
+			<td style="white-space: nowrap">리눅스 기능(Capabilities)</td>
 			<td>
-				<p>아래 명시되지 않은 부가 기능을 추가하는 작업은 금지된다.</p>
+				<p>아래에 나열된 것 이외의 추가 리눅스 기능을 허용해서는 안 된다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.containers[*].securityContext.capabilities.add</code></li>
@@ -118,7 +118,7 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>AUDIT_WRITE</code></li>
 					<li><code>CHOWN</code></li>
 					<li><code>DAC_OVERRIDE</code></li>
@@ -136,23 +136,23 @@ weight: 10
 			</td>
 		</tr>
 		<tr>
-			<td style="white-space: nowrap">호스트 경로(hostPath) 볼륨</td>
+			<td style="white-space: nowrap">HostPath 볼륨</td>
 			<td>
-				<p>호스트 경로 볼륨은 금지된다.</p>
+				<p>HostPath 볼륨은 금지해야 한다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.volumes[*].hostPath</code></li>
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 				</ul>
 			</td>
 		</tr>
 		<tr>
 			<td style="white-space: nowrap">호스트 포트</td>
 			<td>
-				<p>호스트 포트는 허용되지 않아야 하며, 또는 적어도 알려진 목록 범위내로 제한되어야 한다.</p>
+				<p>호스트 포트는 전면 금지하거나(권장), 정해진 목록으로 제한해야 한다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.containers[*].ports[*].hostPort</code></li>
@@ -161,23 +161,70 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
-					<li>Known list</li>
+					<li>미설정/nil</li>
+					<li>정해진 목록(기본 제공 <a href="/docs/concepts/security/pod-security-admission/">파드 시큐리티 어드미션 컨트롤러</a>는 지원하지 않음)</li>
 					<li><code>0</code></li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<td>호스트 프로브 / 라이프사이클 훅(hook) (v1.34+)</td>
+			<td>
+				<p>프로브(probe)와 라이프사이클 훅에서 Host 필드를 허용해서는 안 된다.</p>
+				<p><strong>제한된 필드</strong></p>
+				<ul>
+					<li><code>spec.containers[*].livenessProbe.httpGet.host</code></li>
+					<li><code>spec.containers[*].readinessProbe.httpGet.host</code></li>
+					<li><code>spec.containers[*].startupProbe.httpGet.host</code></li>
+					<li><code>spec.containers[*].livenessProbe.tcpSocket.host</code></li>
+					<li><code>spec.containers[*].readinessProbe.tcpSocket.host</code></li>
+					<li><code>spec.containers[*].startupProbe.tcpSocket.host</code></li>
+					<li><code>spec.containers[*].lifecycle.postStart.tcpSocket.host</code>
+					<li><code>spec.containers[*].lifecycle.preStop.tcpSocket.host</code>
+					<li><code>spec.containers[*].lifecycle.postStart.httpGet.host</code></li>
+					<li><code>spec.containers[*].lifecycle.preStop.httpGet.host</code></li>
+					<li><code>spec.initContainers[*].livenessProbe.httpGet.host</code></li>
+					<li><code>spec.initContainers[*].readinessProbe.httpGet.host</code></li>
+					<li><code>spec.initContainers[*].startupProbe.httpGet.host</code></li>
+					<li><code>spec.initContainers[*].livenessProbe.tcpSocket.host</code></li>
+					<li><code>spec.initContainers[*].readinessProbe.tcpSocket.host</code></li>
+					<li><code>spec.initContainers[*].startupProbe.tcpSocket.host</code></li>
+					<li><code>spec.initContainers[*].lifecycle.postStart.tcpSocket.host</code>
+					<li><code>spec.initContainers[*].lifecycle.preStop.tcpSocket.host</code>
+					<li><code>spec.initContainers[*].lifecycle.postStart.httpGet.host</code></li>
+					<li><code>spec.initContainers[*].lifecycle.preStop.httpGet.host</code></li>
+				</ul>
+				<p><strong>허용된 값</strong></p>
+				<ul>
+					<li>미설정/nil</li>
+					<li>""</li>
 				</ul>
 			</td>
 		</tr>
 		<tr>
 			<td style="white-space: nowrap">AppArmor</td>
 			<td>
-				<p>지원되는 호스트에서는, <code>runtime/default</code> AppArmor 프로필이 기본으로 적용된다. 기본 정책은 기본 AppArmor 프로필이 오버라이드 및 비활성화되는 것을 방지해야 하며, 또는 허용된 프로필에 한해서만 오버라이드 되도록 제한해야 한다.</p>
+				<p>지원되는 호스트에서는 <code>RuntimeDefault</code> AppArmor 프로필이 기본적으로 적용된다. 기본 정책은 기본 AppArmor 프로필의 재정의 또는 비활성화를 방지하거나, 허용된 프로필 집합 내에서만 재정의하도록 제한해야 한다.</p>
 				<p><strong>제한된 필드</strong></p>
+				<ul>
+					<li><code>spec.securityContext.appArmorProfile.type</code></li>
+					<li><code>spec.containers[*].securityContext.appArmorProfile.type</code></li>
+					<li><code>spec.initContainers[*].securityContext.appArmorProfile.type</code></li>
+					<li><code>spec.ephemeralContainers[*].securityContext.appArmorProfile.type</code></li>
+				</ul>
+				<p><strong>허용된 값</strong></p>
+				<ul>
+					<li>미설정/nil</li>
+					<li><code>RuntimeDefault</code></li>
+					<li><code>Localhost</code></li>
+				</ul>
+				<hr />
 				<ul>
 					<li><code>metadata.annotations["container.apparmor.security.beta.kubernetes.io/*"]</code></li>
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>runtime/default</code></li>
 					<li><code>localhost/*</code></li>
 				</ul>
@@ -186,7 +233,7 @@ weight: 10
 		<tr>
 			<td style="white-space: nowrap">SELinux</td>
 			<td>
-				<p>SELinux 타입을 설정하는 것은 제한되며, 맞춤 SELinux 사용자 및 역할 옵션을 설정하는 것은 금지되어 있다.</p>
+				<p>SELinux 타입 설정은 제한되며, 사용자 정의 SELinux 사용자 또는 역할 옵션 설정은 금지된다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.securityContext.seLinuxOptions.type</code></li>
@@ -196,10 +243,11 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/""</li>
+					<li>미설정/""</li>
 					<li><code>container_t</code></li>
 					<li><code>container_init_t</code></li>
 					<li><code>container_kvm_t</code></li>
+					<li><code>container_engine_t</code> (쿠버네티스 1.31부터)</li>
 				</ul>
 				<hr />
 				<p><strong>제한된 필드</strong></p>
@@ -215,14 +263,14 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/""</li>
+					<li>미설정/""</li>
 				</ul>
 			</td>
 		</tr>
 		<tr>
 			<td style="white-space: nowrap"><code>/proc</code> 마운트 타입</td>
 			<td>
-				<p>기본 <code>/proc</code> 마스크는 공격 가능 영역을 최소화하기 위해 설정되고 필수이다.</p>
+				<p>기본 <code>/proc</code> 마스크는 공격 표면을 줄이도록 설정되어 있으므로 반드시 사용하도록 해야 한다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.containers[*].securityContext.procMount</code></li>
@@ -231,16 +279,16 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>Default</code></li>
 				</ul>
 			</td>
 		</tr>
 		<tr>
-  			<td>Seccomp</td>
-  			<td>
-  				<p>Seccomp 프로필은 <code>Unconfined</code>으로 설정하면 안된다.</p>
-  				<p><strong>제한된 필드</strong></p>
+			<td>Seccomp</td>
+			<td>
+				<p>Seccomp 프로필을 명시적으로 <code>Unconfined</code>로 설정해서는 안 된다.</p>
+				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.securityContext.seccompProfile.type</code></li>
 					<li><code>spec.containers[*].securityContext.seccompProfile.type</code></li>
@@ -249,68 +297,73 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>RuntimeDefault</code></li>
 					<li><code>Localhost</code></li>
 				</ul>
-  			</td>
-  		</tr>
+			</td>
+		</tr>
 		<tr>
 			<td style="white-space: nowrap">Sysctls</td>
 			<td>
-				<p>Sysctls는 보안 메커니즘을 비활성화 시키거나 호스트에 위치한 모든 컨테이너에 영향을 미칠 수 있으며, 허용된 "안전한" 서브넷을 제외한 곳에서는 허용되지 않아야 한다. 컨테이너 또는 파드 네임스페이스에 속해 있거나, 같은 노드 내의 다른 파드 및 프로세스와 격리된 상황에서만 sysctl 사용이 안전하다고 간주한다.</p>
+				<p>sysctl은 보안 메커니즘을 비활성화하거나 호스트의 모든 컨테이너에 영향을 줄 수 있으므로, 허용된 "안전한" 일부 항목을 제외하고는 허용하지 않아야 한다. sysctl이 컨테이너나 파드의 네임스페이스에 속하고, 같은 노드의 다른 파드나 프로세스로부터 격리되어 있으면 안전한 것으로 간주한다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.securityContext.sysctls[*].name</code></li>
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>kernel.shm_rmid_forced</code></li>
 					<li><code>net.ipv4.ip_local_port_range</code></li>
 					<li><code>net.ipv4.ip_unprivileged_port_start</code></li>
 					<li><code>net.ipv4.tcp_syncookies</code></li>
 					<li><code>net.ipv4.ping_group_range</code></li>
+					<li><code>net.ipv4.ip_local_reserved_ports</code> (쿠버네티스 1.27부터)</li>
+					<li><code>net.ipv4.tcp_keepalive_time</code> (쿠버네티스 1.29부터)</li>
+					<li><code>net.ipv4.tcp_fin_timeout</code> (쿠버네티스 1.29부터)</li>
+					<li><code>net.ipv4.tcp_keepalive_intvl</code> (쿠버네티스 1.29부터)</li>
+					<li><code>net.ipv4.tcp_keepalive_probes</code> (쿠버네티스 1.29부터)</li>
 				</ul>
 			</td>
 		</tr>
 	</tbody>
 </table>
 
-### 제한(Restricted) {#restricted}
+### 제한 {#restricted}
 
-**_제한_ 정책은 일부 호환성을 희생하면서 현재 사용되고 있는 파드 하드닝 모범 사례 시행하는 것을 목표로 한다.** 
-보안이 중요한 애플리케이션의 운영자 및 개발자는 물론 신뢰도가 낮은 사용자도 대상으로 한다.
-아래에 나열된 제어 방식은
-강제되거나 금지되어야 한다.
+**_제한_ 정책은 일부 호환성을 희생하더라도 현재의 파드 보안 강화 모범 사례를
+적용하는 것을 목표로 한다.** 보안이 중요한 애플리케이션의 운영자와 개발자,
+그리고 신뢰 수준이 낮은 사용자를 대상으로 한다. 아래에 나열된 제어 사항을
+적용하거나 금지해야 한다.
 
 {{< note >}}
-다음 표에서 와일드카드(`*`)는 리스트에 포함된 모든 요소들을 가리킨다. 
-예를 들어, `spec.containers[*].securityContext`는 시큐리티 컨텍스트 오브젝트에 _정의되어 있는 모든 컨테이너를_ 가리킨다. 
-나열된 컨테이너 중 하나라도 요구사항을 충족시키지 못한다면, 파드 전체가 
-검증에 실패한다.
+이 표에서 와일드카드(`*`)는 목록의 모든 요소를 나타낸다. 예를 들어,
+`spec.containers[*].securityContext`는 _정의된 모든 컨테이너_ 의
+시큐리티 컨텍스트 오브젝트를 가리킨다. 나열된 컨테이너 중 하나라도 요구 사항을
+충족하지 못하면 파드 전체의 검증이 실패한다.
 {{< /note >}}
 
 <table>
-	<caption style="display:none">제한 정책 명세서</caption>
+	<caption style="display:none">제한 정책 명세</caption>
 	<tbody>
 		<tr>
 			<td><strong>제어</strong></td>
 			<td><strong>정책</strong></td>
 		</tr>
 		<tr>
-			<td colspan="2"><em>기본 프로필에 해당하는 모든 요소</em></td>
+			<td colspan="2"><em>기본 정책의 모든 항목</em></td>
 		</tr>
 		<tr>
 			<td style="white-space: nowrap">볼륨 타입</td>
 			<td>
-				<p>제한 정책은 다음과 같은 볼륨 타입만 허용한다.</p>
+				<p>제한 정책은 다음 볼륨 타입만 허용한다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.volumes[*]</code></li>
 				</ul>
 				<p><strong>허용된 값</strong></p>
-				<code>spec.volumes[*]</code> 목록에 속한 모든 아이템은 다음 필드 중 하나를 null이 아닌 값으로 설정해야 한다.
+				<code>spec.volumes[*]</code> 목록의 모든 항목은 다음 필드 중 하나를 null이 아닌 값으로 설정해야 한다.
 				<ul>
 					<li><code>spec.volumes[*].configMap</code></li>
 					<li><code>spec.volumes[*].csi</code></li>
@@ -324,9 +377,9 @@ weight: 10
 			</td>
 		</tr>
 		<tr>
-			<td style="white-space: nowrap">권한 상승(v1.8+)</td>
+			<td style="white-space: nowrap">권한 상승 (v1.8+)</td>
 			<td>
-				<p>권한 상승(예를 들어, set-user-ID 또는 set-group-ID 파일 모드를 통한)은 허용되지 않아야 한다. <em>v1.25+에서는 <a href="#policies-specific-to-linux">리눅스 전용 정책이다.</a><code>(spec.os.name != windows)</code></em></p>
+				<p>set-user-ID나 set-group-ID 파일 모드를 통한 권한 상승 등을 허용해서는 안 된다. <em>v1.25 이상에서는 <a href="#os-specific-policy-controls">리눅스 전용 정책이다</a> <code>(spec.os.name != windows)</code></em></p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.containers[*].securityContext.allowPrivilegeEscalation</code></li>
@@ -340,9 +393,9 @@ weight: 10
 			</td>
 		</tr>
 		<tr>
-			<td style="white-space: nowrap">루트가 아닌 권한으로 실행</td>
+			<td style="white-space: nowrap">루트가 아닌 사용자로 실행</td>
 			<td>
-				<p>컨테이너는 루트가 아닌 사용자 권한으로 실행되어야 한다.</p>
+				<p>컨테이너는 반드시 루트가 아닌 사용자로 실행하도록 해야 한다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.securityContext.runAsNonRoot</code></li>
@@ -355,34 +408,34 @@ weight: 10
 					<li><code>true</code></li>
 				</ul>
 				<small>
-					pod-level에서 <code>spec.securityContext.runAsNonRoot</code>가 <code>true</code>로 설정되면
-					컨테이너 필드는 undefined/<code>nil</code>로 설정될 수 있다.
+					파드 수준의 <code>spec.securityContext.runAsNonRoot</code>가
+					<code>true</code>이면 컨테이너 필드는 설정하지 않거나 <code>nil</code>일 수 있다.
 				</small>
 			</td>
 		</tr>
 		<tr>
-			<td style="white-space: nowrap">루트가 아닌 사용자로 실행(v1.23+)</td>
+			<td style="white-space: nowrap">루트가 아닌 사용자로 실행 (v1.23+)</td>
 			<td>
-				<p>컨테이너에서는 <tt>runAsUser</tt> 값을 0으로 설정하지 않아야 한다.</p>
+				<p>컨테이너는 <tt>runAsUser</tt>를 0으로 설정해서는 안 된다.</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.securityContext.runAsUser</code></li>
-					<li><code>spec.containers[*].securityContext.runAsUser</code></li>
+				    <li><code>spec.containers[*].securityContext.runAsUser</code></li>
 					<li><code>spec.initContainers[*].securityContext.runAsUser</code></li>
 					<li><code>spec.ephemeralContainers[*].securityContext.runAsUser</code></li>
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>any non-zero value</li>
+					<li>0이 아닌 모든 값</li>
 					<li><code>undefined/null</code></li>
 				</ul>
 			</td>
 		</tr>
 		<tr>
-  			<td style="white-space: nowrap">Seccomp(v1.19+)</td>
-  			<td>
-  				<p>Seccomp 프로필은 다음과 같은 값으로 설정되어야 한다.<code>Unconfined</code> 프로필 및 프로필의 <em>absence</em>는 금지되어 있다. <em>v1.25+에서는 <a href="#policies-specific-to-linux">리눅스 전용 정책이다.</a><code>(spec.os.name != windows)</code></em></p>
-  				<p><strong>제한된 필드</strong></p>
+			<td style="white-space: nowrap">Seccomp (v1.19+)</td>
+			<td>
+				<p>Seccomp 프로필은 허용된 값 중 하나로 명시적으로 설정해야 한다. <code>Unconfined</code> 프로필과 프로필 <em>미설정</em> 모두 금지된다. <em>v1.25 이상에서는 <a href="#os-specific-policy-controls">리눅스 전용 정책이다</a> <code>(spec.os.name != windows)</code></em></p>
+				<p><strong>제한된 필드</strong></p>
 				<ul>
 					<li><code>spec.securityContext.seccompProfile.type</code></li>
 					<li><code>spec.containers[*].securityContext.seccompProfile.type</code></li>
@@ -395,19 +448,19 @@ weight: 10
 					<li><code>Localhost</code></li>
 				</ul>
 				<small>
-					pod-level의 <code>spec.securityContext.seccompProfile.type</code> 필드가 적절하게 설정되면, 
-					컨테이너 필드는 undefined/<code>nil</code>로 설정될 수 있다.
-					모든 컨테이너 레벨 필드가 설정되어 있다면, 
-					pod-level 필드는 undefined/<code>nil</code>로 설정될 수 있다.
+					파드 수준의 <code>spec.securityContext.seccompProfile.type</code> 필드가
+					적절하게 설정되어 있으면 컨테이너 필드는 설정하지 않거나 <code>nil</code>일 수 있다.
+					반대로 <em>모든</em> 컨테이너 수준 필드가 설정되어 있으면, 파드 수준 필드는
+					설정하지 않거나 <code>nil</code>일 수 있다.
 				</small>
-  			</td>
-  		</tr>
+			</td>
+		</tr>
 		  <tr>
-			<td style="white-space: nowrap">능력(Capabilities) (v1.22+)</td>
+			<td style="white-space: nowrap">리눅스 기능 (v1.22+)</td>
 			<td>
 				<p>
-					컨테이너는 <code>ALL</code> 능력을 내려놓아야 하며, 
-					<code>NET_BIND_SERVICE</code> 능력을 다시 추가하기 위한 목적일 때만 허용되어야 한다. <em>v1.25+에서는 <a href="#policies-specific-to-linux">리눅스 전용 정책이다.</a><code>(spec.os.name != windows)</code></em>
+					컨테이너는 <code>ALL</code>로 모든 리눅스 기능을 제거해야 하며, 다시 추가할 수 있는 것은
+					<code>NET_BIND_SERVICE</code> 기능뿐이다. <em>v1.25 이상에서는 <a href="#os-specific-policy-controls">리눅스 전용 정책이다</a> <code>(.spec.os.name != "windows")</code></em>
 				</p>
 				<p><strong>제한된 필드</strong></p>
 				<ul>
@@ -417,7 +470,7 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li><code>ALL</code>을 포함하고 있는 모든 능력 리스트</li>
+					<li><code>ALL</code>을 포함하는 모든 리눅스 기능 목록</li>
 				</ul>
 				<hr />
 				<p><strong>제한된 필드</strong></p>
@@ -428,7 +481,7 @@ weight: 10
 				</ul>
 				<p><strong>허용된 값</strong></p>
 				<ul>
-					<li>Undefined/nil</li>
+					<li>미설정/nil</li>
 					<li><code>NET_BIND_SERVICE</code></li>
 				</ul>
 			</td>
@@ -436,89 +489,93 @@ weight: 10
 	</tbody>
 </table>
 
-## 정책 초기화
+## 정책 구현 {#policy-instantiation}
 
-정책 초기화에서의 디커플링(Decoupling) 정책 정의는,
-내재되어 있는 시행 메커니즘과 별개로
-클러스터 사이의 공통된 이해와 일관된 정책 언어 사용을 가능하게끔 한다.
+정책 정의와 정책 구현을 분리하면, 실제 적용 메커니즘과
+관계없이 클러스터 전반에서 정책에 대한 공통된 이해와
+일관된 용어를 사용할 수 있다.
 
-메커니즘이 발달함에 따라, 아래와 같이 정책별로 정의가 될 것이다.
-개별 정책에 대한 시행 방식은 여기서 정의하고 있지 않는다.
+메커니즘이 성숙해지면 아래에 정책별로 정의할 것이다. 개별 정책의
+적용 방법은 여기서 정의하지 않는다.
 
-[**파드 시큐리티 어드미션 컨트롤러**](/ko/docs/concepts/security/pod-security-admission/)
+[**파드 시큐리티 어드미션 컨트롤러**](/docs/concepts/security/pod-security-admission/)
 
 - {{< example file="security/podsecurity-privileged.yaml" >}}특권 네임스페이스{{< /example >}}
 - {{< example file="security/podsecurity-baseline.yaml" >}}기본 네임스페이스{{< /example >}}
 - {{< example file="security/podsecurity-restricted.yaml" >}}제한 네임스페이스{{< /example >}}
 
-### 대안
+### 대안 {#alternatives}
 
 {{% thirdparty-content %}}
 
-쿠버네티스 환경에서 정책을 시행하기 위한 대안이 개발되고 있으며 다음은 몇 가지 예시이다. 
+쿠버네티스 생태계에서는 정책 적용을 위한 다음과 같은 다른 대안도 개발되고 있다.
 
 - [Kubewarden](https://github.com/kubewarden)
-- [Kyverno](https://kyverno.io/policies/pod-security/)
+- [Kyverno](https://kyverno.io/policies)
 - [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
 
-## 파드 OS 필드
+## 파드 OS 필드 {#pod-os-field}
 
-쿠버네티스에서는 리눅스 또는 윈도우를 실행하는 노드를 사용할 수 있다.
-하나의 클러스터에 두 종류의 노드를 혼합하여 사용할 수 있다.
-윈도우 환경 쿠버네티스는 리눅스 기반 워크로드와 비교하였을 때 몇 가지 제한사항 및 차별점이 있다.
-구체적으로 말하자면, 대부분의 파드 `securityContext` 필드는 
-[윈도우 환경에서 효과가 없다](/ko/docs/concepts/windows/intro/#compatibility-v1-pod-spec-containers-securitycontext).
+쿠버네티스에서는 리눅스 또는 윈도우를 실행하는 노드를 사용할 수 있다. 한 클러스터에서
+두 종류의 노드를 함께 사용할 수도 있다.
+쿠버네티스의 윈도우 워크로드에는 리눅스 기반 워크로드와 다른 몇 가지 제한과
+차이점이 있다. 특히 파드의 `securityContext` 필드 중 다수는
+[윈도우에서 효과가 없다](/docs/concepts/windows/intro/#compatibility-v1-pod-spec-containers-securitycontext).
 
 {{< note >}}
-v1.24 이전 Kubelet은 파드 OS 필드를 필수로 요구하지 않으며, 만일 클러스터 내에 v1.24 이전에 해당하는 노드가 있다면 v1.25 이전 버전의 제한 정책을 적용해야 한다.
+v1.24 이전의 kubelet은 파드 OS 필드를 적용하지 않으므로, 클러스터에 v1.24 이전 버전의 노드가 있다면 제한 정책을 v1.25 이전 버전으로 고정해야 한다.
 {{< /note >}}
 
-### 제한 파드의 시큐리티 스탠다드 변화
-쿠버네티스 v1.25에서 나타난 또 다른 중요 변화는, _제한_ 파드 시큐리티가 `pod.spec.os.name` 필드를 사용하도록 업데이트 되었다는 것이다.
-특정 OS에 특화된 일부 정책은 OS 이름에 근거하여 
-다른 OS에 대해서는 완화될 수 있다
+### 제한 파드 시큐리티 표준의 변경 사항 {#restricted-pod-security-standard-changes}
+쿠버네티스 v1.25의 또 다른 중요한 변경 사항은 _제한_ 정책이
+`pod.spec.os.name` 필드를 사용하도록 업데이트되었다는 점이다. OS 이름을 기준으로,
+특정 OS에만 해당하는 정책은 다른 OS에서 완화할 수 있다.
 
-
-#### 특정 OS 정책 제어
-`spec.os.name`의 값이 `windows`가 아닐 시에만 다음 제어 항목에 대한 제한 사항이 요구된다.
+#### OS별 정책 제어 {#os-specific-policy-controls}
+다음 제어 사항에 대한 제한은 `.spec.os.name`이 `windows`가 아닌 경우에만 필요하다.
 - 권한 상승
 - Seccomp
-- Linux 기능
+- 리눅스 기능
 
-## FAQ
+## 사용자 네임스페이스 {#user-namespaces}
 
-### 왜 특권 프로필과 기본 프로필 사이의 프로필은 없는 것인가?
+사용자 네임스페이스는 격리 수준을 높여 워크로드를 실행하는
+리눅스 전용 기능이다. 파드 시큐리티 표준과 함께 동작하는 방식은
+사용자 네임스페이스를 사용하는 파드의 [문서](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces#integration-with-pod-security-admission-checks)에 설명되어 있다.
 
-여기서 정의된 세 가지 프로필은 가장 높은 보안에서(제한 프로필) 가장 낮은 보안까지(특권 프로필)
-명백한 선형 관계를 가지며 넓은 범위의 워크로드를 다룬다. 
-기본 정책을 넘는 요청 권한은 일반적으로 애플리케이션 전용에 속하므로 이러한 틈새시장에 대해서는 표준 프로필을 제공하지 않는다.
-이 경우에는 항상 특권 프로필을 사용해야 한다는 주장은 아니지만, 
-해당 영역의 정책은 케이스 별로 정의되어야 한다는 것이다.
+## 자주 묻는 질문 {#faq}
 
-이외 프로필이 분명히 필요하다면 SIG Auth는 향후에 이러한 입장을 재고할 수 있다. 
+### 특권과 기본 사이의 프로필이 없는 이유는 무엇인가? {#why-isn-t-there-a-profile-between-privileged-and-baseline}
 
-### 시큐리티 컨텍스트와 시큐리티 프로필의 차이점은 무엇인가?
+여기에 정의된 세 프로필은 가장 안전한 수준(제한)에서 가장 덜 안전한
+수준(특권)까지 명확한 선형 단계를 이루며, 다양한 워크로드를 포괄한다. 기본 정책을
+넘어서는 권한 요구 사항은 일반적으로 애플리케이션에 매우 특화되어 있으므로,
+이 영역에는 표준 프로필을 제공하지 않는다. 그렇다고 이 경우 항상 특권 프로필을
+사용해야 한다는 의미는 아니며, 각 상황에 맞게 정책을 정의해야 한다는 의미이다.
 
-[시큐리티 컨텍스트](/docs/tasks/configure-pod-container/security-context/)는 파드 및 컨테이너를 런타임에 설정한다. 
-시큐리티 컨텍스트는 파드 매니페스트 내 
-파드 및 컨테이너 명세의 일부로 정의되고 컨테이너 런타임에 파라미터로 제공한다. 
+다른 프로필에 대한 명확한 필요가 생기면 SIG Auth는 향후 이 입장을 재검토할 수 있다.
 
-시큐리티 프로필은 컨트롤 플레인 메커니즘으로, 시큐리티 컨텍스트의 상세 설정을 비롯하여 
-시큐리티 컨텍스트 외부의 다른 관련된 파라미터도 적용한다.
-2021년 7월부로, [파드 시큐리티 폴리시](/ko/docs/concepts/security/pod-security-policy/)는 
-내장된 [파드 시큐리티 어드미션 컨트롤러](/ko/docs/concepts/security/pod-security-admission/)에 의해 대체되어 사용이 중단되었다. 
+### 보안 프로필과 시큐리티 컨텍스트의 차이는 무엇인가? {#what-s-the-difference-between-a-security-profile-and-a-security-context}
+
+[시큐리티 컨텍스트](/docs/tasks/configure-pod-container/security-context/)는 런타임에서 파드와
+컨테이너를 구성한다. 시큐리티 컨텍스트는 파드 매니페스트의 파드 및 컨테이너 명세의
+일부로 정의되며, 컨테이너 런타임에 전달할 파라미터를 나타낸다.
+
+보안 프로필은 시큐리티 컨텍스트의 특정 설정과 그 밖의 관련 파라미터를
+강제하는 컨트롤 플레인 메커니즘이다. 2021년 7월부로,
+[파드 시큐리티 폴리시](/docs/concepts/security/pod-security-policy/)는 사용 중단(deprecated)되었으며,
+기본 제공 [파드 시큐리티 어드미션 컨트롤러](/docs/concepts/security/pod-security-admission/)로 대체되었다.
 
 
-### 샌드박스 파드는 어떠한가?
+### 샌드박스 파드는 어떻게 다루는가? {#what-about-sandboxed-pods}
 
-현재로서는, 파드가 샌드박스 특성을 가지는지 제어할 수 있는 API 표준이 존재하지 않는다.
-샌드박스 파드는 샌드박스 런타임(예를 들면, gVisor 혹은 Kata 컨테이너)을 통해 식별할 수 있지만, 
-샌드박스 런타임이 무엇인지에 대한 표준 정의는 없는 상태이다.
+현재 파드가 샌드박스(sandbox)에서 실행되는 것으로 간주할지 제어하는 API
+표준은 없다. gVisor나 Kata Containers와 같은 샌드박스 런타임의 사용 여부로
+샌드박스 파드를 식별할 수 있지만, 샌드박스 런타임에 대한 표준 정의는 없다.
 
-샌드박스 워크로드가 필요로하는 보호물은 다른 워크로드와 다를 수 있다.
-예를 들어, 내재된 커널과 분리된 워크로드에서는 제한된 특수 권한의 필요성이 적어진다.
-이는 높아진 권한을 요구하는 워크로드가 분리될 수 있도록 허용한다.
+샌드박스 워크로드에 필요한 보호는 다른 워크로드와 다를 수 있다. 예를 들어,
+워크로드가 기반 커널과 격리되어 있으면 특권을 제한할 필요성이
+줄어든다. 이를 통해 높은 권한이 필요한 워크로드도 격리된 상태로 실행할 수 있다.
 
-추가적으로, 샌드박스 방식에 따라 샌드박스 워크로드에 대한 보호가 달라진다.
-이와 같은 경우에는, 하나의 프로필만을 모든 샌드박스 워크로드에 대해 권장할 수 없다.
-
+또한 샌드박스 워크로드의 보호 수준은 샌드박스 구현 방식에 크게
+의존한다. 따라서 모든 샌드박스 워크로드에 권장할 수 있는 단일 프로필은 없다.

--- a/content/ko/docs/concepts/security/service-accounts.md
+++ b/content/ko/docs/concepts/security/service-accounts.md
@@ -1,217 +1,217 @@
 ---
 title: 서비스 어카운트
 description: >
-  쿠버네티스 서비스어카운트 오브젝트에 대해 배운다.
+  쿠버네티스의 서비스어카운트(ServiceAccount) 오브젝트에 대해 알아본다.
 api_metadata:
 - apiVersion: "v1"
-  kind: "ServiceAccount"  
+  kind: "ServiceAccount"
 content_type: concept
 weight: 25
 ---
 
 <!-- overview -->
 
-이 페이지는 쿠버네티스 서비스어카운트(ServiceAccount) 오브젝트를 소개하면서, 서비스 어카운트의
-동작 방식, 사용 사례, 제한 사항, 대안,
-그리고 추가 안내를 위한 자료 링크에 대한 정보를 제공한다.
+이 페이지는 쿠버네티스의 서비스어카운트 오브젝트를 소개하고,
+서비스 어카운트의 동작 방식, 유스케이스, 제한 사항,
+대안 및 추가 지침을 위한 자료 링크를 제공한다.
 
 <!-- body -->
 
-## 서비스 어카운트란 무엇인가? {#what-are-service-accounts}
+## 서비스 어카운트란? {#what-are-service-accounts}
 
-서비스 어카운트란 사람이 사용하지 않는 계정으로, 쿠버네티스
-클러스터 내에서 구분되는 신원을 제공한다. 애플리케이션 파드, 시스템
-컴포넌트, 그리고 클러스터 내부와 외부의 엔티티들은 특정
-서비스어카운트(ServiceAccount)의 자격 증명을 사용하여 해당 서비스어카운트(ServiceAccount)로 식별될 수 있다. 이러한 신원은
-API 서버에 대한 인증이나 신원 기반의 보안 정책을 구현하는 등
-다양한 상황에서 유용하다.
+서비스 어카운트는 사람이 아닌 주체를 위한 계정 유형으로, 쿠버네티스
+클러스터에서 구별되는 신원을 제공한다. 애플리케이션 파드, 시스템
+컴포넌트, 클러스터 내부와 외부의 주체는 특정 서비스어카운트의
+자격 증명을 사용하여 해당 서비스어카운트로 자신을 식별할 수 있다. 이 신원은
+API 서버에 대한 인증이나 신원 기반 보안 정책 구현을 비롯한
+여러 상황에서 유용하다.
 
-서비스 어카운트는 API 서버 내에서 서비스어카운트(ServiceAccount) 오브젝트로 존재한다. 서비스
-어카운트는 다음과 같은 속성을 가진다.
+서비스 어카운트는 API 서버에 서비스어카운트 오브젝트로 존재한다. 서비스
+어카운트에는 다음과 같은 특성이 있다.
 
 * **네임스페이스 범위:** 각 서비스 어카운트는 쿠버네티스
-  {{<glossary_tooltip text="네임스페이스" term_id="namespace">}}에 속한다. 모든 네임스페이스는
-  생성될 때 [`default` 서비스어카운트(ServiceAccount)](#default-service-accounts)를 자동으로 가진다.
+  {{<glossary_tooltip text="네임스페이스" term_id="namespace">}}에 바인딩된다. 모든 네임스페이스에는
+  생성 시 [`default` 서비스어카운트](#default-service-accounts)가 생긴다.
 
-* **경량성:** 서비스 어카운트는 클러스터 내에 존재하며
-  쿠버네티스 API에 의해 정의된다. 특정 작업을 수행할 수 있도록 서비스 어카운트를
-  빠르게 생성할 수 있다.
+* **경량:** 서비스 어카운트는 클러스터 내에 존재하며
+  쿠버네티스 API에 정의된다. 특정 작업을 수행할 수 있도록
+  서비스 어카운트를 빠르게 생성할 수 있다.
 
-* **이식성:** 복잡하게 컨테이너화된 워크로드의
-  구성 번들에는 시스템 컴포넌트를 위한 서비스 어카운트 정의가 포함될 수 있다. 서비스 어카운트는
-  가볍고 네임스페이스 단위로 구분되기 때문에
-  이러한 구성을 손쉽게 다른 환경에서도 사용할 수 있다.
+* **이식 가능:** 복잡한 컨테이너화된 워크로드의 구성 묶음에는
+  시스템 컴포넌트의 서비스 어카운트 정의가 포함될 수 있다.
+  서비스 어카운트의 경량 특성과 네임스페이스에 속하는 신원 덕분에
+  구성을 이식할 수 있다.
 
-서비스 어카운트는 클러스터 내에서 인증된 사용자 계정인
-유저 어카운트와는 다르다. 기본적으로, 유저 어카운트는 쿠버네티스 API 서버에 존재하지 않으며,
-API 서버는 사용자 신원을 불투명한 데이터로
-취급한다. 사용자 계정으로 인증하는 여러 가지 방법이 있다. 일부
-쿠버네티스 버전은 API 서버에 유저 어카운트를 표현하기 위해 커스텀 확장 API를
-추가하기도 한다.
+서비스 어카운트는 클러스터에서 인증된 사람을 나타내는 사용자 계정과
+다르다. 기본적으로 사용자 계정은 쿠버네티스 API 서버에 존재하지
+않으며, 대신 API 서버는 사용자 신원을 의미를 해석하지 않는
+데이터로 처리한다. 여러 방법으로 사용자 계정으로 인증할 수 있다. 일부
+쿠버네티스 배포판은 API 서버에서 사용자 계정을 나타내기 위해
+사용자 정의 확장 API를 추가할 수 있다.
 
-{{< table caption="서비스 어카운트와 유저 비교" >}}
+{{< table caption="서비스 어카운트와 사용자 비교" >}}
 
-| 설명 | 서비스어카운트(ServiceAccount) | 유저 혹은 그룹 |
+| 설명 | 서비스어카운트 | 사용자 또는 그룹 |
 | --- | --- | --- |
-| 위치 | 쿠버네티스 API 서비스어카운트 오브젝트(ServiceAccount object) | 외부 |
+| 위치 | 쿠버네티스 API(서비스어카운트 오브젝트) | 외부 |
 | 접근 제어 | 쿠버네티스 RBAC 또는 기타 [인가 메커니즘](/docs/reference/access-authn-authz/authorization/#authorization-modules) | 쿠버네티스 RBAC 또는 기타 신원 및 접근 관리 메커니즘 |
-| 사용 목적 | 워크로드, 자동화 | 사람 |
+| 용도 | 워크로드, 자동화 | 사람 |
 
 {{< /table >}}
 
 ### 기본 서비스 어카운트 {#default-service-accounts}
 
-클러스터를 생성하면, 쿠버네티스는 클러스터의 각 네임스페이스에 `default`라는 이름의 서비스어카운트(ServiceAccount)
-오브젝트를 자동으로 생성한다. 각 네임스페이스의 `default`
-서비스 어카운트는 역할 기반 접근 제어(RBAC)가 활성화된 경우 쿠버네티스가 모든 인증된 주체에게 부여하는
-[기본 API 검색 권한](/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings)
-외에는 기본 권한을 가지지 않는다.
-만약 특정 네임스페이스에서 `default` 서비스어카운트(ServiceAccount)를 삭제한다면,
+클러스터를 생성하면 쿠버네티스는 클러스터의 모든 네임스페이스에 `default`라는
+서비스어카운트 오브젝트를 자동으로 생성한다. 각 네임스페이스의 `default`
+서비스 어카운트에는 역할 기반 접근 제어(RBAC)가 활성화된 경우 쿠버네티스가 인증된 모든 주체에
+부여하는 [기본 API 디스커버리 권한](/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings)
+외에는 기본적으로 아무런 권한도 없다.
+네임스페이스의 `default` 서비스어카운트 오브젝트를 삭제하면,
 {{< glossary_tooltip text="컨트롤 플레인" term_id="control-plane" >}}이
-새로운 것으로 대체한다.
+새 오브젝트로 대체한다.
 
-네임스페이스에 파드를 배포할 때,
-[서비스어카운트(ServiceAccount)를 파드에 수동으로 할당](#assign-to-pod)하지 않으면, 쿠버네티스는
-해당 네임스페이스의 `default` 서비스어카운트(ServiceAccount)를 파드에 자동으로 할당한다.
+네임스페이스에 파드를 배포할 때
+[서비스어카운트를 파드에 수동으로 할당](#assign-to-pod)하지 않으면, 쿠버네티스는
+해당 네임스페이스의 `default` 서비스어카운트를 파드에 할당한다.
 
-## 쿠버네티스 서비스 어카운트 사용 사례 {#use-cases}
+## 쿠버네티스 서비스 어카운트의 유스케이스 {#use-cases}
 
-일반적인 지침으로서 다음과 같은 상황에서 서비스 어카운트를 사용하여
-신원을 부여할 수 있다.
+일반적인 지침으로, 다음과 같은 상황에서 서비스 어카운트를 사용하여
+신원을 제공할 수 있다.
 
-* 파드가 쿠버네티스 API 서버와 통신해야 하는 경우, 예를 들어
+* 파드가 쿠버네티스 API 서버와 통신해야 하는 경우. 예를 들어
   다음과 같은 상황이 있다.
-  * 시크릿에 저장된 민감한 정보에 읽기 전용으로 접근하는 경우.
-  * [네임스페이스 간 접근](#cross-namespace)을 허용하는 경우, 예를 들어
-    `example` 네임스페이스의 파드가 `kube-node-lease` 네임스페이스의 리스(Lease) 오브젝트를
-    read, list, 그리고 watch 할 수 있도록 하는 경우.
-  * 파드가 외부의 서비스와 통신해야 하는 경우. 예를 들어,
-    워크로드 파드가 상용 클라우드 API를 위한 신원이 필요하고,
-    해당 상용 제공자가 적절한 신뢰 관계 구성을 허용하는 경우.
-  * [`imagePullSecret`을 사용하여 프라이빗 이미지 레지스트리에 인증하는 경우](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account).
-  * 외부 서비스가 쿠버네티스 API 서버와 통신해야 하는 경우. 예를
-    들어, CI/CD 파이프라인의 일부로서 클러스터에 인증해야 하는 경우
-  * 클러스터에서 서드파티 보안 소프트웨어를 사용하는 경우. 이 소프트웨어는
-    다른 파드의 서비스어카운트(ServiceAccount) 신원에 의존하여 파드들을 서로 다른 컨텍스트로
-    그룹화한다.
+  * 시크릿(Secret)에 저장된 민감한 정보에 대한 읽기 전용 접근 제공.
+  * `example` 네임스페이스의 파드가 `kube-node-lease` 네임스페이스의
+    리스(Lease) 오브젝트를 읽고, 나열하고, 감시할 수 있도록 허용하는 등의
+    [네임스페이스 간 접근](#cross-namespace) 권한 부여.
+* 파드가 외부 서비스와 통신해야 하는 경우. 예를 들어,
+  워크로드 파드에 상용 클라우드 API용 신원이 필요하고,
+  해당 제공자가 적절한 신뢰 관계를 구성할 수 있도록 허용하는 경우이다.
+* [`imagePullSecret`을 사용하여 비공개 이미지 레지스트리에 인증하는 경우](/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account).
+* 외부 서비스가 쿠버네티스 API 서버와 통신해야 하는 경우. 예를 들어,
+  CI/CD 파이프라인의 일부로 클러스터에 인증하는 경우이다.
+* 클러스터에서 여러 파드의 서비스어카운트 신원을 기준으로
+  파드를 서로 다른 컨텍스트로 그룹화하는
+  서드파티 보안 소프트웨어를 사용하는 경우.
 
 ## 서비스 어카운트 사용 방법 {#how-to-use}
 
-쿠버네티스 서비스 어카운트를 사용하려면, 다음을 따른다.
+쿠버네티스 서비스 어카운트를 사용하려면 다음을 수행한다.
 
-1. `kubectl`과 같은 쿠버네티스 클라이언트나 오브젝트를 정의한
-   매니페스트를 사용하여 서비스어카운트(ServiceAccount) 오브젝트를 생성한다.
-1. [RBAC](/docs/reference/access-authn-authz/rbac/)과
-   같은 인가 매커니즘을 사용하여
-   서비스어카운트(ServiceAccount) 오브젝트에 권한을 부여한다.
-1. 파드를 생성할 때 서비스어카운트(ServiceAccount) 오브젝트를 파드에 할당한다.
+1. `kubectl`과 같은 쿠버네티스 클라이언트나
+   오브젝트를 정의하는 매니페스트로 서비스어카운트 오브젝트를 생성한다.
+1. [RBAC](/docs/reference/access-authn-authz/rbac/)과 같은
+   인가 메커니즘을 사용하여
+   서비스어카운트 오브젝트에 권한을 부여한다.
+1. 파드 생성 시 서비스어카운트 오브젝트를 파드에 할당한다.
 
-   외부 서비스의 신원을 사용하는 경우,
-   [서비스어카운트(ServiceAccount) 토큰을 가져와](#get-a-token) 해당 서비스에서
-   대신 사용한다.
-  
-자세한 지침은,
-[파드를 위한 서비스 어카운트 구성](/docs/tasks/configure-pod-container/configure-service-account/)을 참고한다.
-
-### 서비스어카운트(ServiceAccount)에 대한 권한 부여 {#grant-permissions}
-
-쿠버네티스에 내장된
-[역할 기반 접근 제어(RBAC)](/docs/reference/access-authn-authz/rbac/)
-매커니즘을 활용하면 각 서비스 어카운트에 필요한 최소한의 권한을 부여할 수 있다.
-먼저 접근 권한을 정의하는 *role*을 생성하고, 이를 서비스어카운트(ServiceAccount)에
-*바인딩*한다. RBAC을 사용하면 최소 권한 원칙에 따라
-서비스 어카운트의 권한을 정의할 수 있다. 따라서 해당 서비스 어카운트를 사용하는 파드는
-올바르게 동작하는 데 필요한 권한 이상을
-가지지 않는다.
+   외부 서비스에서 이 신원을 사용하는 경우에는,
+   대신 [서비스어카운트 토큰을 가져와](#get-a-token)
+   해당 서비스에서 사용한다.
 
 자세한 지침은
-[서비스어카운트(ServiceAccount) 권한](/docs/reference/access-authn-authz/rbac/#service-account-permissions)을 참고한다.
+[파드를 위한 서비스 어카운트 구성](/docs/tasks/configure-pod-container/configure-service-account/)을 참고한다.
 
-#### 서비스어카운트(ServiceAccount)를 이용한 네임스페이스 간 접근 {#cross-namespace}
+### 서비스어카운트에 권한 부여하기 {#grant-permissions}
 
-RBAC을 사용하면 하나의 네임스페이스에 있는 서비스 어카운트가 클러스터 내
-다른 네임스페이스의 리소스에 대해 작업을 수행할 수 있도록 허용할 수 있다. 예를 들어, `dev` 네임스페이스에
-서비스 어카운트와 파드가 있고 해당 파드가 `maintenance` 네임스페이스에서
-실행 중인 잡(Job)을 확인하고 싶어하는 시나리오를 생각해보자. 이 경우
-잡 오브젝트를 나열할 수 있는 권한을 부여하는 롤(Role) 오브젝트를 생성한다. 그리고,
-`maintenance` 네임스페이스에서 해당 롤(Role)과 서비스어카운트(ServiceAccount) 오브젝트를 바인딩하는
-롤바인딩(RoleBinding) 오브젝트를 생성한다. 이제, `dev` 네임스페이스의 파드는 해당 서비스 어카운트를 사용해
-`maintenance` 네임스페이스의 잡 오브젝트를 나열할 수 있다.
+쿠버네티스에 기본 제공되는
+[역할 기반 접근 제어(RBAC)](/docs/reference/access-authn-authz/rbac/)
+메커니즘을 사용하여 각 서비스 어카운트에 필요한 최소 권한을 부여할 수 있다.
+접근 권한을 부여하는 *롤(Role)* 을 생성한 후, 이 롤을
+서비스어카운트에 *바인딩*한다. RBAC을 사용하면 서비스 어카운트의 권한이
+최소 권한 원칙을 따르도록 최소한의 권한 집합을 정의할 수 있다.
+해당 서비스 어카운트를 사용하는 파드는 올바르게 동작하는 데
+필요한 것보다 많은 권한을 받지 않는다.
 
-#### 파드에 서비스어카운트(ServiceAccount) 할당하기 {#assign-to-pod}
+자세한 지침은
+[서비스어카운트 권한](/docs/reference/access-authn-authz/rbac/#service-account-permissions)을 참고한다.
 
-파드에 서비스어카운트(ServiceAccount)를 할당하려면, 파드 명세에 `spec.serviceAccountName`
-필드를 설정한다. 그러면 쿠버네티스는 해당 서비스어카운트(ServiceAccount)의
-자격 증명을 자동으로 파드에 제공한다. v1.22 이상에서는, 쿠버네티스가
-`TokenRequest` API를 사용하여 **자동으로 갱신되는** 단기 토큰을 발급받아 이를
-[프로젝티드 볼륨](/docs/concepts/storage/projected-volumes/#serviceaccounttoken)으로
-파드에 마운트한다.
+#### 서비스어카운트를 사용한 네임스페이스 간 접근 {#cross-namespace}
 
-기본적으로 쿠버네티스는 
-`default` 서비스어카운트(ServiceAccount)든, 사용자가 지정한 커스텀 서비스어카운트(ServiceAccount)든
-파드에 할당된 서비스어카운트(ServiceAccount)의 자격 증명을 제공한다.
+RBAC을 사용하면 한 네임스페이스의 서비스 어카운트가 클러스터 내 다른
+네임스페이스의 리소스에 대해 작업을 수행하도록 허용할 수 있다. 예를 들어,
+`dev` 네임스페이스에 서비스 어카운트와 파드가 있고, 파드에서
+`maintenance` 네임스페이스에서 실행 중인 잡(Job)을 보려고 한다고 가정한다.
+잡 오브젝트를 나열할 권한을 부여하는 롤 오브젝트를 생성할 수 있다. 그런 다음
+`maintenance` 네임스페이스에 롤바인딩(RoleBinding) 오브젝트를 생성하여
+롤을 서비스어카운트 오브젝트에 바인딩한다. 이제 `dev` 네임스페이스의 파드는 해당
+서비스 어카운트로 `maintenance` 네임스페이스의 잡 오브젝트를 나열할 수 있다.
 
-특정 서비스어카운트(ServiceAccount)나 `default` 서비스어카운트(ServiceAccount)의 자격 증명이
-자동으로 주입되지 않도록 하려면,
-파드 명세에서 `automountServiceAccountToken` 필드를 `false`로 설정해야 한다.
+### 파드에 서비스어카운트 할당하기 {#assign-to-pod}
 
-<!-- 쿠버네티스 1.31이 릴리스된 이후에는 이 과거 버전에 대한 설명은 삭제해도 된다 -->
+파드에 서비스어카운트를 할당하려면 파드 명세의 `spec.serviceAccountName`
+필드를 설정한다. 그러면 쿠버네티스가 해당 서비스어카운트의
+자격 증명을 파드에 자동으로 제공한다. v1.22 이상에서 쿠버네티스는
+`TokenRequest` API로 유효 기간이 짧고 **자동으로 교체되는** 토큰을
+받아, 이를
+[프로젝티드 볼륨](/docs/concepts/storage/projected-volumes/#serviceaccounttoken)으로 마운트한다.
 
-v1.22 이전 버전에서는, 쿠버네티스가 시크릿(Secret)을 통해 파드에 장기간 유효한 정적 토큰을
-제공했었다.
+기본적으로 쿠버네티스는 파드에 할당된 서비스어카운트가
+`default` 서비스어카운트이든 사용자가 지정한 서비스어카운트이든
+해당 자격 증명을 파드에 제공한다.
 
-#### 서비스어카운트(ServiceAccount) 자격 증명 수동으로 가져오기 {#get-a-token}
+쿠버네티스가 지정된 서비스어카운트나 `default` 서비스어카운트의
+자격 증명을 자동으로 주입하지 못하도록 하려면, 파드 명세의
+`automountServiceAccountToken` 필드를 `false`로 설정한다.
 
-서비스어카운트(ServiceAccount)의 자격 증명을 API 서버가 아닌 다른 대상에서 사용하거나,
-기본이 아닌 위치에 마운트해야 하는 경우에는 다음 방법 중
+<!-- OK to remove this historical detail after Kubernetes 1.31 is released -->
+
+v1.22 이전 버전에서는 쿠버네티스가 유효 기간이 긴 정적 토큰을
+시크릿으로 파드에 제공한다.
+
+#### 서비스어카운트 자격 증명 수동으로 가져오기 {#get-a-token}
+
+서비스어카운트 자격 증명을 표준 위치 이외의 위치에 마운트하거나,
+API 서버가 아닌 오디언스(audience)에 사용해야 한다면, 다음 방법 중
 하나를 사용한다.
 
-* [토큰리퀘스트 API](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
-  (권장): *애플리케이션 코드* 내에서 단기 서비스 어카운트
-  토큰을 요청한다. 이 토큰은 자동으로 만료되며 만료 시
-  갱신될 수 있다.
-  쿠버네티스를 인식하지 못하는 레거시 애플리케이션이 있는 경우, 동일한
-  파드 내에서 사이드카 컨테이너를 사용해 이러한 토큰을 가져와
-  애플리케이션 워크로드에서 사용할 수 있도록 만들 수 있다.
+* [TokenRequest API](/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)
+  (권장): 자체 *애플리케이션 코드* 내에서 유효 기간이 짧은
+  서비스 어카운트 토큰을 요청한다. 토큰은 자동으로 만료되며 만료 시
+  교체할 수 있다.
+  쿠버네티스를 인식하지 못하는 레거시 애플리케이션이 있다면, 동일한
+  파드 내의 사이드카(sidecar) 컨테이너로 이 토큰을 가져와
+  애플리케이션 워크로드에 제공할 수 있다.
 * [토큰 볼륨 프로젝션](/docs/tasks/configure-pod-container/configure-service-account/#serviceaccount-token-volume-projection)
-  (권장): 쿠버네티스 v1.20 이상에서는, 파드 명세를 사용하여
+  (역시 권장): 쿠버네티스 v1.20 이상에서는 파드 명세를 사용하여
   kubelet이 서비스 어카운트 토큰을 파드에
-  *프로젝티드 볼륨*으로 추가하도록 지정할 수 있다. 프로젝션된 토큰은 자동으로 만료되며, kubelet이
-  만료 전에 토큰을 갱신한다.
+  *프로젝티드 볼륨*으로 추가하도록 지정한다. 프로젝션된 토큰은 자동으로 만료되며, kubelet은
+  만료되기 전에 토큰을 교체한다.
 * [서비스 어카운트 토큰 시크릿](/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount)
-  (권장하지 않음): 서비스 어카운트 토큰을 파드 내 쿠버네티스 시크릿에
-  마운트할 수도 있다. 하지만 이 토큰들은 만료되지 않고 회전도 이루어지지 않는다. v1.24 이전 버전에서는, 각 서비스 어카운트마다 영구 토큰이 자동으로 생성되었다.
-  정적이고 장기간 유효한 자격 증명과 관련된 보안 위험 때문에, 특히 규모가 큰 환경에서는
-  이 방법을 더이상 권장하지 않는다. [LegacyServiceAccountTokenNoAutoGeneration 기능 게이트](/docs/reference/command-line-tools-reference/feature-gates-removed)는
-  (쿠버네티스 v1.24부터 v1.26까지 기본적으로 활성화되어 있었으며), 서비스 어카운트에 대해 이러한 토큰이 자동 생성되지
-  않도록 했다. 해당 기능 게이트는 v1.27에서 GA로 승격되면서 제거되었고, 여전히 무기한의 서비스 어카운트 토큰을 수동으로 생성할 수 있지만, 반드시 보안상의 영향을 고려해야 한다.
+  (권장하지 않음): 서비스 어카운트 토큰을 파드에 쿠버네티스 시크릿으로
+  마운트할 수 있다. 이 토큰은 만료되거나 교체되지 않는다. v1.24 이전에는 서비스 어카운트마다 영구 토큰이 자동으로 생성되었다.
+  정적이며 유효 기간이 긴 자격 증명의 위험 때문에, 특히 대규모 환경에서는
+  이 방법을 더 이상 권장하지 않는다. [LegacyServiceAccountTokenNoAutoGeneration 기능 게이트](/docs/reference/command-line-tools-reference/feature-gates-removed)는
+  쿠버네티스 v1.24부터 v1.26까지 기본적으로 활성화되어, 쿠버네티스가 서비스어카운트에 대해 이러한 토큰을
+  자동으로 생성하지 못하도록 했다. 이 기능 게이트는 GA로 승격되어 v1.27에서 제거되었다. 여전히 유효 기간이 무제한인 서비스 어카운트 토큰을 수동으로 생성할 수 있지만, 보안에 미치는 영향을 고려해야 한다.
 
 #### 서비스 어카운트 토큰의 노드 오디언스 제한 {#node-audience-restriction}
 
 {{< feature-state feature_gate_name="ServiceAccountNodeAudienceRestriction" >}}
 
-`ServiceAccountNodeAudienceRestriction` [기능 게이트](/docs/reference/command-line-tools-reference/feature-gates/)
-가 활성화되면, [NodeRestriction](/docs/reference/access-authn-authz/admission-controllers#noderestriction)
-어드미션 플러그인은 kubelet이 `TokenRequest` API를 통해 서비스 어카운트
-토큰을 생성할 때 요청할 수 있는 오디언스(audience)를 제한한다. 기본적으로 kubelet은
-해당 노드의 파드가 이미 참조하는 오디언스에 대해서만 토큰을 요청할 수 있다(프로젝티드 서비스
-어카운트 토큰 볼륨 또는 CSI 드라이버 토큰 요청을 통해 참조). 관리자는
-`request-serviceaccounts-token-audience` 동사를 사용하는 RBAC 규칙을 통해 kubelet에
-추가 오디언스에 대한 접근 권한을 부여할 수 있다.
+`ServiceAccountNodeAudienceRestriction` [기능 게이트](/docs/reference/command-line-tools-reference/feature-gates/)를
+활성화하면, [NodeRestriction](/docs/reference/access-authn-authz/admission-controllers#noderestriction)
+어드미션 플러그인은 kubelet이 `TokenRequest` API로 서비스 어카운트
+토큰을 생성할 때 요청할 수 있는 오디언스를 제한한다. 기본적으로 kubelet은
+해당 노드의 파드가 이미 참조하는 오디언스에 대해서만 토큰을 요청할 수 있다
+(프로젝티드 서비스 어카운트 토큰 볼륨 또는 CSI 드라이버 토큰 요청으로 참조). 관리자는
+`request-serviceaccounts-token-audience` 동사를 사용하는 RBAC 규칙을 통해
+kubelet에 추가 오디언스에 대한 접근 권한을 부여할 수 있다.
 
 이 제한은 kubelet(노드 신원)에만 적용되며 `TokenRequest` API의 다른
 호출자에게는 영향을 주지 않는다. 자세한 내용과 RBAC 예시는
 [서비스 어카운트 토큰 오디언스 제한](/docs/reference/access-authn-authz/node/#service-account-token-audience-restriction)을 참고한다.
 
 {{< note >}}
-쿠버네티스 클러스터 외부에서 실행되는 애플리케이션의 경우, 시크릿에 저장된
-장기간 유효한 서비스어카운트(ServiceAccount) 토큰을 생성하는 방법을 고려할 수 있다. 이는 인증을 가능하게 하지만, 쿠버네티스 프로젝트에서는 이러한 접근 방식을 피할 것을 권장한다.
-장기간 유효한 베어러(bearer) 토큰은 한 번 유출되면 악용될 수 있기 때문에
-보안 위험을 초래한다. 대신 다른 방법을 고려해야 한다. 예를 들어, 외부
-애플리케이션은 잘 보호된 개인키`와` 인증서를 사용해 인증하거나,
-직접 구현한 [인증 웹훅](/docs/reference/access-authn-authz/authentication/#webhook-token-authentication)과 같은 커스텀 매커니즘을 사용할 수 있다.
+쿠버네티스 클러스터 외부에서 실행되는 애플리케이션을 위해 시크릿에 저장되는
+유효 기간이 긴 서비스어카운트 토큰의 생성을 고려할 수 있다. 이 방식으로 인증할 수는 있지만, 쿠버네티스 프로젝트는 이를 피할 것을 권장한다.
+유효 기간이 긴 베어러(bearer) 토큰은 한 번 유출되면 악용될 수 있으므로
+보안 위험이 된다. 대신 다른 방법을 고려한다. 예를 들어 외부
+애플리케이션은 안전하게 보호되는 개인 키와 인증서를 사용하여 인증하거나,
+직접 구현한 [인증 웹훅](/docs/reference/access-authn-authz/authentication/#webhook-token-authentication)과 같은 사용자 정의 메커니즘으로 인증할 수 있다.
 
-또한 토큰리퀘스트를 사용하여 외부 애플리케이션에서 단기간 유효한 토큰을 발급받을 수 있다.
+TokenRequest를 사용하여 외부 애플리케이션용 단기 토큰을 얻을 수도 있다.
 {{< /note >}}
 
 ### 시크릿에 대한 접근 제한 (사용 중단(deprecated)) {#enforce-mountable-secrets}
@@ -219,15 +219,15 @@ v1.22 이전 버전에서는, 쿠버네티스가 시크릿(Secret)을 통해 파
 {{< feature-state for_k8s_version="v1.32" state="deprecated" >}}
 
 {{< note >}}
-`kubernetes.io/enforce-mountable-secrets`는 쿠버네티스 v1.32부터 더 이상 사용되지 않는다. 마운트된 시크릿에 대한 접근을 분리하려면 별도의 네임스페이스를 사용한다.
+`kubernetes.io/enforce-mountable-secrets`는 쿠버네티스 v1.32부터 사용 중단되었다. 마운트된 시크릿에 대한 접근을 격리하려면 별도의 네임스페이스를 사용한다.
 {{< /note >}}
 
-쿠버네티스는 `kubernetes.io/enforce-mountable-secrets`라는 어노테이션을 제공하며
-이를 서비스어카운트(ServiceAccount)에 추가할 수 있다. 이 어노테이션을 적용하면,
-해당 서비스어카운트(ServiceAccount)의 시크릿은 지정된 유형의 리소스에만 마운트 될 수 있어,
+쿠버네티스는 서비스어카운트에 추가할 수 있는
+`kubernetes.io/enforce-mountable-secrets` 어노테이션을 제공한다. 이 어노테이션을 적용하면,
+서비스어카운트의 시크릿을 지정된 유형의 리소스에만 마운트할 수 있으므로
 클러스터의 보안 수준을 강화할 수 있다.
 
-매니페스트를 사용해 서비스어카운트(ServiceAccount)에 이 어노테이션을 추가할 수 있다.
+매니페스트를 사용하여 서비스어카운트에 어노테이션을 추가할 수 있다.
 
 ```yaml
 apiVersion: v1
@@ -238,94 +238,94 @@ metadata:
   name: my-serviceaccount
   namespace: my-namespace
 ```
-이 어노테이션을 "true"로 설정하면, 쿠버네티스 컨트롤 플레인은 해당
-서비스어카운트(ServiceAccount)에서 사용하는 시크릿에 특정 마운트 제한을 적용한다.
+이 어노테이션을 "true"로 설정하면 쿠버네티스 컨트롤 플레인은
+이 서비스어카운트의 시크릿에 특정 마운트 제한을 적용한다.
 
-1. 파드 안에서 볼륨으로 마운트되는 각 시크릿의 이름은 파드의 서비스어카운트(ServiceAccount)에 있는 `secret` 필드에
-   반드시 명시되어야 한다.
-1. 파드 안에서 `envFrom`을 사용해 참조하는 각 시크릿의 이름 또한 서비스어카운트(ServiceAccount)에 있는 `secret`
-   필드에 반드시 명시되어야 한다.
-1. 파드 안에서 `imagePullSecrets`으로 참조하는 각 시크릿의 이름 또한 서비스어카운트(ServiceAccount)에 있는 `secret`
-   필드에 반드시 명시되어야 한다.
+1. 파드에 볼륨으로 마운트되는 각 시크릿의 이름은 파드의 서비스어카운트의 `secrets` 필드에
+   포함되어야 한다.
+1. 파드에서 `envFrom`으로 참조하는 각 시크릿의 이름도 파드의 서비스어카운트의 `secrets`
+   필드에 포함되어야 한다.
+1. 파드에서 `imagePullSecrets`로 참조하는 각 시크릿의 이름도 파드의 서비스어카운트의 `secrets`
+   필드에 포함되어야 한다.
 
-이러한 제한을 이해하고 적용함으로써, 클러스터 관리자는 보안 수준을 더 엄격하게 유지하고 시크릿이 적절한 리소스에서만 접근되도록 보장할 수 있다.
+이러한 제한을 이해하고 적용하면 클러스터 관리자는 더 엄격한 보안 수준을 유지하고, 적절한 리소스만 시크릿에 접근하도록 보장할 수 있다.
 
 ## 서비스 어카운트 자격 증명 인증 {#authenticating-credentials}
 
-서비스어카운트(ServiceAccount)는 서명된 
-{{<glossary_tooltip term_id="jwt" text="JSON Web Tokens">}}  (JWT)들을
-사용해 쿠버네티스 API 서버와, 신뢰 관계가 설정된
-다른 시스템에 인증한다. 어떻게 토큰이 발급되었는지
-(`TokenRequest`를 통해 기간 제한을 두었는지 혹은 시크릿을 사용하는 
-레거시 방식을 사용했는지)에 따라, 서비스어카운트(ServiceAccount) 토큰에는 만료 시간, 오디언스,
-그리고 토큰이 유효하기 *시작하는* 시간이 포함될 수 있다. 서비스어카운트(ServiceAccount)로
-동작하는 클라이언트가 쿠버네티스 API 서버와 통신하려고 할 때,
-해당 클라이언트는 HTTP 요청에 `Authorization: Bearer <token>` 헤더를
-포함한다. API 서버는 다음과 같은 방식으로 해당 베어러 토큰의 유효성을 검사한다.
+서비스어카운트는 서명된
+{{<glossary_tooltip term_id="jwt" text="JSON 웹 토큰(JSON Web Token)" >}}(JWT)을
+사용하여 쿠버네티스 API 서버와 신뢰 관계가 있는
+다른 시스템에 인증한다. 토큰의 발급 방식
+(`TokenRequest`를 사용한 시간제한 방식 또는 시크릿을 사용하는
+기존 방식)에 따라, 서비스어카운트 토큰에는 만료 시점, 오디언스,
+토큰이 유효해지기 *시작하는* 시점이 포함될 수 있다. 서비스어카운트로
+동작하는 클라이언트가 쿠버네티스 API 서버와 통신하려고 하면,
+HTTP 요청에 `Authorization: Bearer <token>` 헤더를
+포함한다. API 서버는 다음과 같이 해당 베어러 토큰의 유효성을 확인한다.
 
 1. 토큰 서명을 확인한다.
 1. 토큰이 만료되었는지 확인한다.
-1. 토큰 클레임에 포함된 오브젝트 참조가 현재 유효한지 확인한다.
-1. 토큰이 현재 시점에 유효한지 확인한다.
+1. 토큰 클레임(claim)의 오브젝트 참조가 현재 유효한지 확인한다.
+1. 토큰이 현재 유효한지 확인한다.
 1. 오디언스 클레임을 확인한다.
 
-`TokenRequest` API는 서비스어카운트(ServiceAccount)에 대해 _바운드 토큰_ 을 생성한다. 이 바인딩은
-해당 서비스어카운트(ServiceAccount)로 동작하는 파드와 같이 클라이언트의 수명과
-연결된다. 바운드 파드 서비스 어카운트 토큰의 JWT 스키마와 페이로드 예시는
+TokenRequest API는 서비스어카운트에 대한 _바운드 토큰(bound token)_ 을 생성한다.
+이 바인딩은 해당 서비스어카운트로 동작하는 파드와 같은 클라이언트의
+수명에 연결된다. 바운드 파드 서비스 어카운트 토큰의 JWT 스키마와 페이로드(payload) 예시는
 [토큰 볼륨 프로젝션](/docs/tasks/configure-pod-container/configure-service-account/#serviceaccount-token-volume-projection)을 참고한다.
 
-`TokenRequest` API로 발급된 토큰의 경우, API 서버는 해당 서비스어카운트(ServiceAccount)를
-사용 중인 특정 오브젝트 참조가 여전히 존재하는지도 확인하며,
-이때 해당 오브젝트의 {{< glossary_tooltip term_id="uid" text="고유 ID" >}}를 기준으로
-검사한다. 파드에 시크릿으로 마운트된 레거시 토큰에 대해서는, API 서버가
-그 토큰을 시크릿과 대조해 확인한다.
+`TokenRequest` API로 발급한 토큰의 경우, API 서버는 해당 서비스어카운트를
+사용하는 특정 오브젝트 참조가 여전히 존재하는지도 확인한다.
+이때 오브젝트의 {{< glossary_tooltip term_id="uid" text="고유 ID" >}}를
+비교한다. 파드에 시크릿으로 마운트된 기존 토큰의 경우,
+API 서버는 토큰을 시크릿과 대조하여 확인한다.
 
-인증 과정에 대한 더 자세한 정보는,
+인증 과정에 대한 자세한 내용은
 [인증](/docs/reference/access-authn-authz/authentication/#service-account-tokens)을 참고한다.
 
-### 코드에서 서비스 어카운트 자격 증명 인증하기 {#authenticating-in-code}
+### 자체 코드에서 서비스 어카운트 자격 증명 인증하기 {#authenticating-in-code}
 
-자체 서비스에서 쿠버네티스 서비스
-어카운트 자격 증명을 검증해야 하는 경우, 다음 방법을 사용할 수 있다.
+자체 서비스에서 쿠버네티스 서비스 어카운트 자격 증명을
+검증해야 한다면 다음 방법을 사용할 수 있다.
 
-* [TokenReview API](/docs/reference/kubernetes-api/authentication-resources/token-review-v1/)
+* [토큰리뷰(TokenReview) API](/docs/reference/kubernetes-api/authentication-resources/token-review-v1/)
   (권장)
 * OIDC 디스커버리
 
-쿠버네티스 프로젝트에서는 TokenReview API 사용을 권장한다. 왜냐하면
-이 방법은 시크릿, 서비스어카운트(ServiceAccount), 파드나 노드와 같은
-API 오브젝트에 바인딩된 토큰이 해당 오브젝트가 삭제될 때 무효화되도록 하기 때문이다. 예를 들어, 프로젝티드 서비스어카운트(projected ServiceAccount)
-토큰을 포함하는 파드를 삭제하는 경우, 클러스터는
-해당 토큰을 즉각적으로 무효화하고, TokenReview는 즉시 실패한다.
-반면에 OIDC 검증을 사용하는 경우, 클라이언트는 토큰이 만료 시점에 도달할 때까지
-계속 유효한 것으로 처리한다.
+쿠버네티스 프로젝트는 토큰리뷰 API 사용을 권장한다. 이 방법은
+시크릿, 서비스어카운트, 파드 또는 노드와 같은 API 오브젝트가
+삭제되면 해당 오브젝트에 바인딩된 토큰을 무효화하기 때문이다. 예를 들어,
+프로젝티드 서비스어카운트 토큰을 포함한 파드를 삭제하면 클러스터는
+즉시 해당 토큰을 무효화하고 토큰리뷰도 즉시 실패한다.
+반면 OIDC 검증을 사용하면 클라이언트는 토큰의 만료 시점에
+도달할 때까지 토큰을 유효한 것으로 처리한다.
 
-애플리케이션은 자신이 허용하는 오디언스를 항상 정의하고, 토큰의 오디언스가
-애플리케이션이 기대하는 오디언스와 일치하는지
-확인해야 한다. 이렇게 하면 토큰의 사용 범위를 최소화하여 해당 토큰이 오직 애플리케이션 내에서만 사용되고
-다른 곳에서는 사용할 수 없도록 할 수 있다.
+애플리케이션은 허용할 오디언스를 항상 정의하고,
+토큰의 오디언스가 애플리케이션에서 예상하는 오디언스와
+일치하는지 확인해야 한다. 이를 통해 토큰의 범위를 최소화하여,
+해당 애플리케이션에서만 사용하고 다른 곳에서는 사용하지 못하도록 할 수 있다.
 
-## 대안
+## 대안 {#alternatives}
 
-* 다른 메커니즘을 사용해 자체적으로 토큰을 발급하고,
+* 다른 메커니즘으로 자체 토큰을 발급한 후,
   [웹훅 토큰 인증](/docs/reference/access-authn-authz/authentication/#webhook-token-authentication)을 통해
-  자체 검증 서비스를 사용하여 베어러 토큰을 검증한다.
-* 파드에 자체적인 신원을 제공한다.
-  * [SPIFFE CSI 드라이버 플러그인을 사용하여 파드에 SPIFFE SVIDs를 X.509 인증서 쌍으로 제공](https://cert-manager.io/docs/projects/csi-driver-spiffe/).
+  자체 검증 서비스로 베어러 토큰을 검증한다.
+* 파드에 자체 신원을 제공한다.
+  * [SPIFFE CSI 드라이버 플러그인으로 파드에 SPIFFE SVID를 X.509 인증서 쌍으로 제공한다](https://cert-manager.io/docs/projects/csi-driver-spiffe/).
     {{% thirdparty-content single="true" %}}
-  * [Istio와 같은 서비스 메시를 사용하여 파드에 인증서를 제공](https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/).
+  * [이스티오(Istio)와 같은 서비스 메시로 파드에 인증서를 제공한다](https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/).
 * 서비스 어카운트 토큰을 사용하지 않고 클러스터 외부에서 API 서버에 인증한다.
-  * [API 서버가 신원 제공자의 OpenID Connect(OIDC) 토큰을 수락하도록 구성](/docs/reference/access-authn-authz/authentication/#openid-connect-tokens).
-  * 클라우드 제공자와 같이, 외부 ID 및 접근 관리(IAM) 서비스를
-    사용해 생성된 서비스 어카운트나 사용자 계정을 이용해,
-    클러스터에 인증한다.
-  * [CertificateSigningRequest API를 클라이언트 인증서와 함께 사용](/docs/tasks/tls/managing-tls-in-a-cluster/).
-* [kubelet이 이미지 레지스트리에서 자격 증명을 가져오도록 구성](/docs/tasks/administer-cluster/kubelet-credential-provider/).
-* 가상 플랫폼 모듈(TPM)에 접근하기 위해 디바이스 플러그인을 사용하고,
-  이를 통해 개인키를 사용한 인증을 허용한다.
+  * [신원 제공자의 OpenID Connect(OIDC) 토큰을 수락하도록 API 서버를 구성한다](/docs/reference/access-authn-authz/authentication/#openid-connect-tokens).
+  * 클라우드 제공자 등이 제공하는 외부 신원 및 접근 관리
+    (Identity and Access Management, IAM) 서비스로 생성한 서비스 어카운트나 사용자 계정을
+    사용하여 클러스터에 인증한다.
+  * [클라이언트 인증서와 함께 CertificateSigningRequest API를 사용한다](/docs/tasks/tls/managing-tls-in-a-cluster/).
+* [이미지 레지스트리에서 자격 증명을 가져오도록 kubelet을 구성한다](/docs/tasks/administer-cluster/kubelet-credential-provider/).
+* 디바이스 플러그인으로 가상 신뢰 플랫폼 모듈(Trusted Platform Module, TPM)에 접근하고,
+  이를 통해 개인 키를 사용한 인증을 수행한다.
 
 ## {{% heading "whatsnext" %}}
 
-* [클러스터 관리자 권한으로 서비스어카운트(ServiceAccount) 관리하기](/docs/reference/access-authn-authz/service-accounts-admin/)에 대해 배우기.
-* [파드에 서비스어카운트(ServiceAccount) 할당하기](/docs/tasks/configure-pod-container/configure-service-account/)에 대해 배우기.
-* [서비스어카운트(ServiceAccount) API 레퍼런스](/docs/reference/kubernetes-api/authentication-resources/service-account-v1/)에 대해 읽기.
+* [클러스터 관리자로서 서비스어카운트를 관리하는 방법](/docs/reference/access-authn-authz/service-accounts-admin/)을 알아본다.
+* [파드에 서비스어카운트를 할당하는 방법](/docs/tasks/configure-pod-container/configure-service-account/)을 알아본다.
+* [서비스어카운트 API 레퍼런스](/docs/reference/kubernetes-api/authentication-resources/service-account-v1/)를 읽는다.

--- a/content/ko/docs/reference/access-authn-authz/admission-controllers.md
+++ b/content/ko/docs/reference/access-authn-authz/admission-controllers.md
@@ -1,0 +1,933 @@
+---
+# reviewers:
+# - lavalamp
+# - davidopp
+# - derekwaynecarr
+# - erictune
+# - janetkuo
+# - thockin
+title: 쿠버네티스의 어드미션 컨트롤
+linkTitle: 어드미션 컨트롤
+content_type: concept
+weight: 40
+---
+
+<!-- overview -->
+이 페이지는 _어드미션 컨트롤러_ 의 개요를 제공한다.
+
+어드미션 컨트롤러는 쿠버네티스 API 서버로 전달된 요청의 인증과 인가가
+완료된 후, 리소스를 영구 저장하기 전에
+해당 요청을 가로채는 코드이다.
+
+쿠버네티스의 여러 주요 기능을 올바르게 지원하려면 어드미션 컨트롤러를
+활성화해야 한다. 따라서 적절한 어드미션 컨트롤러 집합으로
+올바르게 구성하지 않은 쿠버네티스 API 서버는 불완전한 서버이며,
+기대하는 모든 기능을 지원하지 못한다.
+
+<!-- body -->
+## 어드미션 컨트롤러란? {#what-are-they}
+
+어드미션 컨트롤러는 쿠버네티스
+{{< glossary_tooltip term_id="kube-apiserver" text="API 서버" >}}에 포함된 코드로,
+리소스를 수정하는 요청에 담긴 데이터를 검사한다.
+
+어드미션 컨트롤러는 오브젝트를 생성, 삭제 또는 수정하는 요청에 적용된다.
+또한 API 서버 프록시를 통해 파드에 연결하는 요청과 같은
+사용자 정의 동사를 차단할 수도 있다. 읽기 요청은 어드미션 컨트롤 계층을
+거치지 않으므로, 어드미션 컨트롤러는 오브젝트를 읽는(**get**, **watch**, **list**) 요청을
+차단하지 _않으며_, 차단할 수도 없다.
+
+어드미션 컨트롤 메커니즘은 _검증(validating)_, _변형(mutating)_ 또는 두 가지 모두를 수행할 수 있다.
+변형 컨트롤러는 수정 대상 리소스의 데이터를 변경할 수 있지만, 검증 컨트롤러는 변경할 수 없다.
+
+쿠버네티스 {{< skew currentVersion >}}의 어드미션 컨트롤러는 아래
+[목록](#what-does-each-admission-controller-do)으로 구성되며,
+`kube-apiserver` 바이너리에 컴파일되어 포함된다. 이 컨트롤러는 클러스터
+관리자만 구성할 수 있다.
+
+### 어드미션 컨트롤 확장 지점 {#admission-control-extension-points}
+
+전체 [목록](#what-does-each-admission-controller-do)에는 네 가지
+특별한 컨트롤러가 있다.
+[MutatingAdmissionWebhook](#mutatingadmissionwebhook),
+[MutatingAdmissionPolicy](#mutatingadmissionpolicy),
+[ValidatingAdmissionWebhook](#validatingadmissionwebhook),
+[ValidatingAdmissionPolicy](#validatingadmissionpolicy)이다.
+두 웹훅(webhook) 컨트롤러는 API에 구성된 변형 및 검증
+[어드미션 컨트롤 웹훅](/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks)을
+각각 실행한다. ValidatingAdmissionPolicy는 외부 HTTP 호출에 의존하지 않고
+선언적인 검증 코드를 API에 포함하는 방법을 제공한다.
+MutatingAdmissionPolicy는 선언적인 변형에 대해 같은 기능을 제공한다.
+
+이 네 가지 어드미션 컨트롤러를 사용하여 어드미션 시점의
+클러스터 동작을 사용자 정의할 수 있다.
+
+### 어드미션 컨트롤 단계 {#admission-control-phases}
+
+어드미션 컨트롤 과정은 두 단계로 진행된다. 첫 번째 단계에서는
+변형 어드미션 컨트롤러를 실행한다. 두 번째 단계에서는 검증
+어드미션 컨트롤러를 실행한다. 일부 컨트롤러는 두 가지 모두를
+수행한다는 점에 다시 유의한다.
+
+어느 단계에서든 컨트롤러 하나가 요청을 거부하면 전체
+요청을 즉시 거부하고 최종 사용자에게 오류를 반환한다.
+
+마지막으로, 어드미션 컨트롤러는 대상 오브젝트를 변경하는 것 외에도
+부수 효과를 일으킬 수 있다. 즉, 요청 처리의 일부로 관련
+리소스를 변경할 수 있다. 쿼터 사용량을 증가시키는 것이 이러한 동작이
+필요한 대표적인 예이다. 특정 어드미션 컨트롤러는 해당 요청이
+다른 모든 어드미션 컨트롤러를 통과할지 확실히 알 수 없으므로,
+이러한 부수 효과에는 그에 대응하는 회수 또는 조정 과정이
+필요하다.
+
+이러한 호출의 순서는 아래에서 확인할 수 있다.
+
+{{< figure src="/docs/reference/access-authn-authz/admission-control-phases.svg" alt="어드미션 단계에서 kube-apiserver가 요청을 처리하는 순서도. 변형 웹훅, ValidatingAdmissionPolicy, 검증 웹훅 순으로 실행하며, 처음으로 요청이 거부되거나 모든 검사를 통과할 때까지 진행한다. 변형 웹훅이 오브젝트를 변경하면 이전에 호출된 모든 웹훅을 다시 호출한다." class="diagram-large" link="https://mermaid.live/edit#pako:eNqtVm1r3DgQ_iuDj9CUc3aPlBa6HIFeSu_CEQhNr4XiL7I9a6srSz5J3mQb9r93RrK9jjcp9-H8xdZoXh7N80jyQ1KYEpNV4vDfDnWB76WorGgynemTE_hLbBG8AYce1kb7W_kdoVImF0rtQDjwtXQgnX7hwaJrsfBYQtmFoNr71q2Wy0r6ussXhWmWDdpGyPLsmxs-l9K5Dt3y1du3v3HJB6mlXz1kia-xwSxZZYnGzluhsiTNkgEETUCWnJ-392SmrwE-2ym4kdYa-67wxjoyedvhPs000NNn_iysFLlCFyPCVJwWHPXHpgq1f3l1_qbA11x77vIJ7_2lUcYGx7taepy5KWPaqRc8l08bj1Rx4ldZ3M2cnlp6pvf7_ckJsxVdibNPkRKiBkEof-YJAZFnQRQFOidzqaTfpSB0Ca42nSohR-jaUjB3uEW7Ay8bDAnKKAfKt4gFKMl7dIWd9uy2b_7ozdU2XY5nopUOLaWEmsopqSuSCTk770gllscBZtmQDKTR0NbCIcO647mm88Kz-Q7z2piNSym1UuaOgOY72AolCTV5jglao2Qh0YXVraUOOj34jYkWcIB_5UNB7pjwAU9BrZaaVNzRWwXTWlrHGv9GEqc6KdASc-SU3NbWR0RUDsyaA5pZBaGcmZYZluY4LA4m8KAQncOQrrW4laZztI6CxlRndKI9Rsz1VlEJqXuS9oMcWmE99aMV2sM_xARv2fA-nn53c8WzfxNtVqOnFrLlNrD3hHfna3bnN1KTisjTr8FgrPwexqMmH4WWzaW3KkSPvF9Sx61RMSA39_Anrcblxho49oLfc3txGZcdGZqxc4z3uu_wl9g7Lj6YoLedupfHcZ9H6dyYAPlgmOC66VX3s_hJ5UmOeW3U5WEzB6bOLi4CEyv4GHcOnOKiWqRQWKQdCwJaU77sCWXHEEAsrKbkkJQD_bQruHlFjcUmmlo6h-My3FCXzy34wCcG6W_eJneQdRABl5t1dwVXems2-LPYOSEH1NemlOsd76_IJ5g8vE7lGjRiieW0V0d4J819TMuI9hGnI9Zn4x5L4IDz439ER3J4CtzQEpCaXVjN6lmg88Y-kef_ATvWJiWRgPisnTDRn92DToLa2JmFyjVcSypCGBTqunDjcALk-5iKJWnSX_z0zxGukMNNT5-lsJtwq5Gf6Ly53ekiXt9pYk1X1clqTScpjeJ91f-tjFYsJd3M1_GXJvzZpAntw6_GDD77H6uICLI" >}}
+
+## 어드미션 컨트롤러가 필요한 이유 {#why-do-i-need-them}
+
+쿠버네티스의 여러 주요 기능을 올바르게 지원하려면 어드미션 컨트롤러를
+활성화해야 한다. 따라서 적절한 어드미션 컨트롤러 집합으로
+올바르게 구성하지 않은 쿠버네티스 API 서버는 불완전한 서버이며,
+기대하는 모든 기능을 지원하지 못한다.
+
+## 어드미션 컨트롤러 활성화하기 {#how-do-i-turn-on-an-admission-controller}
+
+쿠버네티스 API 서버의 `enable-admission-plugins` 플래그는 클러스터의 오브젝트를 수정하기 전에 호출할 어드미션 컨트롤 플러그인의 목록을 쉼표로 구분하여 받는다.
+예를 들어 다음 커맨드라인은 `NamespaceLifecycle`과 `LimitRanger`
+어드미션 컨트롤 플러그인을 활성화한다.
+
+```shell
+kube-apiserver --enable-admission-plugins=NamespaceLifecycle,LimitRanger ...
+```
+
+{{< note >}}
+쿠버네티스 클러스터의 배포 방식과 API 서버의 시작 방식에 따라
+설정을 적용하는 방법이 달라질 수 있다. 예를 들어 API 서버가
+systemd 서비스로 배포되어 있다면 systemd 유닛 파일을 수정해야 할 수 있으며,
+쿠버네티스가 자체 호스팅 방식으로 배포되어 있다면 API 서버의
+매니페스트 파일을 수정해야 할 수 있다.
+{{< /note >}}
+
+## 어드미션 컨트롤러 비활성화하기 {#how-do-i-turn-off-an-admission-controller}
+
+쿠버네티스 API 서버의 `disable-admission-plugins` 플래그는 비활성화할 어드미션 컨트롤 플러그인의 목록을 쉼표로 구분하여 받는다. 기본적으로 활성화되는 플러그인 목록에 포함되어 있어도 비활성화한다.
+
+```shell
+kube-apiserver --disable-admission-plugins=PodNodeSelector,AlwaysDeny ...
+```
+
+## 기본적으로 활성화되는 플러그인 {#which-plugins-are-enabled-by-default}
+
+활성화되는 어드미션 플러그인을 확인하려면 다음을 실행한다.
+
+```shell
+kube-apiserver -h | grep enable-admission-plugins
+```
+
+쿠버네티스 {{< skew currentVersion >}}에서 기본적으로 활성화되는 플러그인은 다음과 같다.
+
+```shell
+CertificateApproval, CertificateSigning, CertificateSubjectRestriction, DefaultIngressClass, DefaultStorageClass, DefaultTolerationSeconds, LimitRanger, MutatingAdmissionPolicy, MutatingAdmissionWebhook, NamespaceLifecycle, PersistentVolumeClaimResize, PodSecurity, Priority, ResourceQuota, RuntimeClass, ServiceAccount, StorageObjectInUseProtection, TaintNodesByCondition, ValidatingAdmissionPolicy, ValidatingAdmissionWebhook
+```
+
+## 각 어드미션 컨트롤러의 역할 {#what-does-each-admission-controller-do}
+
+### AlwaysAdmit {#alwaysadmit}
+
+{{< feature-state for_k8s_version="v1.13" state="deprecated" >}}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 모든 파드를 클러스터에 허용한다. 어드미션 컨트롤러가 전혀
+없는 경우와 동작이 같으므로 **사용 중단(deprecated)** 되었다.
+
+### AlwaysDeny {#alwaysdeny}
+
+{{< feature-state for_k8s_version="v1.13" state="deprecated" >}}
+
+**유형**: 검증.
+
+모든 요청을 거부한다. AlwaysDeny는 실질적인 의미가 없으므로 **사용 중단** 되었다.
+
+### AlwaysPullImages {#alwayspullimages}
+
+**유형**: 변형 및 검증.
+
+이 어드미션 컨트롤러는 새 파드를 모두 수정하여 이미지 풀 정책을 `Always`로 강제한다. 이는 멀티테넌트(multitenant)
+클러스터에서 유용하며, 사용자는 이미지를 가져올 자격 증명을 보유한 사람만 자신의
+비공개 이미지를 사용할 수 있다고 확신할 수 있다. 이 어드미션 컨트롤러가 없으면 이미지가 한 번
+노드에 내려받아진 이후에는 어떤 사용자의 파드라도 이미지 이름만 알면 이미지에 대한
+인가 검사 없이 사용할 수 있다(파드가 해당 노드에 스케줄된다고 가정). 이 어드미션 컨트롤러를
+활성화하면 컨테이너를 시작하기 전에 항상 이미지를 내려받으므로, 유효한 자격 증명이
+필요하다.
+
+### CertificateApproval {#certificateapproval}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 CertificateSigningRequest 리소스의 승인 요청을 관찰하고 추가
+인가 검사를 수행하여, 승인하는 사용자가 CertificateSigningRequest 리소스의
+`spec.signerName`에 지정된 인증서 요청을 **승인** 할 권한이 있는지 확인한다.
+
+CertificateSigningRequest 리소스에 대해 여러 작업을 수행하는 데 필요한 권한의
+자세한 내용은 [인증서 서명 요청](/docs/reference/access-authn-authz/certificate-signing-requests/)을 참고한다.
+
+### CertificateSigning {#certificatesigning}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 CertificateSigningRequest 리소스의 `status.certificate` 필드 업데이트를
+관찰하고 추가 인가 검사를 수행하여, 서명하는 사용자가 CertificateSigningRequest 리소스의
+`spec.signerName`에 지정된 인증서 요청에 **서명** 할 권한이 있는지 확인한다.
+
+CertificateSigningRequest 리소스에 대해 여러 작업을 수행하는 데 필요한 권한의
+자세한 내용은 [인증서 서명 요청](/docs/reference/access-authn-authz/certificate-signing-requests/)을 참고한다.
+
+### CertificateSubjectRestriction {#certificatesubjectrestriction}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 `spec.signerName`이 `kubernetes.io/kube-apiserver-client`인
+CertificateSigningRequest 리소스의 생성을 관찰한다. '그룹'(또는 '조직 속성')으로
+`system:masters`를 지정하는 모든 요청을 거부한다.
+
+### DefaultIngressClass {#defaultingressclass}
+
+**유형**: 변형.
+
+이 어드미션 컨트롤러는 특정 인그레스 클래스를 요청하지 않는 `Ingress` 오브젝트의
+생성을 관찰하고, 기본 인그레스 클래스를 자동으로 추가한다. 따라서 특별한
+인그레스 클래스를 요청하지 않는 사용자는 인그레스 클래스를 전혀 신경 쓰지 않아도
+기본 클래스를 사용할 수 있다.
+
+기본 인그레스 클래스가 구성되지 않으면 이 어드미션 컨트롤러는 아무 작업도 수행하지 않는다. 두 개 이상의
+인그레스 클래스가 기본값으로 표시되어 있으면 모든 `Ingress` 생성을 오류와 함께 거부하며, 관리자는
+`IngressClass` 오브젝트를 다시 확인하여 하나만 기본값으로 표시해야 한다
+("ingressclass.kubernetes.io/is-default-class" 어노테이션 사용). 이 어드미션 컨트롤러는
+`Ingress` 업데이트를 모두 무시하며, 생성 시에만 동작한다.
+
+인그레스 클래스와 클래스를 기본값으로 지정하는 방법에 대한 자세한 내용은
+[인그레스](/docs/concepts/services-networking/ingress/) 문서를 참고한다.
+
+### DefaultStorageClass {#defaultstorageclass}
+
+**유형**: 변형.
+
+이 어드미션 컨트롤러는 특정 스토리지 클래스를 요청하지 않는 `PersistentVolumeClaim` 오브젝트의 생성을
+관찰하고, 기본 스토리지 클래스를 자동으로 추가한다.
+따라서 특별한 스토리지 클래스를 요청하지 않는 사용자는 스토리지 클래스를 전혀 신경 쓰지 않아도
+기본 클래스를 사용할 수 있다.
+
+기본 `StorageClass`가 없으면 이 어드미션 컨트롤러는 아무 작업도 수행하지 않는다. 두 개 이상의 스토리지
+클래스가 기본값으로 표시되어 있고 `storageClassName`을 설정하지 않은 `PersistentVolumeClaim`을 생성하면,
+쿠버네티스는 가장 최근에 생성된 기본 `StorageClass`를 사용한다.
+`volumeName`을 지정하여 `PersistentVolumeClaim`을 생성한 경우, 기본 스토리지클래스(StorageClass)를
+적용한 후의 `PersistentVolumeClaim`의 `storageClassName`이 정적 볼륨의 `storageClassName`과
+일치하지 않으면 해당 클레임은 Pending 상태로 유지된다.
+이 어드미션 컨트롤러는 `PersistentVolumeClaim` 업데이트를 모두 무시하며, 생성 시에만 동작한다.
+
+퍼시스턴트볼륨클레임(PersistentVolumeClaim), 스토리지 클래스 및 스토리지 클래스를 기본값으로 지정하는
+방법은 [퍼시스턴트 볼륨](/docs/concepts/storage/persistent-volumes/) 문서를 참고한다.
+
+### DefaultTolerationSeconds {#defaulttolerationseconds}
+
+**유형**: 변형.
+
+이 어드미션 컨트롤러는 파드에 `node.kubernetes.io/not-ready:NoExecute` 또는
+`node.kubernetes.io/unreachable:NoExecute` 테인트(taint)에 대한 톨러레이션(toleration)이
+아직 없는 경우, k8s-apiserver 입력 파라미터인
+`default-not-ready-toleration-seconds`와 `default-unreachable-toleration-seconds`를 기준으로
+`notready:NoExecute`와 `unreachable:NoExecute` 테인트를 용인하는 기본 유예 톨러레이션을 설정한다.
+`default-not-ready-toleration-seconds`와 `default-unreachable-toleration-seconds`의 기본값은 5분이다.
+
+### DenyServiceExternalIPs
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 `Service`의 `externalIPs` 필드를 새로 사용하는 모든 요청을 거부한다.
+이 기능은 네트워크 트래픽 가로채기를 허용하는 매우 강력한 기능이며,
+정책으로 충분히 제어되지 않는다. 컨트롤러를 활성화하면 클러스터 사용자는
+`externalIPs`를 사용하는 새 서비스를 생성하거나, 기존 `Service` 오브젝트의
+`externalIPs`에 새 값을 추가할 수 없다. 기존의 `externalIPs` 사용에는
+영향이 없으며, 기존 `Service` 오브젝트의 `externalIPs`에서 값을 제거할 수는 있다.
+
+대부분의 사용자는 이 기능이 전혀 필요하지 않으므로 클러스터 관리자는 비활성화를 고려해야 한다.
+이 기능을 사용해야 하는 클러스터에서는 사용자 정의 정책으로 사용을 관리하는
+방법을 고려해야 한다.
+
+이 어드미션 컨트롤러는 기본적으로 비활성화되어 있다.
+
+### EventRateLimit {#eventratelimit}
+
+{{< feature-state for_k8s_version="v1.13" state="alpha" >}}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 새 이벤트(Event)를 저장하는 요청이 API 서버에
+폭주하는 문제를 완화한다. 클러스터 관리자는 다음과 같이 이벤트 속도 제한을 지정할 수 있다.
+
+* `EventRateLimit` 어드미션 컨트롤러를 활성화한다.
+* API 서버의 커맨드라인 플래그 `--admission-control-config-file`에 제공한 파일에서
+  `EventRateLimit` 구성 파일을 참조한다.
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: EventRateLimit
+    path: eventconfig.yaml
+...
+```
+
+구성에는 네 가지 유형의 제한을 지정할 수 있다.
+
+ * `Server`: API 서버가 받은 모든 이벤트 요청(생성 또는 수정)이 하나의 버킷(bucket)을 공유한다.
+ * `Namespace`: 각 네임스페이스가 전용 버킷을 가진다.
+ * `User`: 각 사용자에게 버킷을 할당한다.
+ * `SourceAndObject`: 이벤트의 소스와 관련 오브젝트의 각 조합에
+   버킷을 할당한다.
+
+다음은 이러한 구성을 위한 `eventconfig.yaml` 예시이다.
+
+```yaml
+apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+kind: Configuration
+limits:
+  - type: Namespace
+    qps: 50
+    burst: 100
+    cacheSize: 2000
+  - type: User
+    qps: 10
+    burst: 50
+```
+
+자세한 내용은 [EventRateLimit 구성 API(v1alpha1)](/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/)를
+참고한다.
+
+이 어드미션 컨트롤러는 기본적으로 비활성화되어 있다.
+
+### ExtendedResourceToleration {#extendedresourcetoleration}
+
+**유형**: 변형.
+
+이 플러그인은 확장 리소스가 있는 전용 노드의 생성을 돕는다.
+운영자가 GPU, FPGA 등 확장 리소스가 있는 전용 노드를 생성하려면, 확장 리소스의 이름을
+키로 사용하여 [노드에 테인트를 설정](/docs/concepts/scheduling-eviction/taint-and-toleration/#유스케이스-예시)해야 한다.
+이 어드미션 컨트롤러를 활성화하면 확장 리소스를 요청하는 파드에
+해당 테인트의 톨러레이션을 자동으로 추가하므로, 사용자가 이 톨러레이션을
+수동으로 추가할 필요가 없다.
+
+이 어드미션 컨트롤러는 기본적으로 비활성화되어 있다.
+
+### ImagePolicyWebhook {#imagepolicywebhook}
+
+**유형**: 검증.
+
+ImagePolicyWebhook 어드미션 컨트롤러는 백엔드 웹훅이 어드미션 결정을 내릴 수 있도록 한다.
+
+이 어드미션 컨트롤러는 기본적으로 비활성화되어 있다.
+
+#### 구성 파일 형식 {#imagereview-config-file-format}
+
+ImagePolicyWebhook은 구성 파일을 사용하여 백엔드 동작의 옵션을 설정한다.
+이 파일은 JSON 또는 YAML 형식일 수 있으며, 다음과 같은 형식을 사용한다.
+
+```yaml
+imagePolicy:
+  kubeConfigFile: /path/to/kubeconfig/for/backend
+  # time in s to cache approval
+  allowTTL: 50
+  # time in s to cache denial
+  denyTTL: 50
+  # time in ms to wait between retries
+  retryBackoff: 500
+  # determines behavior if the webhook backend fails
+  defaultAllow: true
+```
+
+API 서버의 커맨드라인 플래그 `--admission-control-config-file`에 제공한 파일에서 ImagePolicyWebhook 구성 파일을 참조한다.
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: ImagePolicyWebhook
+    path: imagepolicyconfig.yaml
+...
+```
+
+또는 파일에 구성을 직접 포함할 수 있다.
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: ImagePolicyWebhook
+    configuration:
+      imagePolicy:
+        kubeConfigFile: <path-to-kubeconfig-file>
+        allowTTL: 50
+        denyTTL: 50
+        retryBackoff: 500
+        defaultAllow: true
+```
+
+ImagePolicyWebhook 구성 파일은 백엔드 연결을 설정하는
+[kubeconfig](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
+형식의 파일을 참조해야 한다.
+백엔드는 반드시 TLS를 통해 통신해야 한다.
+
+kubeconfig 파일의 `cluster` 필드는 원격 서비스를 가리켜야 하며, `user` 필드는
+반환된 인가자를 포함해야 한다.
+
+```yaml
+# clusters refers to the remote service.
+clusters:
+  - name: name-of-remote-imagepolicy-service
+    cluster:
+      certificate-authority: /path/to/ca.pem    # CA for verifying the remote service.
+      server: https://images.example.com/policy # URL of remote service to query. Must use 'https'.
+
+# users refers to the API server's webhook configuration.
+users:
+  - name: name-of-api-server
+    user:
+      client-certificate: /path/to/cert.pem # cert for the webhook admission controller to use
+      client-key: /path/to/key.pem          # key matching the cert
+```
+
+추가 HTTP 구성은
+[kubeconfig](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) 문서를 참고한다.
+
+#### 요청 페이로드(payload) {#request-payloads}
+
+어드미션 결정이 필요하면 API 서버는 작업을 설명하는
+`imagepolicy.k8s.io/v1alpha1` `ImageReview` 오브젝트를 JSON으로 직렬화하여 POST 요청으로 보낸다.
+이 오브젝트에는 허용 여부를 결정할 컨테이너를 설명하는 필드와
+`*.image-policy.k8s.io/*`에 일치하는 모든 파드 어노테이션이 포함된다.
+
+{{< note >}}
+웹훅 API 오브젝트에는 다른 쿠버네티스 API 오브젝트와 동일한 버전
+호환성 규칙이 적용된다. 구현자는 알파 오브젝트의 호환성 보장이 더 느슨함에
+유의하고, 올바르게 역직렬화할 수 있도록 요청의 `apiVersion` 필드를
+확인해야 한다.
+또한 API 서버에서 `imagepolicy.k8s.io/v1alpha1` API 익스텐션(extension)
+그룹을 활성화해야 한다(`--runtime-config=imagepolicy.k8s.io/v1alpha1=true`).
+{{< /note >}}
+
+요청 본문의 예시는 다음과 같다.
+
+```json
+{
+  "apiVersion": "imagepolicy.k8s.io/v1alpha1",
+  "kind": "ImageReview",
+  "spec": {
+    "containers": [
+      {
+        "image": "myrepo/myimage:v1"
+      },
+      {
+        "image": "myrepo/myimage@sha256:beb6bd6a68f114c1dc2ea4b28db81bdf91de202a9014972bec5e4d9171d90ed"
+      }
+    ],
+    "annotations": {
+      "mycluster.image-policy.k8s.io/ticket-1234": "break-glass"
+    },
+    "namespace": "mynamespace"
+  }
+}
+```
+
+원격 서비스는 요청의 `status` 필드를 채워 접근을 허용하거나
+허용하지 않는 응답을 반환해야 한다. 응답 본문의 `spec` 필드는 무시되며
+생략할 수 있다. 접근을 허용하는 응답은 다음과 같다.
+
+```json
+{
+  "apiVersion": "imagepolicy.k8s.io/v1alpha1",
+  "kind": "ImageReview",
+  "status": {
+    "allowed": true
+  }
+}
+```
+
+접근을 허용하지 않으려면 서비스는 다음과 같이 반환한다.
+
+```json
+{
+  "apiVersion": "imagepolicy.k8s.io/v1alpha1",
+  "kind": "ImageReview",
+  "status": {
+    "allowed": false,
+    "reason": "image currently blacklisted"
+  }
+}
+```
+
+{{< note >}}
+`ImageReview` 오브젝트에는 파드에서 컨테이너로 실행할 모든 이미지가
+포함된다. 파드 명세의 containers,
+initContainers, ephemeralContainers 필드에 지정된 이미지가 이에 해당한다.
+따라서 이미지 볼륨에 포함된 이미지는
+ImagePolicyWebhook의 적용 범위에 포함되지 않는다.
+{{< /note >}}
+
+자세한 문서는
+[`imagepolicy.v1alpha1` API](/docs/reference/config-api/imagepolicy.v1alpha1/)를 참고한다.
+
+#### 어노테이션으로 확장하기 {#extending-with-annotations}
+
+파드의 어노테이션 중 `*.image-policy.k8s.io/*`에 일치하는 것은 모두 웹훅으로 전송된다.
+어노테이션을 전송하면 이미지 정책 백엔드를 알고 있는 사용자가
+추가 정보를 보낼 수 있으며, 백엔드 구현에 따라
+서로 다른 정보를 받을 수 있다.
+
+여기에 포함할 수 있는 정보의 예시는 다음과 같다.
+
+* 비상시에 정책을 재정의하기 위한 "긴급 접근(break glass)" 요청.
+* 긴급 접근 요청을 기록한 티켓 시스템의 티켓 번호.
+* 정책 서버가 별도로 조회하지 않도록 제공된 이미지의 imageID에 대한 힌트.
+
+어떤 경우든 어노테이션은 사용자가 제공하며, 쿠버네티스는 이를 어떠한 방식으로도 검증하지 않는다.
+
+### LimitPodHardAntiAffinityTopology {#limitpodhardantiaffinitytopology}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 `requiredDuringSchedulingIgnoredDuringExecution`에서
+`kubernetes.io/hostname` 이외의 `AntiAffinity` 토폴로지 키를 정의하는 모든 파드를 거부한다.
+
+이 어드미션 컨트롤러는 기본적으로 비활성화되어 있다.
+
+### LimitRanger {#limitranger}
+
+**유형**: 변형 및 검증.
+
+이 어드미션 컨트롤러는 수신 요청을 관찰하고 `Namespace`의 `LimitRange` 오브젝트에
+나열된 제약 조건을 위반하지 않는지 확인한다. 쿠버네티스 배포에서
+`LimitRange` 오브젝트를 사용한다면 이러한 제약을 적용하기 위해 이 어드미션 컨트롤러를
+반드시 사용해야 한다. LimitRanger는 리소스 요청을 지정하지 않은 파드에 기본 리소스 요청을
+적용하는 데 사용할 수도 있다. 현재 기본 LimitRanger는 `default` 네임스페이스의 모든
+파드에 0.1 CPU 요구량을 적용한다.
+
+자세한 내용은 [리밋레인지(LimitRange) API 레퍼런스](/docs/reference/kubernetes-api/policy-resources/limit-range-v1/)와
+[리밋레인지 예시](/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)를
+참고한다.
+
+### MutatingAdmissionPolicy {#mutatingadmissionpolicy}
+
+**유형**: 변형.
+
+[이 어드미션 컨트롤러](/docs/reference/access-authn-authz/mutating-admission-policy/)는 일치하는 수신 요청에 대해
+선언적인 프로세스 내부 변형을 구현한다. 변형은 어플라이 구성이나 JSON 패치를 사용하여
+일치하는 오브젝트를 수정하는 CEL 표현식으로 정의된다.
+외부 HTTP 호출에 의존하지 않으면서
+[MutatingAdmissionWebhook](#mutatingadmissionwebhook)보다 지연 시간이 짧은
+대안을 제공한다.
+MutatingAdmissionPolicy 중 하나라도 실패하면 요청이 실패한다.
+
+### MutatingAdmissionWebhook {#mutatingadmissionwebhook}
+
+**유형**: 변형.
+
+이 어드미션 컨트롤러는 요청과 일치하는 모든 변형 웹훅을 호출한다. 일치하는
+웹훅은 순차적으로 호출되며, 각 웹훅은 필요에 따라 오브젝트를 수정할 수 있다.
+
+이 어드미션 컨트롤러는 이름에서 알 수 있듯이 변형 단계에서만 실행된다.
+
+이 컨트롤러가 호출한 웹훅에 부수 효과(예: 쿼터 감소)가 있다면,
+뒤이어 실행되는 웹훅이나 검증 어드미션 컨트롤러가 요청 완료를 허용한다고
+보장할 수 없으므로 *반드시* 조정 시스템이 있어야 한다.
+
+MutatingAdmissionWebhook을 비활성화하면 `--runtime-config` 플래그를 통해
+`admissionregistration.k8s.io/v1` 그룹/버전의 `MutatingWebhookConfiguration`
+오브젝트도 비활성화해야 한다. 두 가지 모두 기본적으로 활성화되어 있다.
+
+#### 변형 웹훅 작성 및 설치 시 주의 사항 {#use-caution-when-authoring-and-installing-mutating-webhooks}
+
+* 생성하려던 오브젝트와 반환받은 오브젝트가 다르면
+  사용자가 혼란을 느낄 수 있다.
+* 기본 제공 제어 루프가 생성하려던 오브젝트와 다시 읽은 오브젝트가
+  다르면 제어 루프가 정상 동작하지 않을 수 있다.
+  * 원래 설정되지 않은 필드를 설정하는 것이 원래 요청에서 설정된 필드를
+    덮어쓰는 것보다 문제를 일으킬 가능성이 낮다. 후자는 피한다.
+* 기본 제공 리소스나 서드파티 리소스의 제어 루프가 향후 변경되면
+  현재 잘 동작하는 웹훅도 동작하지 않을 수 있다. 웹훅 설치 API가
+  확정되더라도 가능한 모든 웹훅 동작이 무기한 지원된다고
+  보장되지는 않는다.
+
+### NamespaceAutoProvision {#namespaceautoprovision}
+
+**유형**: 변형.
+
+이 어드미션 컨트롤러는 네임스페이스에 속하는 리소스에 대한 모든 수신 요청을 검사하고,
+참조하는 네임스페이스가 존재하는지 확인한다.
+네임스페이스를 찾을 수 없으면 생성한다.
+이 어드미션 컨트롤러는 사용 전에 네임스페이스를 미리 생성하도록
+제한하고 싶지 않은 배포 환경에서 유용하다.
+
+### NamespaceExists {#namespaceexists}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 `Namespace` 자체를 제외한 네임스페이스 범위 리소스의 모든 요청을 검사한다.
+요청에서 참조하는 네임스페이스가 존재하지 않으면 요청을 거부한다.
+
+### NamespaceLifecycle {#namespacelifecycle}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 종료 중인 `Namespace`에 새 오브젝트를 생성하지 못하도록
+하고, 존재하지 않는 `Namespace`에 대한 요청을 거부한다.
+또한 시스템용으로 예약된 세 네임스페이스인 `default`,
+`kube-system`, `kube-public`의 삭제를 방지한다.
+
+`Namespace`를 삭제하면 해당 네임스페이스의 모든 오브젝트(파드, 서비스 등)를
+제거하는 일련의 작업이 시작된다. 이 과정의 무결성을 보장하려면
+이 어드미션 컨트롤러를 실행할 것을 강력히 권장한다.
+
+### NodeDeclaredFeatureValidator {#nodedeclaredfeaturevalidator}
+
+{{< feature-state feature_gate_name="NodeDeclaredFeatures" >}}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 바인딩된 파드에 대한 쓰기를 가로채어,
+변경 사항이 파드가 현재 실행 중인 노드에서 선언한 기능과
+호환되는지 확인한다. 노드의 `.status.declaredFeatures` 필드를 사용하여
+활성화된 기능 집합을 확인한다. 파드 업데이트에 현재 노드의 기능
+목록에 없는 기능이 필요하면, 어드미션 컨트롤러는
+업데이트 요청을 거부한다. 이를 통해 파드가 스케줄된 후 기능
+불일치로 인해 런타임 오류가 발생하는 것을 방지한다.
+
+이 어드미션 컨트롤러는 [`NodeDeclaredFeatures`](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#NodeDeclaredFeatures) 기능 게이트를
+활성화하면 기본적으로 활성화된다.
+
+### NodeRestriction {#noderestriction}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 kubelet이 수정할 수 있는 `Node`와 `Pod` 오브젝트를 제한한다. 이 어드미션 컨트롤러의 제한을 받으려면,
+kubelet은 `system:node:<nodeName>` 형식의 사용자 이름으로 `system:nodes` 그룹의 자격 증명을 사용해야 한다.
+이러한 kubelet은 자신의 `Node` API 오브젝트와 자신의 노드에 바인딩된 `Pod` API 오브젝트만 수정할 수 있다.
+kubelet은 자신의 `Node` API 오브젝트에서 테인트를 업데이트하거나 제거할 수 없다.
+
+`NodeRestriction` 어드미션 플러그인은 kubelet이 자신의 `Node` API 오브젝트를 삭제하지 못하도록 하며,
+`kubernetes.io/` 또는 `k8s.io/` 접두사 아래의 레이블 수정에 다음과 같은 제한을 적용한다.
+
+* **금지**(kubelet은 이 레이블을 수정할 수 없음)
+  * `node-restriction.kubernetes.io/` 접두사를 사용하는 레이블. 이 접두사는 관리자가 워크로드 격리를 위해 `Node` 오브젝트에 레이블을 지정하는 용도로 예약되어 있다.
+  * `node-role.kubernetes.io/` 접두사를 사용하는 레이블(예: `node-role.kubernetes.io/control-plane`). 권한이 없는 노드가 클러스터 역할을 스스로 선언하지 못하도록 제한한다.
+* **허용**(kubelet이 추가, 제거, 업데이트할 수 있음)
+  * `kubernetes.io/hostname`
+  * `kubernetes.io/arch`
+  * `kubernetes.io/os`
+  * `beta.kubernetes.io/instance-type`
+  * `node.kubernetes.io/instance-type`
+  * `failure-domain.beta.kubernetes.io/region`(사용 중단)
+  * `failure-domain.beta.kubernetes.io/zone`(사용 중단)
+  * `topology.kubernetes.io/region`
+  * `topology.kubernetes.io/zone`
+  * `kubelet.kubernetes.io/` 접두사를 사용하는 레이블
+  * `node.kubernetes.io/` 접두사를 사용하는 레이블
+* **예약됨**
+  kubelet이 `kubernetes.io` 또는 `k8s.io` 접두사 아래의 다른 레이블을 사용하는 것은 예약되어 있다.
+  `NodeRestriction` 어드미션 플러그인은 인가되지 않은 자체 레이블 지정을 방지하기 위해 일반적으로 이를 허용하지 않지만,
+  향후 기능의 일부로 이러한 접두사 아래에 추가 레이블을 허용할 수 있다.
+
+`ServiceAccountNodeAudienceRestriction` [기능 게이트](/docs/reference/command-line-tools-reference/feature-gates/)를
+활성화하면, 이 어드미션 플러그인은 kubelet이 `TokenRequest` API를 통해 서비스 어카운트 토큰을
+요청할 수 있는 오디언스(audience)도 제한한다. kubelet은 해당 노드의 파드에서 이미
+참조하는 오디언스(프로젝티드 서비스 어카운트 토큰 볼륨 또는 CSI 드라이버 토큰 요청으로 참조)나,
+RBAC의 `request-serviceaccounts-token-audience` 동사를 통해 명시적으로
+허용된 오디언스에 대해서만 토큰을 요청할 수 있다. 자세한 내용은
+[서비스 어카운트 토큰 오디언스 제한](/docs/reference/access-authn-authz/node/#service-account-token-audience-restriction)을 참고한다.
+
+향후 버전에서는 kubelet이 올바르게 동작하는 데 필요한 최소 권한만 갖도록
+추가 제한이 적용될 수 있다.
+
+### OwnerReferencesPermissionEnforcement {#ownerreferencespermissionenforcement}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 오브젝트에 대한 **delete** 권한을 가진 사용자만
+`metadata.ownerReferences`를 변경할 수 있도록 해당 필드에 대한 접근을 보호한다.
+또한 참조된 *소유자(owner)* 의 `finalizers` 하위 리소스에 대한
+**update** 권한을 가진 사용자만 오브젝트의 `metadata.ownerReferences[x].blockOwnerDeletion`을
+변경할 수 있도록 해당 필드에 대한 접근을 보호한다.
+
+### PersistentVolumeClaimResize {#persistentvolumeclaimresize}
+
+{{< feature-state for_k8s_version="v1.24" state="stable" >}}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 수신되는 `PersistentVolumeClaim` 크기 조정 요청을
+확인하기 위한 추가 검증을 구현한다.
+
+`PersistentVolumeClaimResize` 어드미션 컨트롤러를 활성화할 것을 권장한다.
+이 어드미션 컨트롤러는 클레임의 `StorageClass`에서 `allowVolumeExpansion`을 `true`로
+설정하여 크기 조정을 명시적으로 활성화하지 않는 한, 기본적으로 모든 클레임의 크기 조정을 차단한다.
+
+예를 들어 다음 `StorageClass`에서 생성된 모든 `PersistentVolumeClaim`은 볼륨 확장을 지원한다.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gluster-vol-default
+provisioner: kubernetes.io/glusterfs
+parameters:
+  resturl: "http://192.168.10.100:8080"
+  restuser: ""
+  secretNamespace: ""
+  secretName: ""
+allowVolumeExpansion: true
+```
+
+퍼시스턴트볼륨클레임에 대한 자세한 내용은 [퍼시스턴트볼륨클레임](/docs/concepts/storage/persistent-volumes/#퍼시스턴트볼륨클레임)을 참고한다.
+
+### PodNodeSelector {#podnodeselector}
+
+{{< feature-state for_k8s_version="v1.5" state="alpha" >}}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 네임스페이스 어노테이션과 전역 구성을 읽어,
+네임스페이스 내에서 사용할 노드 셀렉터의 기본값을 설정하고 사용 범위를 제한한다.
+
+이 어드미션 컨트롤러는 기본적으로 비활성화되어 있다.
+
+#### 구성 파일 형식 {#configuration-file-format}
+
+`PodNodeSelector`는 구성 파일을 사용하여 백엔드 동작의 옵션을 설정한다.
+향후 릴리스에서는 구성 파일 형식이 버전이 지정된 파일로 바뀔 예정임에 유의한다.
+이 파일은 JSON 또는 YAML 형식일 수 있으며, 다음과 같은 형식을 사용한다.
+
+```yaml
+podNodeSelectorPluginConfig:
+  clusterDefaultNodeSelector: name-of-node-selector
+  namespace1: name-of-node-selector
+  namespace2: name-of-node-selector
+```
+
+API 서버의 커맨드라인 플래그 `--admission-control-config-file`에 제공한 파일에서
+`PodNodeSelector` 구성 파일을 참조한다.
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodNodeSelector
+  path: podnodeselector.yaml
+...
+```
+
+#### 구성 어노테이션 형식 {#configuration-annotation-format}
+
+`PodNodeSelector`는 `scheduler.alpha.kubernetes.io/node-selector` 어노테이션 키를 사용하여
+네임스페이스에 노드 셀렉터를 할당한다.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/node-selector: name-of-node-selector
+  name: namespace3
+```
+
+#### 내부 동작 {#internal-behavior}
+
+이 어드미션 컨트롤러는 다음과 같이 동작한다.
+
+1. `Namespace`에 `scheduler.alpha.kubernetes.io/node-selector` 키의 어노테이션이 있으면,
+   해당 값을 노드 셀렉터로 사용한다.
+2. 네임스페이스에 해당 어노테이션이 없으면, `PodNodeSelector` 플러그인 구성 파일에 정의된
+   `clusterDefaultNodeSelector`를 노드 셀렉터로 사용한다.
+3. 파드의 노드 셀렉터와 네임스페이스의 노드 셀렉터가 충돌하는지 검사한다.
+   충돌하면 거부한다.
+4. 파드의 노드 셀렉터를 플러그인 구성 파일에 정의된 네임스페이스별 허용 셀렉터와
+   비교한다. 충돌하면 거부한다.
+
+{{< note >}}
+PodNodeSelector를 사용하면 파드가 특정 레이블을 가진 노드에서 실행되도록 강제할 수 있다. 특정 테인트가
+있는 노드에서 파드가 실행되지 않도록 하는 PodTolerationRestriction 어드미션 플러그인도 참고한다.
+{{< /note >}}
+
+### PodSecurity {#podsecurity}
+
+{{< feature-state for_k8s_version="v1.25" state="stable" >}}
+
+**유형**: 검증.
+
+PodSecurity 어드미션 컨트롤러는 새 파드를 허용하기 전에
+검사하고, 요청한 시큐리티 컨텍스트와 파드가 속할 네임스페이스에
+허용된 [파드 시큐리티 표준](/docs/concepts/security/pod-security-standards/)의
+제한을 기준으로 해당 파드를 허용할지 결정한다.
+
+자세한 내용은 [파드 시큐리티 어드미션](/docs/concepts/security/pod-security-admission/)
+문서를 참고한다.
+
+PodSecurity는 PodSecurityPolicy라는 이전 어드미션 컨트롤러를 대체했다.
+
+### PodTolerationRestriction {#podtolerationrestriction}
+
+{{< feature-state for_k8s_version="v1.7" state="alpha" >}}
+
+**유형**: 변형 및 검증.
+
+PodTolerationRestriction 어드미션 컨트롤러는 파드의 톨러레이션과
+해당 네임스페이스의 톨러레이션 사이에 충돌이 있는지 확인한다.
+충돌이 있으면 파드 요청을 거부한다.
+그런 다음 네임스페이스에 어노테이션으로 지정된 톨러레이션을 파드의 톨러레이션에 합친다.
+결과로 얻은 톨러레이션을 네임스페이스에 어노테이션으로 지정된 허용 톨러레이션 목록과 비교한다.
+검사를 통과하면 파드 요청을 허용하고, 그렇지 않으면 거부한다.
+
+파드의 네임스페이스에 기본 톨러레이션이나 허용 톨러레이션이 어노테이션으로
+지정되어 있지 않으면, 클러스터 수준의 기본 톨러레이션이나 허용 톨러레이션 목록이
+지정된 경우 이를 대신 사용한다.
+
+네임스페이스의 톨러레이션은 `scheduler.alpha.kubernetes.io/defaultTolerations` 어노테이션 키로 할당한다.
+허용 톨러레이션 목록은 `scheduler.alpha.kubernetes.io/tolerationsWhitelist` 어노테이션 키로 추가할 수 있다.
+
+네임스페이스 어노테이션의 예시는 다음과 같다.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apps-that-need-nodes-exclusively
+  annotations:
+    scheduler.alpha.kubernetes.io/defaultTolerations: '[{"operator": "Exists", "effect": "NoSchedule", "key": "dedicated-node"}]'
+    scheduler.alpha.kubernetes.io/tolerationsWhitelist: '[{"operator": "Exists", "effect": "NoSchedule", "key": "dedicated-node"}]'
+```
+
+이 어드미션 컨트롤러는 기본적으로 비활성화되어 있다.
+
+### PodTopologyLabels {#podtopologylabels}
+
+{{< feature-state feature_gate_name="PodTopologyLabelsAdmission" >}}
+
+**유형**: 변형
+
+PodTopologyLabels 어드미션 컨트롤러는 노드에 바인딩된 모든 파드의
+`pods/binding` 하위 리소스를 변형하여, 바인딩된 노드와 일치하는 토폴로지 레이블을 추가한다.
+이를 통해 노드의 토폴로지 레이블을 파드 레이블로 사용할 수 있으며,
+[다운워드(Downward) API](/docs/concepts/workloads/pods/downward-api/)를 사용하여
+실행 중인 컨테이너에 노출할 수 있다.
+이 컨트롤러를 통해 사용할 수 있는 레이블은
+[topology.kubernetes.io/region](/docs/reference/labels-annotations-taints/#topologykubernetesioregion)과
+[topology.kubernetes.io/zone](/docs/reference/labels-annotations-taints/#topologykubernetesiozone)이다.
+
+{{<note>}}
+변형 어드미션 웹훅이 `pods/binding` 하위 리소스의 레이블을 추가하거나 수정하면,
+이 컨트롤러에 의해 해당 변경 사항이 파드 레이블에 전파되며,
+키가 충돌하는 레이블을 덮어쓴다.
+{{</note>}}
+
+이 어드미션 컨트롤러는 `PodTopologyLabelsAdmission` 기능 게이트를 활성화하면 활성화된다.
+
+### Priority {#priority}
+
+**유형**: 변형 및 검증.
+
+Priority 어드미션 컨트롤러는 `priorityClassName` 필드를 사용하여 우선순위의
+정숫값을 채운다.
+우선순위 클래스를 찾을 수 없으면 파드를 거부한다.
+
+### ResourceQuota {#resourcequota}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 수신 요청을 관찰하고 `Namespace`의 `ResourceQuota` 오브젝트에
+나열된 제약 조건을 위반하지 않는지 확인한다. 쿠버네티스 배포에서
+`ResourceQuota` 오브젝트를 사용한다면 쿼터 제약을 적용하기 위해
+이 어드미션 컨트롤러를 반드시 사용해야 한다.
+
+자세한 내용은 [리소스쿼터(ResourceQuota) API 레퍼런스](/docs/reference/kubernetes-api/policy-resources/resource-quota-v1/)와
+[리소스 쿼터 예시](/docs/concepts/policy/resource-quotas/)를 참고한다.
+
+### RuntimeClass {#runtimeclass}
+
+**유형**: 변형 및 검증.
+
+[파드 오버헤드](/docs/concepts/scheduling-eviction/pod-overhead/)를 구성한 런타임클래스(RuntimeClass)를
+정의하면, 이 어드미션 컨트롤러가 수신되는 파드를 검사한다.
+이 어드미션 컨트롤러를 활성화하면 오버헤드가 이미 설정된
+모든 파드 생성 요청을 거부한다.
+`.spec`에 런타임클래스를 구성하고 선택한 파드의 경우,
+이 어드미션 컨트롤러는 해당 런타임클래스에 정의된 값을 기준으로
+파드의 `.spec.overhead`를 설정한다.
+
+자세한 내용은 [파드 오버헤드](/docs/concepts/scheduling-eviction/pod-overhead/)도
+참고한다.
+
+### ServiceAccount {#serviceaccount}
+
+**유형**: 변형 및 검증.
+
+이 어드미션 컨트롤러는
+[서비스어카운트(ServiceAccount)](/docs/tasks/configure-pod-container/configure-service-account/)를 위한 자동화를 구현한다.
+쿠버네티스 프로젝트는 이 어드미션 컨트롤러의 활성화를 강력히 권장한다.
+쿠버네티스 `ServiceAccount` 오브젝트를 사용하려면
+이 어드미션 컨트롤러를 활성화해야 한다.
+
+시크릿(Secret)의 보안을 강화하려면, 별도의 네임스페이스를 사용하여 마운트된 시크릿에 대한 접근을 격리한다.
+
+### StorageObjectInUseProtection
+
+**유형**: 변형.
+
+`StorageObjectInUseProtection` 플러그인은 새로 생성된 퍼시스턴트볼륨클레임(PVC) 또는 퍼시스턴트볼륨(PersistentVolume, PV)에
+`kubernetes.io/pvc-protection` 또는 `kubernetes.io/pv-protection` 파이널라이저(finalizer)를 추가한다.
+사용자가 PVC 또는 PV를 삭제하더라도, PVC 또는 PV 보호 컨트롤러가 해당
+PVC 또는 PV에서 파이널라이저를 제거할 때까지 PVC 또는 PV는 제거되지 않는다.
+자세한 내용은
+[사용 중인 스토리지 오브젝트 보호](/docs/concepts/storage/persistent-volumes/#사용-중인-스토리지-오브젝트-보호)를
+참고한다.
+
+### TaintNodesByCondition {#taintnodesbycondition}
+
+**유형**: 변형.
+
+이 어드미션 컨트롤러는 새로 생성된 노드에 `NotReady`와 `NoSchedule`
+{{< glossary_tooltip text="테인트" term_id="taint" >}}를 설정한다. 이를 통해 보고된 상태를 정확히 반영하도록
+새 노드의 테인트를 업데이트하기 전에 파드가 해당 노드에 스케줄될 수 있는
+경쟁 상태를 방지한다.
+
+### ValidatingAdmissionPolicy {#validatingadmissionpolicy}
+
+**유형**: 검증.
+
+[이 어드미션 컨트롤러](/docs/reference/access-authn-authz/validating-admission-policy/)는 일치하는 수신 요청에 대한 CEL 검증을 구현한다.
+`validatingadmissionpolicy` 기능 게이트와 `admissionregistration.k8s.io/v1alpha1` 그룹/버전을 모두 활성화하면 활성화된다.
+ValidatingAdmissionPolicy 중 하나라도 실패하면 요청이 실패한다.
+
+### ValidatingAdmissionWebhook {#validatingadmissionwebhook}
+
+**유형**: 검증.
+
+이 어드미션 컨트롤러는 요청과 일치하는 모든 검증 웹훅을 호출한다. 일치하는
+웹훅은 병렬로 호출되며, 하나라도 요청을 거부하면 요청이
+실패한다. 이 어드미션 컨트롤러는 검증 단계에서만 실행된다. `MutatingAdmissionWebhook` 어드미션
+컨트롤러가 호출하는 웹훅과 달리, 이 컨트롤러가 호출하는 웹훅은 오브젝트를 변경할 수 없다.
+
+이 컨트롤러가 호출한 웹훅에 부수 효과(예: 쿼터 감소)가 있다면,
+뒤이어 실행되는 웹훅이나 다른 검증 어드미션 컨트롤러가 요청 완료를 허용한다고
+보장할 수 없으므로 *반드시* 조정 시스템이 있어야 한다.
+
+ValidatingAdmissionWebhook을 비활성화하면 `--runtime-config` 플래그를 통해
+`admissionregistration.k8s.io/v1` 그룹/버전의 `ValidatingWebhookConfiguration`
+오브젝트도 비활성화해야 한다.
+
+## 권장하는 어드미션 컨트롤러 집합 {#is-there-a-recommended-set-of-admission-controllers-to-use}
+
+권장하는 어드미션 컨트롤러는 기본적으로 활성화되어 있으므로
+([여기](/docs/reference/command-line-tools-reference/kube-apiserver/#options)에 표시됨),
+명시적으로 지정할 필요가 없다.
+`--enable-admission-plugins` 플래그를 사용하면 기본 집합 외에 추가 어드미션 컨트롤러를
+활성화할 수 있다(**순서는 중요하지 않다**).

--- a/content/ko/docs/reference/access-authn-authz/authentication.md
+++ b/content/ko/docs/reference/access-authn-authz/authentication.md
@@ -1,0 +1,2055 @@
+---
+# reviewers:
+# - erictune
+# - lavalamp
+# - deads2k
+# - liggitt
+title: 사용자 인증
+content_type: concept
+weight: 10
+---
+
+<!-- overview -->
+이 페이지는 [쿠버네티스 API](/docs/concepts/overview/kubernetes-api/)에 대한 인증을 중심으로
+쿠버네티스 인증의 개요를 제공한다.
+
+<!-- body -->
+## 쿠버네티스의 사용자 {#users-in-kubernetes}
+
+모든 쿠버네티스 클러스터에는 쿠버네티스가 관리하는 서비스 어카운트와
+일반 사용자라는 두 가지 사용자 범주가 있다.
+
+일반 사용자는 클러스터와 독립적인 서비스가 다음과 같은 방식으로 관리한다고 가정한다.
+
+- 관리자가 개인 키를 배포한다.
+- Keystone이나 Google Accounts와 같은 사용자 저장소를 사용한다.
+- 사용자 이름과 비밀번호 목록이 있는 파일을 사용한다.
+
+이와 관련하여, _쿠버네티스에는 일반 사용자 계정을 나타내는 오브젝트가 없다._
+API 호출을 통해 일반 사용자를 클러스터에 추가할 수 없다.
+
+API 호출로 일반 사용자를 추가할 수는 없지만, 클러스터의 인증 기관
+(Certificate Authority, CA)이 서명한 유효한 인증서를 제시하는
+사용자는 인증된 것으로 간주된다. 이 구성에서 쿠버네티스는
+인증서 '주체(subject)'의 일반 이름(common name) 필드(예:
+"/CN=bob")에서 사용자 이름을 결정한다. 이후 역할 기반 접근 제어
+(Role-Based Access Control, RBAC) 하위 시스템이 해당 사용자가 리소스에
+특정 작업을 수행하도록 인가되었는지 결정한다.
+
+반면 서비스 어카운트는 쿠버네티스 API가 관리하는 사용자이다. 특정
+네임스페이스에 바인딩되며 API 서버가 자동으로 생성하거나 API 호출로
+수동 생성한다. 서비스 어카운트는 `Secrets`로 저장된 자격 증명 집합과
+연결되며, 이 자격 증명은 파드에 마운트되어 클러스터 내부 프로세스가
+쿠버네티스 API와 통신할 수 있도록 한다.
+
+API 요청은 일반 사용자나 서비스 어카운트에 연결되거나,
+[익명 요청](#anonymous-requests)으로 처리된다. 즉, 워크스테이션에서 `kubectl`을 입력하는
+사용자부터 노드의 `kubelets`, 컨트롤 플레인 구성 요소에 이르기까지
+클러스터 내부 또는 외부의 모든 프로세스는 API 서버에 요청할 때 인증해야 하며,
+그렇지 않으면 익명 사용자로 처리된다.
+
+인증을 시도하여 성공하면 API 서버는 자동으로 해당 사용자를
+특별한 그룹인 `system:authenticated`의 멤버로 표시한다.
+
+## 인증 전략 {#authentication-strategies}
+
+쿠버네티스는 인증 플러그인을 통해 클라이언트 인증서, 베어러(bearer) 토큰 또는
+인증 프록시를 사용하여 API 요청을 인증한다. API 서버에 HTTP 요청이
+전달되면, 플러그인은 요청에 다음 속성을 연결하려고
+시도한다.
+
+* 사용자 이름: 최종 사용자를 식별하는 문자열이다. 일반적인 값으로 `kube-admin`이나 `jane@example.com` 등이 있다.
+* UID: 최종 사용자를 식별하는 문자열로, 사용자 이름보다 일관되고 고유한 식별자를 제공하려는 목적이다.
+* 그룹: 문자열 집합으로, 각 문자열은 이름이 지정된 논리적 사용자 집합에 사용자가 속함을 나타낸다.
+  일반적인 값으로 `system:masters`나 `devops-team` 등이 있다.
+* 추가 필드: 문자열을 문자열 목록에 매핑하며, 인가자에게 유용할 수 있는 추가 정보를 담는다.
+
+{{< note >}}
+인증 시스템은 이 값들의 의미를 해석하지 않으며,
+[인가자](/docs/reference/access-authn-authz/authorization/)가 해석할 때만 의미를 가진다.
+{{< /note >}}
+
+## 익명 요청 {#anonymous-requests}
+
+익명 접근을 활성화하면 구성된 다른 인증 방식에서 거부하지 않은 요청을
+익명 요청으로 처리하고, 사용자 이름 `system:anonymous`와 그룹
+`system:unauthenticated`를 부여한다.
+
+예를 들어 토큰 인증을 구성하고 익명 접근을 활성화한 서버에서,
+유효하지 않은 베어러 토큰을 제공하는 요청은 `401 Unauthorized` 오류를 받는다.
+베어러 토큰을 제공하지 않는 요청은 익명 요청으로 처리된다.
+
+`AlwaysAllow` 이외의
+[인가 모드](/docs/reference/access-authn-authz/authorization/#authorization-modules)를
+사용하면 익명 접근이 기본적으로 활성화된다. API 서버에 `--anonymous-auth=false`
+커맨드라인 옵션을 전달하여 비활성화할 수 있다.
+기본 제공 ABAC 및 RBAC 인가자는 `system:anonymous` 사용자나
+`system:unauthenticated` 그룹에 대한 명시적인 인가를 요구한다. 쿠버네티스 1.5 이하 버전의
+기존 정책 규칙이 있다면, `*` 사용자나 `*` 그룹에 접근 권한을 부여하는
+해당 규칙은 익명 사용자에게 자동으로 접근을 허용하지 않는다.
+
+### 익명 인증자 구성 {#anonymous-authenticator-configuration}
+
+{{< feature-state feature_gate_name="AnonymousAuthConfigurableEndpoints" >}}
+
+`AuthenticationConfiguration`을 사용하여 익명 인증자를
+구성할 수 있다. `AuthenticationConfiguration` 파일에 anonymous 필드를
+설정하면 `--anonymous-auth` 커맨드라인 옵션을 설정할 수 없다.
+
+인증 구성 파일을 사용하여 익명 인증자를 구성하는 주요 장점은
+익명 인증을 활성화하거나 비활성화하는 것 외에도,
+어떤 엔드포인트에서 익명 인증을 지원할지 구성할 수 있다는 점이다.
+
+인증 구성 파일의 예시는 다음과 같다.
+
+{{< highlight yaml "linenos=false,hl_lines=2-5" >}}
+---
+#
+# CAUTION: this is an example configuration.
+#          Do not use this as-is for your own cluster!
+#
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+anonymous:
+  enabled: true
+  conditions:
+  - path: /livez
+  - path: /readyz
+  - path: /healthz
+{{< /highlight >}}
+
+위 구성에서는 `/livez`, `/readyz`, `/healthz` 엔드포인트만
+익명 요청으로 접근할 수 있다. 인가 구성에서 허용하더라도 다른
+엔드포인트에는 익명으로 접근할 수 없다.
+
+## 인증 방식 {#authentication-methods}
+
+여러 인증 방식을 동시에 활성화할 수 있다. 일반적으로 최소한 다음 두 가지 방식을 사용해야 한다.
+
+- 서비스어카운트(ServiceAccount)를 위한 [서비스 어카운트 토큰](/docs/concepts/security/service-accounts/#authenticating-credentials)
+- (일반) 사용자 인증을 위한 하나 이상의 다른 방식
+
+사용 가능한 인증 방식은 다음과 같다.
+
+* [X.509 클라이언트 인증서](#x509-client-certificates)
+* [부트스트랩 토큰](#bootstrap-tokens)
+* [서비스 어카운트 토큰](#service-account-tokens)
+* [정적 토큰 파일](#static-token-file)
+* [외부 통합](#external-integrations)
+  * [JSON 웹 토큰](#json-web-token-authentication)
+  * [OpenID Connect 토큰](#openid-connect-tokens)
+  * [웹훅 토큰 인증](#webhook-token-authentication)
+  * [인증 리버스 프록시](#authenticating-proxy)
+
+여러 인증자 모듈을 활성화하면 요청을 처음으로 인증하는 데 성공한
+모듈에서 평가를 종료한다.
+API 서버는 인증자의 실행 순서를 보장하지 않는다.
+
+### X.509 클라이언트 인증서 {#x509-client-certificates}
+
+클러스터의 _클라이언트 신뢰_ 인증 기관(CA)이 서명한 유효한 클라이언트 인증서를
+제시하는 모든 쿠버네티스 클라이언트는 인증된 것으로 간주된다. 이 구성에서 쿠버네티스는
+인증서 _주체_ 의 `commonName` 필드로 사용자 이름을 결정한다.
+(예를 들어 `commonName=bob`은 사용자 이름이 "bob"인 사용자를 나타낸다.)
+이후 쿠버네티스 [인가](/docs/reference/access-authn-authz/authorization)
+메커니즘이 해당 사용자의 리소스에 대한 특정 작업 수행을 허용할지 결정한다.
+
+클라이언트 인증서 인증은 API 서버에 `--client-ca-file=<SOMEFILE>`
+옵션을 전달하여 활성화한다.
+이 옵션은 클러스터의 _클라이언트 신뢰_ 인증 기관을 구성한다.
+참조하는 파일에는 API 서버가 클라이언트 인증서를 검증할 때
+사용할 수 있는 인증 기관이 하나 이상 포함되어야 한다.
+클라이언트 인증서가 제시되고 검증되면, 주체의 일반 이름을 해당 요청의
+사용자 이름으로 사용한다. 클라이언트 인증서는 조직 필드를 사용하여 사용자의 그룹 소속을
+나타낼 수도 있다. 사용자에게 여러 그룹 소속을 포함하려면,
+인증서에 여러 조직 필드를 포함한다.
+
+클라이언트 인증서 생성 방법은 [인증서 관리](/docs/tasks/administer-cluster/certificates/)를 참고하거나, 이 페이지 뒷부분의 간단한 [예시](#x509-client-certificates-example)를 읽는다.
+
+#### 쿠버네티스와 호환되는 클라이언트 인증서 {#x509-client-certificates-k8s}
+
+API 서버가 클라이언트 인증서에 대해 수락하는 신뢰 체인의 CA에서 발급한
+유효한 인증서를 제시하여 쿠버네티스에 인증할 수 있다.
+인증서는 유효해야 하며, API 서버는 X.509의 `notBefore` 및 `notAfter` 속성을 기준으로 이를 확인한다. 또한 인증서의
+_확장 키 용도(extended key usage)_ 에 클라이언트 인증(`ClientAuth`)이 포함되어야 한다.
+
+{{< note >}}
+쿠버네티스 {{< skew currentVersion >}}는 인증서 _폐기(revocation)_ 를 지원하지 않는다.
+발급된 인증서는 만료될 때까지 유효하다.
+{{< /note >}}
+
+##### 사용자 이름 매핑 {#x509-client-certificates-k8s-username}
+
+쿠버네티스는 클라이언트 인증서에 주체의 사용자 이름으로 사용하는
+`commonName`(OID `2.5.4.3`) 속성이 포함되어 있다고 가정한다.
+
+##### 사용자 ID 매핑 {#user-id-mapping}
+
+{{< feature-state feature_gate_name="AllowParsingUserUIDFromCertAuth" >}}
+
+이 기능을 사용하려면 인증서에 `1.3.6.1.4.1.57683.2` 속성이 포함되어 있어야 하며,
+`AllowParsingUserUIDFromCertAuth` [기능 게이트](/docs/reference/command-line-tools-reference/feature-gates/)가
+활성화되어 있어야 한다(기본적으로 활성화되어 있음).
+
+쿠버네티스는 인증서에서 **선택적** 사용자 UID를 파싱할 수 있다.
+UID는 사용자 이름과 다르다. 인증서를 요청한 사람이나
+인증서 승인 규칙을 설정한 사람이 그 의미를
+정의하는 값이며, 쿠버네티스는 그 의미를 해석하지 않는다.
+
+예를 들어 한 클러스터에서는 UID가 `1042`(단순한 정수)일 수 있지만,
+다른 인증서에서는 `d3f77937-ec82-4f16-8010-61821abe315a`(UUID)를
+UID로 사용할 수 있다.
+
+다음 예시로 그 의미를 설명할 수 있다. 일반 이름이 "Ada Lovelace"로
+설정되어 있고, `uid` 속성(OID `0.9.2342.19200300.100.1.1`)의 값이
+"aaking1815"인 인증서가 있다면, 쿠버네티스는 클라이언트의 사용자 이름을 "Ada Lovelace"로 간주한다.
+`uid` 속성은 쿠버네티스가 찾는 CNCF 전용 OID가 아니므로
+쿠버네티스는 이를 무시한다.
+쿠버네티스가 `aaking1815`를 UID로 인식하도록 하려면, 인증서 주체의
+OID `1.3.6.1.4.1.57683.2` 속성 값으로 설정해야 한다.
+
+##### 그룹 매핑 {#x509-client-certificates-k8s-group}
+
+인증서에 그룹 정보를 정적으로 포함하여 사용자를 그룹에
+매핑할 수 있다. 사용자가 속한 각 그룹의 이름을 인증서 주체의
+`organization`(OID `2.5.6.4`)으로 추가한다.
+사용자에게 여러 그룹 소속을 포함하려면 인증서 주체에 여러 조직을 포함한다.
+(순서는 중요하지 않다.)
+예시 사용자의 인증서 식별 이름(distinguished name)은
+CN=Ada&nbsp;Lovelace,O=Users,O=Staff,O=Programmers일 수 있으며, 이 사용자는
+"Programmers", "Staff", "system:authenticated", "Users" 그룹에 속하게 된다.
+
+인증서에 그룹 정보를 포함하는 것은 선택 사항이다. 인증서에 그룹을 지정하지 않으면
+사용자는 "system:authenticated"에만 속하게 된다.
+
+##### 노드 클라이언트 인증서 {#x509-client-certificates-nodes}
+
+쿠버네티스는 노드의 신원에도 동일한 방식을 사용할 수 있다. 노드는
+{{<glossary_tooltip term_id="kubelet" text="kubelet">}}을 실행하는 쿠버네티스 API 서버의 클라이언트이다.
+(여기서는 관련성이 낮지만, 일반적으로 API 서버 역시 각 노드의 클라이언트이다.)
+예를 들어 도메인 이름이 "server-1a-antarctica42.cluster.example"인 노드 "server-1a-antarctica42"는 "CN=system:node:server-1a-antarctica/42,O=system:nodes"에 발급된 인증서를 사용할 수 있다. 그러면 노드의 사용자 이름은 "system:node:server-1a-antarctica/g42"이고, 노드는 "system:authenticated" 및 "system:nodes"의 멤버가 된다.
+
+kubelet은 노드의 인증서와 개인 키를 사용하여
+클러스터의 API 서버에 인증한다.
+
+{{< note >}}
+노드의 머신 신원은
+{{< glossary_tooltip text="서비스어카운트" term_id="service-account" >}}와 같지 않다.
+{{< /note >}}
+
+#### 예시 {#x509-client-certificates-example}
+
+`openssl` 커맨드라인 툴을 사용하여 인증서 서명 요청을 생성할 수 있다.
+
+```bash
+# This example assumes that you already have a private key alovelace.pem
+openssl req -new -key alovelace.pem -out alovelace-csr.pem -subj "/CN=alovelace/O=app1/O=app2"
+```
+
+이 명령은 "app1"과 "app2"라는 두 그룹에 속하는 사용자 이름 "alovelace"에 대한 서명 요청을 생성한다. 이후 클러스터의 클라이언트 신뢰 인증 기관이 이 요청에 서명하도록 하여, 클러스터에 대한 클라이언트 인증에 사용할 인증서를 얻을 수 있다.
+
+### 부트스트랩 토큰 {#bootstrap-tokens}
+
+{{< feature-state for_k8s_version="v1.18" state="stable" >}}
+
+새 클러스터의 부트스트래핑을 간소화하기 위해, 쿠버네티스는 동적으로
+관리되는 베어러 토큰 유형인 *부트스트랩 토큰*을 제공한다. 이 토큰은
+`kube-system` 네임스페이스에 시크릿(Secret)으로 저장되며,
+동적으로 관리하고 생성할 수 있다. 컨트롤러 매니저에는 부트스트랩 토큰이
+만료되면 삭제하는 TokenCleaner 컨트롤러가 포함된다.
+
+토큰의 형식은 `[a-z0-9]{6}.[a-z0-9]{16}`이다. 첫 번째 부분은
+토큰 ID이고 두 번째 부분은 토큰 시크릿이다. HTTP 헤더에서
+토큰을 다음과 같이 지정한다.
+
+```http
+Authorization: Bearer 781292.db7bc3a58fc5f07e
+```
+
+API 서버에서 `--enable-bootstrap-token-auth` 플래그를 사용하여
+부트스트랩 토큰 인증자를 활성화해야 한다. kube-controller-manager의
+`--controllers` 커맨드라인 인자를 통해 TokenCleaner 컨트롤러도
+활성화해야 한다.
+예를 들어 `--controllers=*,tokencleaner`와 같이 설정한다.
+`kubeadm` 도구를 사용하여 클러스터를 부트스트랩하면 이 설정을 자동으로 처리한다.
+
+인증자는 `system:bootstrap:<Token ID>`로 인증한다. 이는
+`system:bootstrappers` 그룹에 포함된다. 부트스트래핑 이후에도 이 토큰을
+계속 사용하지 않도록 이름과 그룹을 의도적으로
+제한한다. 이 사용자 이름과 그룹은 클러스터의 부트스트래핑을 지원하는
+적절한 인가 정책을 작성하는 데 사용할 수 있으며,
+실제로 `kubeadm`이 이렇게 사용한다.
+
+부트스트랩 토큰 인증자와 컨트롤러, 그리고 `kubeadm`으로 이 토큰을 관리하는
+방법에 대한 자세한 문서는
+[부트스트랩 토큰](/docs/reference/access-authn-authz/bootstrap-tokens/)을 참고한다.
+
+#### 요청에 베어러 토큰 포함하기 {#putting-a-bearer-token-in-a-request}
+
+HTTP 클라이언트에서 베어러 토큰 인증을 사용할 때, API 서버는
+값이 `Bearer <token>`인 `Authorization` 헤더를
+요구한다. 베어러 토큰은 HTTP의 인코딩 및 인용
+기능만으로 HTTP 헤더 값에 포함할 수 있는 문자열이어야 한다.
+예를 들어 베어러 토큰이
+`31ada4fd-adec-460c-809a-9e56ceb75269`라면, HTTP 헤더에서는
+아래와 같이 나타낸다.
+
+```http
+Authorization: Bearer 31ada4fd-adec-460c-809a-9e56ceb75269
+```
+
+
+### 서비스 어카운트 토큰 {#service-account-tokens}
+
+서비스 어카운트는 서명된 베어러 토큰으로 요청을 검증하는,
+자동으로 활성화되는 인증자이다. 이 플러그인은 두 가지 선택적 플래그를 받는다.
+
+* `--service-account-key-file`: 서비스어카운트 토큰을 검증하는 데 사용하는 PEM 인코딩된 x509 RSA 또는 ECDSA
+  개인 키나 공개 키를 포함한 파일이다. 지정된 파일에는
+  여러 키를 포함할 수 있으며, 서로 다른 파일을 지정하여 플래그를 여러 번
+  사용할 수 있다. 지정하지 않으면 --tls-private-key-file을 사용한다.
+* `--service-account-lookup`: 활성화하면 API에서 삭제된 토큰을 폐기한다.
+
+서비스 어카운트는 일반적으로 API 서버가 자동으로 생성하며,
+`ServiceAccount` [어드미션 컨트롤러](/docs/reference/access-authn-authz/admission-controllers/)를
+통해 클러스터에서 실행 중인 파드와 연결된다. 베어러 토큰은
+파드 내의 정해진 위치에 마운트되어 클러스터 내부 프로세스가
+API 서버와 통신할 수 있도록 한다. `PodSpec`의 `serviceAccountName`
+필드를 사용하여 계정을 파드에 명시적으로 연결할 수도 있다.
+
+{{< note >}}
+이 연결은 자동으로 이루어지므로 일반적으로 `serviceAccountName`을 생략한다.
+{{< /note >}}
+
+```yaml
+apiVersion: apps/v1 # this apiVersion is relevant as of Kubernetes 1.9
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: default
+spec:
+  replicas: 3
+  template:
+    metadata:
+    # ...
+    spec:
+      serviceAccountName: bob-the-bot
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+```
+
+서비스 어카운트 베어러 토큰은 클러스터 외부에서도 유효하게 사용할 수 있으며,
+쿠버네티스 API와 통신하려는 장기간 실행 작업의 신원을
+생성하는 데 사용할 수 있다. 서비스 어카운트를 수동으로 생성하려면
+`kubectl create serviceaccount (NAME)` 명령을 사용한다. 이 명령은 현재
+네임스페이스에 서비스 어카운트를 생성한다.
+
+```bash
+kubectl create serviceaccount jenkins
+```
+
+```none
+serviceaccount/jenkins created
+```
+
+연결된 토큰을 수동으로 생성할 수 있다.
+
+```bash
+kubectl create token jenkins
+```
+
+```none
+eyJhbGciOiJSUzI1NiIsImtp...
+```
+
+생성된 토큰은 서명된 [JSON 웹 토큰(JSON Web Token)](https://www.rfc-editor.org/rfc/rfc7519)(JWT)이다.
+
+서명된 JWT는 해당 서비스 어카운트로 인증하기 위한 베어러 토큰으로
+사용할 수 있다. 요청에 토큰을 포함하는 방법은 [앞의 설명](#putting-a-bearer-token-in-a-request)을
+참고한다. 일반적으로 이 토큰은 클러스터 내부에서 API 서버에 접근하기 위해
+파드에 마운트되지만, 클러스터 외부에서도 사용할 수 있다.
+
+서비스 어카운트는 사용자 이름 `system:serviceaccount:(NAMESPACE):(SERVICEACCOUNT)`로 인증하며,
+`system:serviceaccounts` 및 `system:serviceaccounts:(NAMESPACE)` 그룹에 속한다.
+
+{{< warning >}}
+서비스 어카운트 토큰은 시크릿 API 오브젝트에 저장할 수도 있으므로, 시크릿에 대한
+쓰기 접근 권한이 있는 모든 사용자는 토큰을 요청할 수 있으며, 해당 시크릿에 대한
+읽기 접근 권한이 있는 모든 사용자는 서비스 어카운트로 인증할 수 있다. 서비스 어카운트에
+권한을 부여하거나 시크릿의 읽기 또는 쓰기 권한을 부여할 때 주의한다.
+{{< /warning >}}
+
+
+
+## 외부 통합 {#external-integrations}
+
+쿠버네티스는 JWT와 OpenID Connect(OIDC)를 기본적으로 지원한다. [JSON 웹 토큰 인증](#json-web-token-authentication)을 참고한다.
+
+다른 인증 프로토콜(예: LDAP, SAML, Kerberos, 대체 X.509 방식)과의 통합은
+[인증 프록시](#authenticating-proxy)를 사용하거나
+[인증 웹훅](#webhook-token-authentication)과 통합하여 구현할 수 있다.
+
+API 서버가 유효한 인증서를 신뢰한다면, 클라이언트에게 [X.509 클라이언트 인증서](#x509-client-certificates)를
+발급하는 사용자 정의 방식도 사용할 수 있다.
+인증서 생성 방법은 [X.509 클라이언트 인증서](#x509-client-certificates)를
+참고한다.
+
+클라이언트에 인증서를 발급한다면, 클라우드 플랫폼 관리자로서 인증서의
+유효 기간과 그 밖의 설계상 선택이 적절한 보안 수준을
+제공하도록 해야 한다.
+
+### JSON 웹 토큰 인증 {#json-web-token-authentication}
+
+[JSON 웹 토큰](https://www.rfc-editor.org/rfc/rfc7519)(JWT)을 준수하는 토큰으로 사용자를 인증하도록
+쿠버네티스를 구성할 수 있다. JWT 인증 메커니즘은 쿠버네티스 자체에서 발급하는 서비스어카운트 토큰에 사용되며,
+다른 신원 소스와 통합하는 데 사용할 수도 있다.
+
+인증자는 원시 ID 토큰을 파싱하고, 구성된 발급자가 서명했는지 검증하려고 시도한다.
+외부에서 발급된 토큰은 OIDC 디스커버리를 사용하여 발급자의 공개 엔드포인트에서 서명 검증용 공개 키를 찾는다.
+
+최소한의 유효한 JWT 페이로드(payload)에는 다음 클레임(claim)이 **반드시** 포함되어야 한다.
+
+```javascript
+{
+  "iss": "https://example.com",   // must match the issuer.url
+  "aud": ["my-app"],              // at least one of the entries in issuer.audiences must match the "aud" claim in presented JWTs.
+  "exp": 1234567890,              // token expiration as Unix time (the number of seconds elapsed since January 1, 1970 UTC)
+  "<username-claim>": "user"      // this is the username claim configured in the claimMappings.username.claim or claimMappings.username.expression
+}
+```
+
+#### JWT 이그레스 셀렉터 유형 {#jwt-egress-selector-type}
+
+{{< feature-state feature_gate_name="StructuredAuthenticationConfigurationEgressSelector" >}}
+
+JWT 발급자 구성의 `egressSelectorType` 필드를 사용하면 발급자와 관련된 모든 트래픽
+(디스커버리, JWKS, 분산 클레임 등)을 보낼 때 사용할 _이그레스 셀렉터(egress selector)_ 를 지정할 수 있다.
+이 기능을 사용하려면 `StructuredAuthenticationConfigurationEgressSelector` 기능 게이트를 활성화해야 한다.
+
+#### OpenID Connect 토큰 {#openid-connect-tokens}
+
+[OpenID Connect](https://openid.net/connect/)는 OAuth2의 한 형태로,
+Microsoft Entra ID, Salesforce, Google 등의 OAuth2 제공자가 지원한다.
+이 프로토콜이 OAuth2에 추가하는 주요 기능은 액세스 토큰과 함께 반환되는
+[ID 토큰](https://openid.net/specs/openid-connect-core-1_0.html#IDToken)이라는 추가 필드이다.
+이 토큰은 사용자 이메일과 같은 정해진 필드를 포함하며,
+서버가 서명한 JSON 웹 토큰(JWT)이다.
+
+인증자는 사용자를 식별하기 위해 OAuth2
+[토큰 응답](https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse)의 `id_token`을
+베어러 토큰으로 사용한다(`access_token`이 아님). 요청에 토큰을 포함하는 방법은
+[앞의 설명](#putting-a-bearer-token-in-a-request)을 참고한다.
+
+{{< mermaid >}}
+sequenceDiagram
+    participant user as 사용자
+    participant idp as 신원 제공자
+    participant kube as kubectl
+    participant api as API 서버
+
+    user ->> idp: 1. IdP에 로그인
+    activate idp
+    idp -->> user: 2. access_token,<br>id_token, refresh_token 제공
+    deactivate idp
+    activate user
+    user ->> kube: 3. --token에 id_token을 지정하여<br>kubectl 호출<br>또는 .kube/config에 토큰 추가
+    deactivate user
+    activate kube
+    kube ->> api: 4. Authorization: Bearer...
+    deactivate kube
+    activate api
+    api ->> api: 5. JWT 서명이 유효한가?
+    api ->> api: 6. JWT가 만료되었는가? (iat+exp)
+    api ->> api: 7. 사용자가 인가되었는가?
+    api -->> kube: 8. 인가됨: 작업 수행<br>및 결과 반환
+    deactivate api
+    activate kube
+    kube --x user: 9. 결과 반환
+    deactivate kube
+{{< /mermaid >}}
+
+1. 신원 제공자에 로그인한다.
+1. 신원 제공자는 `access_token`, `id_token`, `refresh_token`을 제공한다.
+1. `kubectl`을 사용할 때 `--token` 커맨드라인 인자로 `id_token`을 전달하거나, `kubeconfig`에 직접 추가한다.
+1. `kubectl`은 Authorization 헤더에 `id_token`을 담아 API 서버에 보낸다.
+1. API 서버는 JWT 서명이 유효한지 확인한다.
+1. `id_token`이 만료되지 않았는지 확인한다.
+
+   `AuthenticationConfiguration`에 CEL 표현식이 구성되어 있으면 클레임 및/또는 사용자 검증을 수행한다.
+
+1. 사용자가 인가되었는지 확인한다.
+1. 인가되면 API 서버가 `kubectl`에 응답을 반환한다.
+1. `kubectl`은 사용자에게 결과를 제공한다.
+
+신원을 검증하는 데 필요한 모든 데이터가 `id_token`에 있으므로, 쿠버네티스가 신원 제공자에
+다시 연락할 필요가 없다. 모든 요청이 스테이트리스인 모델에서 이는 확장성이 매우 높은
+인증 솔루션을 제공한다. 다만 몇 가지 어려움이 있다.
+
+1. 쿠버네티스에는 인증 과정을 시작하는 "웹 인터페이스"가 없다. 자격 증명을 수집하는 브라우저나
+   인터페이스가 없으므로 먼저 신원 제공자에 인증해야 한다.
+1. `id_token`은 폐기할 수 없고 인증서와 유사하므로 유효 기간이 짧아야 한다(몇 분 정도).
+   따라서 몇 분마다 새 토큰을 받아야 하는 것이 매우 번거로울 수 있다.
+1. 쿠버네티스 대시보드에 인증하려면 `kubectl proxy` 명령이나 `id_token`을 주입하는
+   리버스 프록시를 사용해야 한다.
+
+#### API 서버 구성하기 {#configuring-the-api-server}
+
+##### 커맨드라인 인자 사용하기 {#using-command-line-arguments}
+
+플러그인을 활성화하려면 API 서버에 다음 커맨드라인 인자를 구성한다.
+
+| 파라미터 | 설명 | 예시 | 필수 여부 |
+| --------- | ----------- | ------- | ------- |
+| `--oidc-issuer-url` | API 서버가 공개 서명 키를 찾을 수 있는 제공자 URL이다. `https://` 스킴을 사용하는 URL만 허용한다. 일반적으로 제공자의 디스커버리 URL에서 경로를 비운 값이다. | 발급자의 OIDC 디스커버리 URL이 `https://accounts.provider.example/.well-known/openid-configuration`이면, 값은 `https://accounts.provider.example`이어야 한다. | 예 |
+| `--oidc-client-id` | 모든 토큰의 발급 대상이어야 하는 클라이언트 ID이다. | kubernetes | 예 |
+| `--oidc-username-claim` | 사용자 이름으로 사용할 JWT 클레임이다. 기본값은 최종 사용자의 고유 식별자로 기대되는 `sub`이다. 관리자는 제공자에 따라 `email`이나 `name` 등의 다른 클레임을 선택할 수 있다. 다만 `email` 이외의 클레임에는 다른 플러그인과의 이름 충돌을 방지하기 위해 발급자 URL이 접두사로 붙는다. | sub | 아니요 |
+| `--oidc-username-prefix` | 기존 이름(예: `system:` 사용자)과의 충돌을 방지하기 위해 사용자 이름 클레임 앞에 붙이는 접두사이다. 예를 들어 `oidc:`를 지정하면 `oidc:jane.doe`와 같은 사용자 이름을 만든다. 이 인자를 제공하지 않고 `--oidc-username-claim`이 `email` 이외의 값이면, 기본 접두사는 `( Issuer URL )#`이며 `( Issuer URL )`은 `--oidc-issuer-url` 값이다. `-`를 사용하면 접두사를 모두 비활성화할 수 있다. | `oidc:` | 아니요 |
+| `--oidc-groups-claim` | 사용자의 그룹으로 사용할 JWT 클레임이다. 클레임이 있으면 문자열 배열이어야 한다. | groups | 아니요 |
+| `--oidc-groups-prefix` | 기존 이름(예: `system:` 그룹)과의 충돌을 방지하기 위해 그룹 클레임 앞에 붙이는 접두사이다. 예를 들어 `oidc:`를 지정하면 `oidc:engineering` 및 `oidc:infra`와 같은 그룹 이름을 만든다. | `oidc:` | 아니요 |
+| `--oidc-required-claim` | ID 토큰의 필수 클레임을 나타내는 key=value 쌍이다. 설정하면 ID 토큰에 해당 클레임이 존재하고 값이 일치하는지 검증한다. 여러 클레임을 지정하려면 이 인자를 반복한다. | `claim=value` | 아니요 |
+| `--oidc-ca-file` | 신원 제공자의 웹 인증서에 서명한 CA의 인증서 경로이다. 기본값은 호스트의 루트 CA이다. | `/etc/kubernetes/ssl/kc-ca.pem` | 아니요 |
+| `--oidc-signing-algs` | 허용하는 서명 알고리즘이다. 기본값은 RS256이다. 허용되는 값은 RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512이다. 값은 RFC 7518 https://tools.ietf.org/html/rfc7518#section-3.1 에 정의되어 있다. | `RS512` | 아니요 |
+
+##### 파일에서 인증 구성 읽기 {#using-authentication-configuration}
+
+{{< feature-state feature_gate_name="StructuredAuthenticationConfiguration" >}}
+
+구성 파일 방식에서는 각각 고유한 `issuer.url`과 `issuer.discoveryURL`을 가진
+여러 JWT 인증자를 구성할 수 있다. 또한 [CEL](/docs/reference/using-api/cel/) 표현식을
+지정하여 클레임을 사용자 속성에 매핑하고, 클레임과 사용자 정보를 검증할 수 있다.
+구성 파일이 수정되면 API 서버가 인증자를 자동으로 다시 로드한다.
+`apiserver_authentication_config_controller_automatic_reload_last_timestamp_seconds` 메트릭으로
+API 서버가 마지막으로 구성을 다시 로드한 시점을 모니터링할 수 있다.
+
+API 서버의 `--authentication-config` 커맨드라인 인자로 인증 구성 파일 경로를 지정해야 한다. 구성 파일 대신 커맨드라인 인자를 사용하려는 경우에도,
+기존 인자는 계속 그대로 동작한다. 여러 인증자 구성이나 발급자에 대한
+여러 오디언스 설정과 같은 새 기능을 사용하려면 구성 파일 방식으로 전환한다.
+
+구조화된 인증을 사용하려면 kube-apiserver에 `--authentication-config` 커맨드라인
+인자를 지정한다. 구조화된 인증 구성 파일의 예시는 아래와 같다.
+
+{{< note >}}
+`--authentication-config`와 `--oidc-*` 커맨드라인 인자를 함께 지정하면
+잘못된 구성이다. 이 경우 API 서버는 오류를 보고한 후 즉시 종료한다.
+구조화된 인증 구성으로 전환하려면 `--oidc-*` 커맨드라인 인자를 제거하고,
+대신 구성 파일을 사용해야 한다.
+{{< /note >}}
+
+{{< highlight yaml "linenos=false,hl_lines=2-5" >}}
+---
+#
+# CAUTION: this is an example configuration.
+#          Do not use this for your own cluster!
+#
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+# list of authenticators to authenticate Kubernetes users using JWT compliant tokens.
+# the maximum number of allowed authenticators is 64.
+jwt:
+- issuer:
+    # url must be unique across all authenticators.
+    # url must not conflict with issuer configured in --service-account-issuer.
+    url: https://example.com # Same as --oidc-issuer-url.
+    # discoveryURL, if specified, overrides the URL used to fetch discovery
+    # information instead of using "{url}/.well-known/openid-configuration".
+    # The exact value specified is used, so "/.well-known/openid-configuration"
+    # must be included in discoveryURL if needed.
+    #
+    # The "issuer" field in the fetched discovery information must match the "issuer.url" field
+    # in the AuthenticationConfiguration and will be used to validate the "iss" claim in the presented JWT.
+    # This is for scenarios where the well-known and jwks endpoints are hosted at a different
+    # location than the issuer (such as locally in the cluster).
+    # discoveryURL must be different from url if specified and must be unique across all authenticators.
+    discoveryURL: https://discovery.example.com/.well-known/openid-configuration
+    # PEM encoded CA certificates used to validate the connection when fetching
+    # discovery information. If not set, the system verifier will be used.
+    # Same value as the content of the file referenced by the --oidc-ca-file command line argument.
+    certificateAuthority: <PEM encoded CA certificates>
+    # audiences is the set of acceptable audiences the JWT must be issued to.
+    # At least one of the entries must match the "aud" claim in presented JWTs.
+    audiences:
+    - my-app # Same as --oidc-client-id.
+    - my-other-app
+    # this is required to be set to "MatchAny" when multiple audiences are specified.
+    audienceMatchPolicy: MatchAny
+    # egressSelectorType is an indicator of which egress selection should be used for sending all traffic related
+    # to this issuer (discovery, JWKS, distributed claims, etc).  If unspecified, no custom dialer is used.
+    # The StructuredAuthenticationConfigurationEgressSelector feature gate must be enabled
+    # before you can use the egressSelectorType field.
+    # When specified, the valid choices are "controlplane" and "cluster".  These correspond to the associated
+    # values in the --egress-selector-config-file.
+    # - controlplane: for traffic intended to go to the control plane.
+    # - cluster: for traffic intended to go to the system being managed by Kubernetes.
+    egressSelectorType: <egress-selector-type>
+  # rules applied to validate token claims to authenticate users.
+  claimValidationRules:
+    # Same as --oidc-required-claim key=value.
+  - claim: hd
+    requiredValue: example.com
+    # Instead of claim and requiredValue, you can use expression to validate the claim.
+    # expression is a CEL expression that evaluates to a boolean.
+    # all the expressions must evaluate to true for validation to succeed.
+  - expression: 'claims.hd == "example.com"'
+    # Message customizes the error message seen in the API server logs when the validation fails.
+    message: the hd claim must be set to example.com
+  - expression: 'claims.exp - claims.nbf <= 86400'
+    message: total token lifetime must not exceed 24 hours
+  claimMappings:
+    # username represents an option for the username attribute.
+    # This is the only required attribute.
+    username:
+      # Same as --oidc-username-claim. Mutually exclusive with username.expression.
+      claim: "sub"
+      # Same as --oidc-username-prefix. Mutually exclusive with username.expression.
+      # if username.claim is set, username.prefix is required.
+      # Explicitly set it to "" if no prefix is desired.
+      prefix: ""
+      # Mutually exclusive with username.claim and username.prefix.
+      # expression is a CEL expression that evaluates to a string.
+      #
+      # 1.  If username.expression uses 'claims.email', then 'claims.email_verified' must be used in
+      #     username.expression or extra[*].valueExpression or claimValidationRules[*].expression.
+      #     An example claim validation rule expression that matches the validation automatically
+      #     applied when username.claim is set to 'email' is 'claims.?email_verified.orValue(true) == true'.
+      #     By explicitly comparing the value to true, we let type-checking see the result will be a boolean, and
+      #     to make sure a non-boolean email_verified claim will be caught at runtime.
+      # 2.  If the username asserted based on username.expression is the empty string, the authentication
+      #     request will fail.
+      expression: 'claims.username + ":external-user"'
+    # groups represents an option for the groups attribute.
+    groups:
+      # Same as --oidc-groups-claim. Mutually exclusive with groups.expression.
+      claim: "sub"
+      # Same as --oidc-groups-prefix. Mutually exclusive with groups.expression.
+      # if groups.claim is set, groups.prefix is required.
+      # Explicitly set it to "" if no prefix is desired.
+      prefix: ""
+      # Mutually exclusive with groups.claim and groups.prefix.
+      # expression is a CEL expression that evaluates to a string or a list of strings.
+      expression: 'claims.roles.split(",")'
+    # uid represents an option for the uid attribute.
+    uid:
+      # Mutually exclusive with uid.expression.
+      claim: 'sub'
+      # Mutually exclusive with uid.claim
+      # expression is a CEL expression that evaluates to a string.
+      expression: 'claims.sub'
+    # extra attributes to be added to the UserInfo object. Keys must be domain-prefix path and must be unique.
+    extra:
+      # key is a string to use as the extra attribute key.
+      # key must be a domain-prefix path (e.g. example.org/foo). All characters before the first "/" must be a valid
+      # subdomain as defined by RFC 1123. All characters trailing the first "/" must
+      # be valid HTTP Path characters as defined by RFC 3986.
+      # k8s.io, kubernetes.io and their subdomains are reserved for Kubernetes use and cannot be used.
+      # key must be lowercase and unique across all extra attributes.
+    - key: 'example.com/tenant'
+      # valueExpression is a CEL expression that evaluates to a string or a list of strings.
+      valueExpression: 'claims.tenant'
+  # validation rules applied to the final user object.
+  userValidationRules:
+    # expression is a CEL expression that evaluates to a boolean.
+    # all the expressions must evaluate to true for the user to be valid.
+  - expression: "!user.username.startsWith('system:')"
+    # Message customizes the error message seen in the API server logs when the validation fails.
+    message: 'username cannot used reserved system: prefix'
+  - expression: "user.groups.all(group, !group.startsWith('system:'))"
+    message: 'groups cannot used reserved system: prefix'
+{{< /highlight >}}
+
+* 클레임 검증 규칙 표현식
+
+  `jwt.claimValidationRules[i].expression`은 CEL로 평가할 표현식을 나타낸다.
+  CEL 표현식은 `claims` CEL 변수에 구성된 토큰 페이로드 내용에 접근할 수 있다.
+  `claims`는 클레임 이름(문자열)을 클레임 값(모든 타입 가능)에 매핑한다.
+
+* 사용자 검증 규칙 표현식
+
+  `jwt.userValidationRules[i].expression`은 CEL로 평가할 표현식을 나타낸다.
+  CEL 표현식은 `user` CEL 변수에 구성된 `userInfo` 내용에 접근할 수 있다.
+  `user`의 스키마는 [UserInfo](/docs/reference/generated/kubernetes-api/v{{< skew currentVersion >}}/#userinfo-v1-authentication-k8s-io)
+  API 문서를 참고한다.
+
+* 클레임 매핑 표현식
+
+  `jwt.claimMappings.username.expression`, `jwt.claimMappings.groups.expression`, `jwt.claimMappings.uid.expression`,
+  `jwt.claimMappings.extra[i].valueExpression`은 CEL로 평가할 표현식을 나타낸다.
+  CEL 표현식은 `claims` CEL 변수에 구성된 토큰 페이로드 내용에 접근할 수 있다.
+  `claims`는 클레임 이름(문자열)을 클레임 값(모든 타입 가능)에 매핑한다.
+
+  자세한 내용은 [CEL 문서](/docs/reference/using-api/cel/)를 참고한다.
+
+  다음은 서로 다른 토큰 페이로드를 사용하는 `AuthenticationConfiguration`의 예시이다.
+
+  {{< tabs name="example_configuration" >}}
+  {{% tab name="유효한 토큰" %}}
+  ```yaml
+  apiVersion: apiserver.config.k8s.io/v1
+  kind: AuthenticationConfiguration
+  jwt:
+  - issuer:
+      url: https://example.com
+      audiences:
+      - my-app
+    claimMappings:
+      username:
+        expression: 'claims.username + ":external-user"'
+      groups:
+        expression: 'claims.roles.split(",")'
+      uid:
+        expression: 'claims.sub'
+      extra:
+      - key: 'example.com/tenant'
+        valueExpression: 'claims.tenant'
+    userValidationRules:
+    - expression: "!user.username.startsWith('system:')" # the expression will evaluate to true, so validation will succeed.
+      message: 'username cannot used reserved system: prefix'
+  ```
+
+  ```bash
+  TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImY3dF9tOEROWmFTQk1oWGw5QXZTWGhBUC04Y0JmZ0JVbFVpTG5oQkgxdXMiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJrdWJlcm5ldGVzIiwiZXhwIjoxNzAzMjMyOTQ5LCJpYXQiOjE3MDExMDcyMzMsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20iLCJqdGkiOiI3YzMzNzk0MjgwN2U3M2NhYTJjMzBjODY4YWMwY2U5MTBiY2UwMmRkY2JmZWJlOGMyM2I4YjVmMjdhZDYyODczIiwibmJmIjoxNzAxMTA3MjMzLCJyb2xlcyI6InVzZXIsYWRtaW4iLCJzdWIiOiJhdXRoIiwidGVuYW50IjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjRhIiwidXNlcm5hbWUiOiJmb28ifQ.TBWF2RkQHm4QQz85AYPcwLxSk-VLvQW-mNDHx7SEOSv9LVwcPYPuPajJpuQn9C_gKq1R94QKSQ5F6UgHMILz8OfmPKmX_00wpwwNVGeevJ79ieX2V-__W56iNR5gJ-i9nn6FYk5pwfVREB0l4HSlpTOmu80gbPWAXY5hLW0ZtcE1JTEEmefORHV2ge8e3jp1xGafNy6LdJWabYuKiw8d7Qga__HxtKB-t0kRMNzLRS7rka_SfQg0dSYektuxhLbiDkqhmRffGlQKXGVzUsuvFw7IGM5ZWnZgEMDzCI357obHeM3tRqpn5WRjtB8oM7JgnCymaJi-P3iCd88iu1xnzA
+  ```
+
+  토큰 페이로드는 다음과 같다.
+
+  ```json
+    {
+      "aud": "kubernetes",
+      "exp": 1703232949,
+      "iat": 1701107233,
+      "iss": "https://example.com",
+      "jti": "7c337942807e73caa2c30c868ac0ce910bce02ddcbfebe8c23b8b5f27ad62873",
+      "nbf": 1701107233,
+      "roles": "user,admin",
+      "sub": "auth",
+      "tenant": "72f988bf-86f1-41af-91ab-2d7cd011db4a",
+      "username": "foo"
+    }
+  ```
+
+  위 `AuthenticationConfiguration`에서 이 토큰은 다음 `UserInfo` 오브젝트를 생성하고 사용자를 성공적으로 인증한다.
+
+  ```json
+  {
+      "username": "foo:external-user",
+      "uid": "auth",
+      "groups": [
+          "user",
+          "admin"
+      ],
+      "extra": {
+          "example.com/tenant": ["72f988bf-86f1-41af-91ab-2d7cd011db4a"]
+      }
+  }
+  ```
+  {{% /tab %}}
+  {{% tab name="클레임 검증 실패" %}}
+  ```yaml
+  apiVersion: apiserver.config.k8s.io/v1
+  kind: AuthenticationConfiguration
+  jwt:
+  - issuer:
+      url: https://example.com
+      audiences:
+      - my-app
+    claimValidationRules:
+    - expression: 'claims.hd == "example.com"' # the token below does not have this claim, so validation will fail.
+      message: the hd claim must be set to example.com
+    claimMappings:
+      username:
+        expression: 'claims.username + ":external-user"'
+      groups:
+        expression: 'claims.roles.split(",")'
+      uid:
+        expression: 'claims.sub'
+      extra:
+      - key: 'example.com/tenant'
+        valueExpression: 'claims.tenant'
+    userValidationRules:
+    - expression: "!user.username.startsWith('system:')" # the expression will evaluate to true, so validation will succeed.
+      message: 'username cannot used reserved system: prefix'
+  ```
+
+  ```bash
+  TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImY3dF9tOEROWmFTQk1oWGw5QXZTWGhBUC04Y0JmZ0JVbFVpTG5oQkgxdXMiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJrdWJlcm5ldGVzIiwiZXhwIjoxNzAzMjMyOTQ5LCJpYXQiOjE3MDExMDcyMzMsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20iLCJqdGkiOiI3YzMzNzk0MjgwN2U3M2NhYTJjMzBjODY4YWMwY2U5MTBiY2UwMmRkY2JmZWJlOGMyM2I4YjVmMjdhZDYyODczIiwibmJmIjoxNzAxMTA3MjMzLCJyb2xlcyI6InVzZXIsYWRtaW4iLCJzdWIiOiJhdXRoIiwidGVuYW50IjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjRhIiwidXNlcm5hbWUiOiJmb28ifQ.TBWF2RkQHm4QQz85AYPcwLxSk-VLvQW-mNDHx7SEOSv9LVwcPYPuPajJpuQn9C_gKq1R94QKSQ5F6UgHMILz8OfmPKmX_00wpwwNVGeevJ79ieX2V-__W56iNR5gJ-i9nn6FYk5pwfVREB0l4HSlpTOmu80gbPWAXY5hLW0ZtcE1JTEEmefORHV2ge8e3jp1xGafNy6LdJWabYuKiw8d7Qga__HxtKB-t0kRMNzLRS7rka_SfQg0dSYektuxhLbiDkqhmRffGlQKXGVzUsuvFw7IGM5ZWnZgEMDzCI357obHeM3tRqpn5WRjtB8oM7JgnCymaJi-P3iCd88iu1xnzA
+  ```
+
+  토큰 페이로드는 다음과 같다.
+
+  ```json
+    {
+      "aud": "kubernetes",
+      "exp": 1703232949,
+      "iat": 1701107233,
+      "iss": "https://example.com",
+      "jti": "7c337942807e73caa2c30c868ac0ce910bce02ddcbfebe8c23b8b5f27ad62873",
+      "nbf": 1701107233,
+      "roles": "user,admin",
+      "sub": "auth",
+      "tenant": "72f988bf-86f1-41af-91ab-2d7cd011db4a",
+      "username": "foo"
+    }
+  ```
+
+  위 `AuthenticationConfiguration`에서는 `hd` 클레임이 `example.com`으로
+  설정되어 있지 않으므로 토큰 인증에 실패한다. API 서버는 `401 Unauthorized` 오류를 반환한다.
+  {{% /tab %}}
+  {{% tab name="사용자 검증 실패" %}}
+  ```yaml
+  apiVersion: apiserver.config.k8s.io/v1
+  kind: AuthenticationConfiguration
+  jwt:
+  - issuer:
+      url: https://example.com
+      audiences:
+      - my-app
+    claimValidationRules:
+    - expression: 'claims.hd == "example.com"'
+      message: the hd claim must be set to example.com
+    claimMappings:
+      username:
+        expression: '"system:" + claims.username' # this will prefix the username with "system:" and will fail user validation.
+      groups:
+        expression: 'claims.roles.split(",")'
+      uid:
+        expression: 'claims.sub'
+      extra:
+      - key: 'example.com/tenant'
+        valueExpression: 'claims.tenant'
+    userValidationRules:
+    - expression: "!user.username.startsWith('system:')" # the username will be system:foo and expression will evaluate to false, so validation will fail.
+      message: 'username cannot used reserved system: prefix'
+  ```
+
+  ```bash
+  TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImY3dF9tOEROWmFTQk1oWGw5QXZTWGhBUC04Y0JmZ0JVbFVpTG5oQkgxdXMiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJrdWJlcm5ldGVzIiwiZXhwIjoxNzAzMjMyOTQ5LCJoZCI6ImV4YW1wbGUuY29tIiwiaWF0IjoxNzAxMTEzMTAxLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwianRpIjoiYjViMDY1MjM3MmNkMjBlMzQ1YjZmZGZmY2RjMjE4MWY0YWZkNmYyNTlhYWI0YjdlMzU4ODEyMzdkMjkyMjBiYyIsIm5iZiI6MTcwMTExMzEwMSwicm9sZXMiOiJ1c2VyLGFkbWluIiwic3ViIjoiYXV0aCIsInRlbmFudCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0YSIsInVzZXJuYW1lIjoiZm9vIn0.FgPJBYLobo9jnbHreooBlvpgEcSPWnKfX6dc0IvdlRB-F0dCcgy91oCJeK_aBk-8zH5AKUXoFTlInfLCkPivMOJqMECA1YTrMUwt_IVqwb116AqihfByUYIIqzMjvUbthtbpIeHQm2fF0HbrUqa_Q0uaYwgy8mD807h7sBcUMjNd215ff_nFIHss-9zegH8GI1d9fiBf-g6zjkR1j987EP748khpQh9IxPjMJbSgG_uH5x80YFuqgEWwq-aYJPQxXX6FatP96a2EAn7wfPpGlPRt0HcBOvq5pCnudgCgfVgiOJiLr_7robQu4T1bis0W75VPEvwWtgFcLnvcQx0JWg
+  ```
+
+  토큰 페이로드는 다음과 같다.
+
+  ```json
+    {
+      "aud": "kubernetes",
+      "exp": 1703232949,
+      "hd": "example.com",
+      "iat": 1701113101,
+      "iss": "https://example.com",
+      "jti": "b5b0652372cd20e345b6fdffcdc2181f4afd6f259aab4b7e35881237d29220bc",
+      "nbf": 1701113101,
+      "roles": "user,admin",
+      "sub": "auth",
+      "tenant": "72f988bf-86f1-41af-91ab-2d7cd011db4a",
+      "username": "foo"
+    }
+  ```
+
+  위 `AuthenticationConfiguration`에서 이 토큰은 다음 `UserInfo` 오브젝트를 생성한다.
+
+  ```json
+  {
+      "username": "system:foo",
+      "uid": "auth",
+      "groups": [
+          "user",
+          "admin"
+      ],
+      "extra": {
+          "example.com/tenant": ["72f988bf-86f1-41af-91ab-2d7cd011db4a"]
+      }
+  }
+  ```
+
+  사용자 이름이 `system:`으로 시작하므로 사용자 검증에 실패한다.
+  API 서버는 `401 Unauthorized` 오류를 반환한다.
+  {{% /tab %}}
+  {{< /tabs >}}
+
+
+
+##### 제한 사항 {#oidc-limitations}
+
+1. 분산 클레임은 [CEL](/docs/reference/using-api/cel/) 표현식으로 처리할 수 없다.
+
+쿠버네티스는 OpenID Connect 신원 제공자를 제공하지 않는다.
+기존 공개 OpenID Connect 신원 제공자를 사용하거나, OpenID Connect 프로토콜을
+지원하는 자체 신원 제공자를 실행할 수 있다.
+
+신원 제공자가 쿠버네티스와 함께 동작하려면 다음을 충족해야 한다.
+
+1. [OpenID Connect 디스커버리](https://openid.net/specs/openid-connect-discovery-1_0.html)를 지원한다.
+
+   OIDC 디스커버리를 사용하여 발급자의 공개 엔드포인트에서 서명 검증용 공개 키를 찾는다.
+   인증 구성 파일을 사용하는 경우, 신원 제공자는 디스커버리 엔드포인트를 공개적으로 노출할 필요가 없다.
+   디스커버리 엔드포인트를 발급자와 다른 위치(예: 클러스터 내부)에 호스팅하고, 구성 파일에
+   `issuer.discoveryURL`을 지정할 수 있다.
+
+1. 더 이상 사용되지 않는 암호가 아닌 안전한 암호를 사용하여 TLS로 실행한다.
+1. CA가 서명한 인증서를 보유한다(CA가 상용 CA가 아니거나 자체 서명한 경우도 포함).
+
+위의 세 번째 요구 사항인 CA 서명 인증서에 대해 추가로 설명한다. 자체 신원
+제공자를 배포하는 경우, 자체 서명 인증서라도 `CA` 플래그가 `TRUE`로 설정된
+인증서로 신원 제공자의 웹 서버 인증서에 반드시 서명해야 한다. 이는 Go 언어의
+TLS 클라이언트 구현이 인증서 검증 표준을 매우 엄격하게 따르기 때문이다.
+사용할 CA가 없다면 표준 인증서 생성 도구를 사용하여 간단한 CA와
+서명된 인증서 및 키 쌍을 생성할 수 있다.
+
+#### kubectl 사용하기 {#using-kubectl}
+
+##### 방법 1 - OIDC 인증자 {#option-1-oidc-authenticator}
+
+첫 번째 방법은 모든 요청에 `id_token`을 베어러 토큰으로 설정하고, 토큰이 만료되면 갱신하는
+kubectl `oidc` 인증자를 사용하는 것이다. 제공자에 로그인한 후, kubectl을 사용하여
+`id_token`, `refresh_token`, `client_id`, `client_secret`을 추가해 플러그인을 구성한다.
+
+갱신 토큰 응답에 `id_token`을 포함하지 않는 제공자는 이 플러그인에서 지원하지 않으므로,
+(`--token`을 지정하는) [방법 2](#option-2-use-the-token-option)를 사용해야 한다.
+
+```bash
+kubectl config set-credentials USER_NAME \
+   --auth-provider=oidc \
+   --auth-provider-arg=idp-issuer-url=( issuer url ) \
+   --auth-provider-arg=client-id=( your client id ) \
+   --auth-provider-arg=client-secret=( your client secret ) \
+   --auth-provider-arg=refresh-token=( your refresh token ) \
+   --auth-provider-arg=idp-certificate-authority=( path to your ca certificate ) \
+   --auth-provider-arg=id-token=( your id_token )
+```
+
+예를 들어 신원 제공자에 인증한 후 아래 명령을 실행한다.
+
+```bash
+kubectl config set-credentials mmosley  \
+        --auth-provider=oidc  \
+        --auth-provider-arg=idp-issuer-url=https://oidcidp.tremolo.lan:8443/auth/idp/OidcIdP  \
+        --auth-provider-arg=client-id=kubernetes  \
+        --auth-provider-arg=client-secret=1db158f6-177d-4d9c-8a8b-d36869918ec5  \
+        --auth-provider-arg=refresh-token=q1bKLFOyUiosTfawzA93TzZIDzH2TNa2SMm0zEiPKTUwME6BkEo6Sql5yUWVBSWpKUGphaWpxSVAfekBOZbBhaEW+VlFUeVRGcluyVF5JT4+haZmPsluFoFu5XkpXk5BXqHega4GAXlF+ma+vmYpFcHe5eZR+slBFpZKtQA= \
+        --auth-provider-arg=idp-certificate-authority=/root/ca.pem \
+        --auth-provider-arg=id-token=eyJraWQiOiJDTj1vaWRjaWRwLnRyZW1vbG8ubGFuLCBPVT1EZW1vLCBPPVRybWVvbG8gU2VjdXJpdHksIEw9QXJsaW5ndG9uLCBTVD1WaXJnaW5pYSwgQz1VUy1DTj1rdWJlLWNhLTEyMDIxNDc5MjEwMzYwNzMyMTUyIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL29pZGNpZHAudHJlbW9sby5sYW46ODQ0My9hdXRoL2lkcC9PaWRjSWRQIiwiYXVkIjoia3ViZXJuZXRlcyIsImV4cCI6MTQ4MzU0OTUxMSwianRpIjoiMm96US15TXdFcHV4WDlHZUhQdy1hZyIsImlhdCI6MTQ4MzU0OTQ1MSwibmJmIjoxNDgzNTQ5MzMxLCJzdWIiOiI0YWViMzdiYS1iNjQ1LTQ4ZmQtYWIzMC0xYTAxZWU0MWUyMTgifQ.w6p4J_6qQ1HzTG9nrEOrubxIMb9K5hzcMPxc9IxPx2K4xO9l-oFiUw93daH3m5pluP6K7eOE6txBuRVfEcpJSwlelsOsW8gb8VJcnzMS9EnZpeA0tW_p-mnkFc3VcfyXuhe5R3G7aa5d8uHv70yJ9Y3-UhjiN9EhpMdfPAoEB9fYKKkJRzF7utTTIPGrSaSU6d2pcpfYKaxIwePzEkT4DfcQthoZdy9ucNvvLoi1DIC-UocFD8HLs8LYKEqSxQvOcvnThbObJ9af71EwmuE21fO5KzMW20KtAeget1gnldOosPtz1G5EwvaQ401-RPQzPGMVBld0_zMCAwZttJ4knw
+```
+
+그러면 아래와 같은 구성이 생성된다.
+
+```yaml
+users:
+- name: mmosley
+  user:
+    auth-provider:
+      config:
+        client-id: kubernetes
+        client-secret: 1db158f6-177d-4d9c-8a8b-d36869918ec5
+        id-token: eyJraWQiOiJDTj1vaWRjaWRwLnRyZW1vbG8ubGFuLCBPVT1EZW1vLCBPPVRybWVvbG8gU2VjdXJpdHksIEw9QXJsaW5ndG9uLCBTVD1WaXJnaW5pYSwgQz1VUy1DTj1rdWJlLWNhLTEyMDIxNDc5MjEwMzYwNzMyMTUyIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL29pZGNpZHAudHJlbW9sby5sYW46ODQ0My9hdXRoL2lkcC9PaWRjSWRQIiwiYXVkIjoia3ViZXJuZXRlcyIsImV4cCI6MTQ4MzU0OTUxMSwianRpIjoiMm96US15TXdFcHV4WDlHZUhQdy1hZyIsImlhdCI6MTQ4MzU0OTQ1MSwibmJmIjoxNDgzNTQ5MzMxLCJzdWIiOiI0YWViMzdiYS1iNjQ1LTQ4ZmQtYWIzMC0xYTAxZWU0MWUyMTgifQ.w6p4J_6qQ1HzTG9nrEOrubxIMb9K5hzcMPxc9IxPx2K4xO9l-oFiUw93daH3m5pluP6K7eOE6txBuRVfEcpJSwlelsOsW8gb8VJcnzMS9EnZpeA0tW_p-mnkFc3VcfyXuhe5R3G7aa5d8uHv70yJ9Y3-UhjiN9EhpMdfPAoEB9fYKKkJRzF7utTTIPGrSaSU6d2pcpfYKaxIwePzEkT4DfcQthoZdy9ucNvvLoi1DIC-UocFD8HLs8LYKEqSxQvOcvnThbObJ9af71EwmuE21fO5KzMW20KtAeget1gnldOosPtz1G5EwvaQ401-RPQzPGMVBld0_zMCAwZttJ4knw
+        idp-certificate-authority: /root/ca.pem
+        idp-issuer-url: https://oidcidp.tremolo.lan:8443/auth/idp/OidcIdP
+        refresh-token: q1bKLFOyUiosTfawzA93TzZIDzH2TNa2SMm0zEiPKTUwME6BkEo6Sql5yUWVBSWpKUGphaWpxSVAfekBOZbBhaEW+VlFUeVRGcluyVF5JT4+haZmPsluFoFu5XkpXk5BXq
+      name: oidc
+```
+
+`id_token`이 만료되면 `kubectl`은 `refresh_token`과 `client_secret`을 사용하여 `id_token`의 갱신을
+시도하고, 새로운 `refresh_token`과 `id_token` 값을 `.kube/config`에 저장한다.
+
+##### 방법 2 - `--token` 커맨드라인 인자 사용하기 {#option-2-use-the-token-option}
+
+`kubectl` 명령은 `--token` 커맨드라인 인자로 토큰을 전달할 수 있다.
+이 옵션에 `id_token`을 복사하여 붙여 넣는다.
+
+```bash
+kubectl --token=eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL21sYi50cmVtb2xvLmxhbjo4MDQzL2F1dGgvaWRwL29pZGMiLCJhdWQiOiJrdWJlcm5ldGVzIiwiZXhwIjoxNDc0NTk2NjY5LCJqdGkiOiI2RDUzNXoxUEpFNjJOR3QxaWVyYm9RIiwiaWF0IjoxNDc0NTk2MzY5LCJuYmYiOjE0NzQ1OTYyNDksInN1YiI6Im13aW5kdSIsInVzZXJfcm9sZSI6WyJ1c2VycyIsIm5ldy1uYW1lc3BhY2Utdmlld2VyIl0sImVtYWlsIjoibXdpbmR1QG5vbW9yZWplZGkuY29tIn0.f2As579n9VNoaKzoF-dOQGmXkFKf1FMyNV0-va_B63jn-_n9LGSCca_6IVMP8pO-Zb4KvRqGyTP0r3HkHxYy5c81AnIh8ijarruczl-TK_yF5akjSTHFZD-0gRzlevBDiH8Q79NAr-ky0P4iIXS8lY9Vnjch5MF74Zx0c3alKJHJUnnpjIACByfF2SCaYzbWFMUNat-K1PaUk5-ujMBG7yYnr95xD-63n8CO8teGUAAEMx6zRjzfhnhbzX-ajwZLGwGUBT4WqjMs70-6a7_8gZmLZb2az1cZynkFRj2BaCkVT3A2RrjeEwZEtGXlMqKJ1_I2ulrOVsYx01_yD35-rw get nodes
+```
+
+
+### 웹훅 토큰 인증 {#webhook-token-authentication}
+
+쿠버네티스의 _웹훅 인증_ 은 베어러 토큰을 검증하기 위해 외부로 HTTP 호출을 수행하는 메커니즘이다.
+
+API 서버의 구성 항목은 다음과 같다.
+
+* `--authentication-token-webhook-config-file`: 원격 웹훅 서비스에 접근하는 방법을 설명하는 구성 파일이다.
+* `--authentication-token-webhook-cache-ttl`: 인증 결정을 캐시하는 기간이다. 기본값은 2분이다.
+* `--authentication-token-webhook-version`: 웹훅과 정보를 주고받을 때 `authentication.k8s.io/v1beta1` 또는 `authentication.k8s.io/v1`
+  `TokenReview` 오브젝트 중 어느 것을 사용할지 결정한다. 기본값은 `v1beta1`이다.
+
+구성 파일은 [kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+파일 형식을 사용한다. 파일에서 `clusters`는 원격 서비스를 가리키고,
+`users`는 API 서버 웹훅을 가리킨다. 예시는 다음과 같다.
+
+```yaml
+# Kubernetes API version
+apiVersion: v1
+# kind of the API object
+kind: Config
+# clusters refers to the remote service.
+clusters:
+  - name: name-of-remote-authn-service
+    cluster:
+      certificate-authority: /path/to/ca.pem         # CA for verifying the remote service.
+      server: https://authn.example.com/authenticate # URL of remote service to query. 'https' recommended for production.
+
+# users refers to the API server's webhook configuration.
+users:
+  - name: name-of-api-server
+    user:
+      client-certificate: /path/to/cert.pem # cert for the webhook plugin to use
+      client-key: /path/to/key.pem          # key matching the cert
+
+# kubeconfig files require a context. Provide one for the API server.
+current-context: webhook
+contexts:
+- context:
+    cluster: name-of-remote-authn-service
+    user: name-of-api-server
+  name: webhook
+```
+
+클라이언트가 [앞에서](#putting-a-bearer-token-in-a-request) 설명한 것처럼 베어러 토큰을 사용하여
+API 서버에 인증하려고 하면, 인증 웹훅은 토큰을 포함한 `TokenReview` 오브젝트를
+JSON으로 직렬화하여 원격 서비스에 POST 요청으로 보낸다.
+
+웹훅 API 오브젝트에는 다른 쿠버네티스 API 오브젝트와 동일한 [버전 호환성 규칙](/docs/concepts/overview/kubernetes-api/)이 적용됨에 유의한다.
+구현자는 올바르게 역직렬화할 수 있도록 요청의 `apiVersion` 필드를 확인해야 하며,
+**반드시** 요청과 동일한 버전의 `TokenReview` 오브젝트로 응답해야 한다.
+
+{{< tabs name="TokenReview_request" >}}
+{{% tab name="authentication.k8s.io/v1" %}}
+{{< note >}}
+쿠버네티스 API 서버는 하위 호환성을 위해 기본적으로 `authentication.k8s.io/v1beta1` 토큰리뷰(TokenReview)를 보낸다.
+`authentication.k8s.io/v1` 토큰리뷰를 받으려면 `--authentication-token-webhook-version=v1`로 API 서버를 시작해야 한다.
+{{< /note >}}
+
+```yaml
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "TokenReview",
+  "spec": {
+    # Opaque bearer token sent to the API server
+    "token": "014fbff9a07c...",
+
+    # Optional list of the audience identifiers for the server the token was presented to.
+    # Audience-aware token authenticators (for example, OIDC token authenticators)
+    # should verify the token was intended for at least one of the audiences in this list,
+    # and return the intersection of this list and the valid audiences for the token in the response status.
+    # This ensures the token is valid to authenticate to the server it was presented to.
+    # If no audiences are provided, the token should be validated to authenticate to the Kubernetes API server.
+    "audiences": ["https://myserver.example.com", "https://myserver.internal.example.com"]
+  }
+}
+```
+{{% /tab %}}
+{{% tab name="authentication.k8s.io/v1beta1" %}}
+```yaml
+{
+  "apiVersion": "authentication.k8s.io/v1beta1",
+  "kind": "TokenReview",
+  "spec": {
+    # Opaque bearer token sent to the API server
+    "token": "014fbff9a07c...",
+
+    # Optional list of the audience identifiers for the server the token was presented to.
+    # Audience-aware token authenticators (for example, OIDC token authenticators)
+    # should verify the token was intended for at least one of the audiences in this list,
+    # and return the intersection of this list and the valid audiences for the token in the response status.
+    # This ensures the token is valid to authenticate to the server it was presented to.
+    # If no audiences are provided, the token should be validated to authenticate to the Kubernetes API server.
+    "audiences": ["https://myserver.example.com", "https://myserver.internal.example.com"]
+  }
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+원격 서비스는 요청의 `status` 필드를 채워 로그인 성공 여부를 나타내야 한다.
+응답 본문의 `spec` 필드는 무시되며 생략할 수 있다.
+원격 서비스는 받은 것과 동일한 `TokenReview` API 버전으로 응답해야 한다.
+베어러 토큰 검증에 성공하면 다음과 같이 반환한다.
+
+{{< tabs name="TokenReview_response_success" >}}
+{{% tab name="authentication.k8s.io/v1" %}}
+```yaml
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "TokenReview",
+  "status": {
+    "authenticated": true,
+    "user": {
+      # Required
+      "username": "janedoe@example.com",
+      # Optional
+      "uid": "42",
+      # Optional group memberships
+      "groups": ["developers", "qa"],
+      # Optional additional information provided by the authenticator.
+      # This should not contain confidential data, as it can be recorded in logs
+      # or API objects, and is made available to admission webhooks.
+      "extra": {
+        "extrafield1": [
+          "extravalue1",
+          "extravalue2"
+        ]
+      }
+    },
+    # Optional list audience-aware token authenticators can return,
+    # containing the audiences from the `spec.audiences` list for which the provided token was valid.
+    # If this is omitted, the token is considered to be valid to authenticate to the Kubernetes API server.
+    "audiences": ["https://myserver.example.com"]
+  }
+}
+```
+{{% /tab %}}
+{{% tab name="authentication.k8s.io/v1beta1" %}}
+```yaml
+{
+  "apiVersion": "authentication.k8s.io/v1beta1",
+  "kind": "TokenReview",
+  "status": {
+    "authenticated": true,
+    "user": {
+      # Required
+      "username": "janedoe@example.com",
+      # Optional
+      "uid": "42",
+      # Optional group memberships
+      "groups": ["developers", "qa"],
+      # Optional additional information provided by the authenticator.
+      # This should not contain confidential data, as it can be recorded in logs
+      # or API objects, and is made available to admission webhooks.
+      "extra": {
+        "extrafield1": [
+          "extravalue1",
+          "extravalue2"
+        ]
+      }
+    },
+    # Optional list audience-aware token authenticators can return,
+    # containing the audiences from the `spec.audiences` list for which the provided token was valid.
+    # If this is omitted, the token is considered to be valid to authenticate to the Kubernetes API server.
+    "audiences": ["https://myserver.example.com"]
+  }
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+요청이 성공하지 못하면 다음과 같이 반환한다.
+
+{{< tabs name="TokenReview_response_error" >}}
+{{% tab name="authentication.k8s.io/v1" %}}
+```yaml
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "TokenReview",
+  "status": {
+    "authenticated": false,
+    # Optionally include details about why authentication failed.
+    # If no error is provided, the API will return a generic Unauthorized message.
+    # The error field is ignored when authenticated=true.
+    "error": "Credentials are expired"
+  }
+}
+```
+{{% /tab %}}
+{{% tab name="authentication.k8s.io/v1beta1" %}}
+```yaml
+{
+  "apiVersion": "authentication.k8s.io/v1beta1",
+  "kind": "TokenReview",
+  "status": {
+    "authenticated": false,
+    # Optionally include details about why authentication failed.
+    # If no error is provided, the API will return a generic Unauthorized message.
+    # The error field is ignored when authenticated=true.
+    "error": "Credentials are expired"
+  }
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+### 인증 리버스 프록시 {#authenticating-proxy}
+
+{{< warning >}}
+다른 용도로도 사용하는 인증 기관(CA)이 있다면, 위험과 해당 CA의 사용을
+보호하는 메커니즘을 이해하지 않는 한 그 인증 기관을
+인증 프록시 클라이언트의 신원 확인용으로 **신뢰하지 않는다**.
+{{< /warning >}}
+
+`X-Remote-User`와 같은 요청 헤더 값으로 사용자를 식별하도록 API 서버를 구성할 수 있다.
+이는 해당 헤더를 설정하는 _인증 프록시_ 와 함께 사용하도록 설계되었다.
+
+인증 리버스 프록시 사용은 [사용자 가장(impersonation)](/docs/reference/access-authn-authz/user-impersonation/)과 다르다.
+사용자 가장에서는 한 사용자가 API 서버에 다른 사용자가 보낸 것처럼 요청을
+처리하도록 요구한다. 인증 리버스 프록시에서는 API 서버가 직접 연결된 클라이언트를 신뢰하여,
+원래 요청을 보낸 주체의 신원 정보를 제공받는다.
+
+커맨드라인 인자를 사용하여 구성하는 방법은
+[웹 요청 헤더 구성](#api-server-authn-config-cli-reverse-proxy)을 참고한다.
+
+#### 예시 {#authenticating-proxy-example}
+
+예를 들어 다음 구성을 사용하는 경우,
+
+```
+--requestheader-username-headers=X-Remote-User
+--requestheader-group-headers=X-Remote-Group
+--requestheader-extra-headers-prefix=X-Remote-Extra-
+```
+
+다음 요청은
+
+```http
+GET / HTTP/1.1
+X-Remote-User: fido
+X-Remote-Group: dogs
+X-Remote-Group: dachshunds
+X-Remote-Extra-Acme.com%2Fproject: some-project
+X-Remote-Extra-Scopes: openid
+X-Remote-Extra-Scopes: profile
+```
+
+다음 사용자 정보로 처리된다.
+
+```yaml
+name: fido
+groups:
+- dogs
+- dachshunds
+extra:
+  acme.com/project:
+  - some-project
+  scopes:
+  - openid
+  - profile
+```
+
+
+#### 클라이언트 인증서 {#reverse-proxy-client-certificate}
+
+헤더 위조를 방지하려면, 요청 헤더를 검사하기 전에 인증 프록시가 API 서버에
+유효한 클라이언트 인증서를 제시하고 지정된 CA를 기준으로
+검증받아야 한다.
+
+요청 헤더 인증 모드의 [커맨드라인 옵션](#api-server-authn-config-cli-reverse-proxy)
+레퍼런스를 참고한다.
+
+<!-- deliberately repeating the earlier warning -->
+위험과 CA의 사용을 보호하는 메커니즘을 이해하지 않는 한,
+다른 용도로 사용하는 CA를 **재사용하지 않는다**.
+
+### 정적 토큰 파일 통합 {#static-token-file}
+
+API 서버는 커맨드라인에 `--token-auth-file=<SOMEFILE>` 옵션을
+지정하면 파일에서 정적 베어러 토큰을 읽는다.
+쿠버네티스 {{< skew currentVersion >}}에서 토큰은 무기한 유효하며, API 서버를
+다시 시작하지 않고는 토큰 목록을 변경할 수 없다.
+
+토큰 파일은 최소 세 개의 열(토큰, 사용자 이름, 사용자 UID)을 가진 CSV 파일이며,
+뒤에 선택적으로 쉼표로 구분된 그룹 이름 목록이 올 수 있다.
+
+
+{{< note >}}
+그룹이 두 개 이상이면 해당 열을 큰따옴표로 묶어야 한다. 예시는 다음과 같다.
+
+```conf
+token,user,uid,"group1,group2,group3"
+```
+{{< /note >}}
+
+정적 토큰 파일은 본질적으로 유효 기간이 길고, 고정되어 있으며,
+교체되지 않을 수도 있는 토큰에 적합하다. 또한 모니터링 에이전트와 같이
+클라이언트가 컨트롤 플레인 내 특정 API 서버와 같은 곳에서 실행되는
+경우에도 유용하다.
+
+클러스터 프로비저닝 중 이 방식을 사용한 후 장기적으로 사용할
+다른 인증 방식으로 전환한다면, 부트스트래핑에 사용한 토큰을
+비활성화해야 한다. 이를 위해서는
+각 API 서버를 다시 시작해야 한다.
+
+그 밖의 상황, 특히 신속한 토큰 교체가 중요한 경우에는,
+쿠버네티스 프로젝트는 이 메커니즘 대신
+[웹훅 토큰 인증자](#webhook-token-authentication)를 사용할 것을 권장한다.
+
+## 사용자 가장 {#user-impersonation}
+
+[사용자 가장](/docs/reference/access-authn-authz/user-impersonation/)은
+가장 헤더를 통해 사용자가 다른 사용자로 동작할 수 있는 방법을 제공한다.
+
+## 인증 구성 {#api-server-authn-config}
+
+쿠버네티스 인증은
+[커맨드라인 인자](#api-server-authn-config-cli) 또는
+[구성 파일](#api-server-authn-config-file)을 사용하여 구성할 수 있다.
+
+일반적으로 두 방식을 함께 사용한다.
+
+### 커맨드라인 인자를 통한 구성 {#api-server-authn-config-cli}
+
+다음 커맨드라인 인자를 사용하여 클러스터 컨트롤 플레인이 클라이언트를 인증하는 방법을 구성할 수 있다.
+
+API 서버의 [커맨드라인 레퍼런스](/docs/reference/command-line-tools-reference/kube-apiserver/)에서
+관련된 모든 커맨드라인 인자를 더 자세히 설명한다.
+
+#### 익명 인증 구성 {#api-server-authn-config-cli-anonymous}
+
+`--anonymous-auth`
+: 인증하지 않은 클라이언트가 API 서버의 보안 포트로 요청할 수 있는지 제어한다. 익명 요청의 사용자 이름은 `system:anonymous`이고, 그룹 이름은 `system:unauthenticated`이다. [익명 요청](#anonymous-requests)도 참고한다.
+
+#### 부트스트랩 토큰 구성 {#api-server-authn-config-cli-bootstrap}
+
+`--enable-bootstrap-token-auth`
+: 이 플래그를 설정하면 [부트스트랩 토큰](#bootstrap-tokens)으로 인증할 수 있다.
+
+#### 인증서 인증 구성 {#api-server-authn-config-cli-x-509}
+
+`--client-ca-file`
+: 클라이언트가 X.509 인증서 인증을 사용할 때 클라이언트의 신원을 검증하기 위한 신뢰 앵커(trust anchor)의 경로이다.
+
+#### OIDC 구성 {#api-server-authn-config-cli-oidc}
+
+`--oidc-ca-file`
+: 클라이언트가 OIDC를 사용할 때 클라이언트의 신원을 검증하기 위한 신뢰 앵커의 경로이다.
+
+`--oidc-client-id`
+: OpenID Connect 클라이언트의 클라이언트 ID이다.
+
+`--oidc-username-claim`
+: 사용자 이름을 지정하는 JWT 클레임의 이름이다. 최종 사용자의 고유 식별자여야 하므로 기본 클레임 이름은 `sub`이다. `email`이나 `name`과 같은 다른 클레임을 선택할 수도 있다. `sub`나 `email` 이외의 클레임의 경우, kube-apiserver는 이름 충돌을 방지하기 위해 그룹 이름에 접두사를 추가한다.
+
+`--oidc-username-prefix`
+: 기존 이름(예: `system:` 사용자)과의 충돌을 방지하기 위해 사용자 이름 클레임 앞에 붙이는 접두사이다. 예를 들어 `oidc:`를 지정하면 `oidc:jane.doe`와 같은 사용자 이름을 만든다. 이 인자를 제공하지 않고 `--oidc-username-claim`이 `email` 이외의 값이면, 기본 접두사는 `( Issuer URL )#`이며 `( Issuer URL )`은 `--oidc-issuer-url` 값이다. 접두사 값을 `-`로 지정하면 사용자 이름 접두사를 비활성화할 수 있다.
+
+`--oidc-groups-claim`
+: 사용자 그룹을 지정하는 사용자 정의 OpenID Connect 클레임의 이름이다. 토큰의 클레임은 문자열 배열이어야 한다. 기본값은 없다.
+
+`--oidc-groups-prefix`
+: 기존 이름(예: `system:` 그룹)과의 충돌을 방지하기 위해 그룹 클레임 앞에 붙이는 접두사이다. 예를 들어 `oidc:`를 지정하면 `oidc:engineering` 및 `oidc:infra`와 같은 그룹 이름을 만든다. 기본 접두사는 `oidc:`이다.
+
+`--oidc-issuer-url`
+: OpenID 발급자의 URL이다. URL 스킴은 **반드시** `https`여야 한다. 발급자의 OIDC 디스커버리 URL이 `https://accounts.provider.example/.well-known/openid-configuration`이면, 값은 `https://accounts.provider.example`이어야 한다.
+
+`--oidc-required-claim`
+: 쿠버네티스가 클라이언트를 인증하기 전에 토큰에 반드시 존재해야 하는 클레임이다. 형식은 `key=value`이다. 이 인자는 여러 번 지정할 수 있다.
+
+`--oidc-signing-algs`
+: 허용하는 서명 알고리즘이다. 허용되는 값은 RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384, PS512이다. 값은 [RFC 7518](https://tools.ietf.org/html/rfc7518#section-3.1)에 정의되어 있다. 기본값은 `RS512`이다.
+
+#### 서비스어카운트 구성 {#api-server-authn-config-cli-sa}
+
+`--api-audiences`
+: 서비스 어카운트 토큰의 인증 오디언스를 정의한다.
+
+`--service-account-extend-token-expiration`
+: 이 플래그는 토큰 생성 시 프로젝티드 서비스 어카운트 토큰의 만료 기간 연장을 활성화하여, 기존 토큰에서 바운드 서비스 어카운트 토큰 기능으로 안전하게 전환할 수 있도록 돕는다. [서비스 어카운트 자격 증명 인증](/docs/concepts/security/service-accounts/#authenticating-credentials)을 참고한다.
+
+`--service-account-issuer`
+: 서비스 어카운트 토큰 발급자의 식별자이다. 발급자는 발급하는 각 토큰의 `iss` 클레임에 이 식별자를 명시한다. 쿠버네티스 프로젝트는 스킴이 `https`인 URL을 사용할 것을 권장한다.
+
+`--service-account-jwks-uri`
+: `/.well-known/openid-configuration`에서 제공하는 디스커버리 문서의 [JSON 웹 키 집합(JSON Web Key Set)](https://www.rfc-editor.org/rfc/rfc7517) URI를 재정의한다.
+
+`--service-account-key-file`
+: 서비스어카운트 토큰을 검증하는 데 사용하는 PEM 인코딩된 X.509 공개 키 또는 개인 키(RSA 또는 ECDSA)를 포함한 파일의 경로이다. 지정된 파일에는 여러 키를 포함할 수 있으며, 서로 다른 경로로 인자를 여러 번 지정할 수 있다.
+
+`--service-account-lookup`
+: true이면 API 서버가 인증 과정의 일부로 서비스어카운트 토큰이 etcd에 존재하는지 검증한다.
+
+`--service-account-max-token-expiration`
+: 서비스 어카운트 토큰 발급자가 생성하는 토큰의 최대 유효 기간을 쿠버네티스 기간 문자열로 나타낸 값이다.
+
+`--service-account-signing-endpoint`
+: 외부 JWT 서명자가 수신 대기하는 소켓의 경로이다. 외부 토큰 서명자와 통합하는 데 사용할 수 있다.
+
+`--service-account-signing-key-file`
+: 서비스 어카운트 토큰 발급자의 현재 개인 키를 포함한 파일의 경로이다. API 서버가 실행 중일 때 이 파일을 변경해도 다시 읽지 **않는다**.
+
+#### 정적 토큰 구성 {#api-server-authn-config-cli-bearer}
+
+`--token-auth-file`
+: [정적 베어러 토큰](#static-token-file)의 구성 파일 경로이다. API 서버가 실행 중일 때 이 파일을 변경해도 다시 읽지 **않는다**.
+
+#### 웹훅 인증 구성 {#api-server-authn-config-cli-webhook}
+
+`--authentication-token-webhook-cache-ttl`
+: 토큰 검증을 위한 외부 HTTP 호출 결과를 API 서버가 캐시하는 기간으로, 쿠버네티스 기간 형식으로 지정한다.
+
+`--authentication-token-webhook-config-file`
+: API 서버가 외부 HTTP 호출을 할 때 인증하는 방법을 지정하는 kubeconfig 형식의 클라이언트 구성 경로이다. API 서버가 실행 중일 때 이 파일을 변경해도 다시 읽지 **않는다**.
+
+`--authentication-token-webhook-version`
+: 토큰을 검사하기 위해 외부 HTTP 호출을 할 때 사용할 토큰리뷰의 API 버전이다.
+
+#### 웹 요청 인증 구성 {#api-server-authn-config-cli-reverse-proxy}
+
+<!-- trailing whitespace (exactly two spaces) is significant in the following list -->
+
+{{< caution >}}
+반드시 따라야 하는 중요한 정보 보안 지침이 있으므로, 이 커맨드라인 인자를
+지정하기 전에 [인증 프록시](#authenticating-proxy) 구성에 관한
+문서를 읽어야 한다.
+{{< /caution >}}
+
+`--requestheader-client-ca-file`
+: _필수._
+  인증 프록시의 신원을 검증하기 위한 신뢰 앵커를 포함한 PEM 인코딩 인증서 번들의 경로이다.<br>
+  요청 헤더에서 사용자 이름을 확인하기 전에 유효한
+  [클라이언트 인증서](#reverse-proxy-client-certificate)를 제시하고, 지정된 파일에 포함된
+  인증 기관을 기준으로 검증받아야 한다.
+
+`--requestheader-allowed-names`
+: _선택 사항._ 쉼표로 구분된 일반 이름(CN) 값의 목록이다.<br>
+  설정하면 요청 헤더에서 사용자 이름을 확인하기 전에,
+  지정된 목록에 포함된 CN을 가진 유효한 클라이언트 인증서를
+  제시해야 한다. 비어 있으면 모든 CN을 허용한다.
+
+`--requestheader-username-headers`
+: _필수이며 대소문자를 구분하지 않는다._ 사용자 신원을 확인하기 위해 순서대로 검사할 헤더 이름이다.<br>
+  값이 들어 있는 첫 번째 헤더를 사용자 이름으로 사용한다.
+
+`--requestheader-group-headers`
+: _선택 사항이며 대소문자를 구분하지 않는다._
+  사용자의 그룹을 확인하기 위해 순서대로 검사할 헤더 이름이다.<br>
+  `X-Remote-Group`을 권장한다.
+  지정된 모든 헤더의 모든 값을 그룹 이름으로 사용한다.
+
+`--requestheader-extra-headers-prefix`
+: _선택 사항이며 대소문자를 구분하지 않는다._
+  사용자에 대한 추가 정보를 확인하기 위해 찾을 헤더 접두사이다.<br>
+  `X-Remote-Extra-`를 권장한다.
+  추가 데이터는 일반적으로 구성된 인가 플러그인이 사용한다.
+  지정된 접두사 중 하나로 시작하는 모든 헤더에서 접두사를 제거한다.
+  나머지 헤더 이름을 소문자로 변환하고 [퍼센트 디코딩](https://tools.ietf.org/html/rfc3986#section-2.1)하여
+  추가 정보의 키로 사용하며, 헤더 값을 추가 정보의 값으로 사용한다.
+
+
+### 구성 파일을 통한 구성 {#api-server-authn-config-file}
+
+{{< feature-state feature_gate_name="StructuredAuthenticationConfiguration" >}}
+
+kube-apiserver에 `--authentication-config` 커맨드라인 인자를 지정하면, API 서버는
+지정한 경로의 파일을 로드하고 그 내용으로 인증을 구성한다.
+
+API 서버가 실행 중일 때도 해당 파일의 내용을 변경할 수 있으며, 변경하면 API 서버가 파일을 다시 읽는다.
+
+{{< note >}}
+이 파일은 원자적인 방식으로 수정해야 한다(예: 같은 위치에 임시 파일을 작성한 후, 임시 파일의 이름을 변경하여 이 파일을 대체한다).
+{{< /note >}}
+
+#### 구성 파일 경로 {#api-server-authn-config-cli-general}
+
+`--authentication-config`
+: 이 특별한 커맨드라인 인자는 [구성 파일을 사용하여 인증을 구성](#api-server-authn-config-file)하도록 지정한다.
+
+#### 예시 {#api-server-authn-config-file-example}
+
+다음은 쿠버네티스의 (구조화된) 인증 구성 파일 예시이다.
+
+{{< highlight yaml "linenos=false,hl_lines=2-5" >}}
+---
+#
+# CAUTION: this is an example configuration.
+#          Check and amend this before you use it in your own cluster!
+#
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+anonymous:
+  enabled: false
+{{< /highlight >}}
+
+## client-go 자격 증명 플러그인 {#client-go-credential-plugins}
+
+{{< feature-state for_k8s_version="v1.22" state="stable" >}}
+
+`k8s.io/client-go`와 이를 사용하는 `kubectl`, `kubelet` 등의 도구는 외부 명령을
+실행하여 사용자 자격 증명을 받을 수 있다.
+
+이 기능은 `k8s.io/client-go`가 기본적으로 지원하지 않는 인증 프로토콜
+(LDAP, Kerberos, OAuth2, SAML 등)과의 클라이언트 측 통합을 위한 것이다. 플러그인은
+프로토콜별 로직을 구현한 후, 클라이언트가 의미를 해석하지 않고 사용할 자격 증명을 반환한다. 거의 모든 자격 증명 플러그인
+유스케이스에서는 클라이언트 플러그인이 생성한 자격 증명 형식을 해석하기 위해
+[웹훅 토큰 인증자](#webhook-token-authentication)를 지원하는 서버 측 컴포넌트가 필요하다.
+
+{{< note >}}
+이전 `kubectl` 버전에는 AKS 및 GKE 인증을 위한 기본 지원이 포함되어 있었지만, 현재는 제공되지 않는다.
+{{< /note >}}
+
+### 유스케이스 예시 {#example-use-case}
+
+가상의 유스케이스로, 조직이 LDAP 자격 증명을 사용자별 서명된 토큰으로 교환하는
+외부 서비스를 운영한다고 가정한다. 이 서비스는 토큰을 검증하기 위한 [웹훅 토큰
+인증자](#webhook-token-authentication) 요청에도 응답할 수 있다. 사용자는 워크스테이션에
+자격 증명 플러그인을 설치해야 한다.
+
+API에 인증하는 과정은 다음과 같다.
+
+* 사용자가 `kubectl` 명령을 실행한다.
+* 자격 증명 플러그인이 사용자에게 LDAP 자격 증명을 요청하고, 외부 서비스에서 이를 토큰으로 교환한다.
+* 자격 증명 플러그인이 client-go에 토큰을 반환하면, client-go는 이를 API 서버에 대한 베어러 토큰으로 사용한다.
+* API 서버는 [웹훅 토큰 인증자](#webhook-token-authentication)를 사용하여 외부 서비스에 `TokenReview`를 보낸다.
+* 외부 서비스가 토큰의 서명을 검증하고 사용자의 사용자 이름과 그룹을 반환한다.
+
+### 구성 {#configuration}
+
+자격 증명 플러그인은 [kubectl 구성 파일](/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)의
+사용자 필드 일부로 구성한다.
+
+{{< tabs name="exec_plugin_kubeconfig_example_1" >}}
+{{% tab name="client.authentication.k8s.io/v1" %}}
+```yaml
+apiVersion: v1
+kind: Config
+users:
+- name: my-user
+  user:
+    exec:
+      # Command to execute. Required.
+      command: "example-client-go-exec-plugin"
+
+      # API version to use when decoding the ExecCredentials resource. Required.
+      #
+      # The API version returned by the plugin MUST match the version listed here.
+      #
+      # To integrate with tools that support multiple versions (such as client.authentication.k8s.io/v1beta1),
+      # set an environment variable, pass an argument to the tool that indicates which version the exec plugin expects,
+      # or read the version from the ExecCredential object in the KUBERNETES_EXEC_INFO environment variable.
+      apiVersion: "client.authentication.k8s.io/v1"
+
+      # Environment variables to set when executing the plugin. Optional.
+      env:
+      - name: "FOO"
+        value: "bar"
+
+      # Arguments to pass when executing the plugin. Optional.
+      args:
+      - "arg1"
+      - "arg2"
+
+      # Text shown to the user when the executable doesn't seem to be present. Optional.
+      installHint: |
+        example-client-go-exec-plugin is required to authenticate
+        to the current cluster.  It can be installed:
+
+        On macOS: brew install example-client-go-exec-plugin
+
+        On Ubuntu: apt-get install example-client-go-exec-plugin
+
+        On Fedora: dnf install example-client-go-exec-plugin
+
+        ...
+
+      # Whether or not to provide cluster information, which could potentially contain
+      # very large CA data, to this exec plugin as a part of the KUBERNETES_EXEC_INFO
+      # environment variable.
+      provideClusterInfo: true
+
+      # The contract between the exec plugin and the standard input I/O stream. If the
+      # contract cannot be satisfied, this plugin will not be run and an error will be
+      # returned. Valid values are "Never" (this exec plugin never uses standard input),
+      # "IfAvailable" (this exec plugin wants to use standard input if it is available),
+      # or "Always" (this exec plugin requires standard input to function). Required.
+      interactiveMode: Never
+clusters:
+- name: my-cluster
+  cluster:
+    server: "https://172.17.4.100:6443"
+    certificate-authority: "/etc/kubernetes/ca.pem"
+    extensions:
+    - name: client.authentication.k8s.io/exec # reserved extension name for per cluster exec config
+      extension:
+        arbitrary: config
+        this: can be provided via the KUBERNETES_EXEC_INFO environment variable upon setting provideClusterInfo
+        you: ["can", "put", "anything", "here"]
+contexts:
+- name: my-cluster
+  context:
+    cluster: my-cluster
+    user: my-user
+current-context: my-cluster
+```
+{{% /tab %}}
+{{% tab name="client.authentication.k8s.io/v1beta1" %}}
+```yaml
+apiVersion: v1
+kind: Config
+users:
+- name: my-user
+  user:
+    exec:
+      # Command to execute. Required.
+      command: "example-client-go-exec-plugin"
+
+      # API version to use when decoding the ExecCredentials resource. Required.
+      #
+      # The API version returned by the plugin MUST match the version listed here.
+      #
+      # To integrate with tools that support multiple versions (such as client.authentication.k8s.io/v1),
+      # set an environment variable, pass an argument to the tool that indicates which version the exec plugin expects,
+      # or read the version from the ExecCredential object in the KUBERNETES_EXEC_INFO environment variable.
+      apiVersion: "client.authentication.k8s.io/v1beta1"
+
+      # Environment variables to set when executing the plugin. Optional.
+      env:
+      - name: "FOO"
+        value: "bar"
+
+      # Arguments to pass when executing the plugin. Optional.
+      args:
+      - "arg1"
+      - "arg2"
+
+      # Text shown to the user when the executable doesn't seem to be present. Optional.
+      installHint: |
+        example-client-go-exec-plugin is required to authenticate
+        to the current cluster.  It can be installed:
+
+        On macOS: brew install example-client-go-exec-plugin
+
+        On Ubuntu: apt-get install example-client-go-exec-plugin
+
+        On Fedora: dnf install example-client-go-exec-plugin
+
+        ...
+
+      # Whether or not to provide cluster information, which could potentially contain
+      # very large CA data, to this exec plugin as a part of the KUBERNETES_EXEC_INFO
+      # environment variable.
+      provideClusterInfo: true
+
+      # The contract between the exec plugin and the standard input I/O stream. If the
+      # contract cannot be satisfied, this plugin will not be run and an error will be
+      # returned. Valid values are "Never" (this exec plugin never uses standard input),
+      # "IfAvailable" (this exec plugin wants to use standard input if it is available),
+      # or "Always" (this exec plugin requires standard input to function). Optional.
+      # Defaults to "IfAvailable".
+      interactiveMode: Never
+clusters:
+- name: my-cluster
+  cluster:
+    server: "https://172.17.4.100:6443"
+    certificate-authority: "/etc/kubernetes/ca.pem"
+    extensions:
+    - name: client.authentication.k8s.io/exec # reserved extension name for per cluster exec config
+      extension:
+        arbitrary: config
+        this: can be provided via the KUBERNETES_EXEC_INFO environment variable upon setting provideClusterInfo
+        you: ["can", "put", "anything", "here"]
+contexts:
+- name: my-cluster
+  context:
+    cluster: my-cluster
+    user: my-user
+current-context: my-cluster
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+상대 명령 경로는 구성 파일의 디렉터리를 기준으로 해석한다.
+KUBECONFIG가 `/home/jane/kubeconfig`이고 exec 명령이 `./bin/example-client-go-exec-plugin`이면,
+`/home/jane/bin/example-client-go-exec-plugin` 바이너리를 실행한다.
+
+```yaml
+- name: my-user
+  user:
+    exec:
+      # Path relative to the directory of the kubeconfig
+      command: "./bin/example-client-go-exec-plugin"
+      apiVersion: "client.authentication.k8s.io/v1"
+      interactiveMode: Never
+```
+
+### 입력 및 출력 형식 {#input-and-output-formats}
+
+실행된 명령은 `stdout`에 `ExecCredential` 오브젝트를 출력한다. `k8s.io/client-go`는
+`status`에 반환된 자격 증명을 사용하여 쿠버네티스 API에 인증한다.
+실행된 명령은 `KUBERNETES_EXEC_INFO` 환경 변수를 통해 `ExecCredential` 오브젝트를
+입력으로 전달받는다. 이 입력에는 반환할 `ExecCredential` 오브젝트의 예상 API 버전이나,
+플러그인이 `stdin`으로 사용자와 상호작용할 수 있는지 등 유용한
+정보가 포함된다.
+
+대화형 세션(즉, 터미널)에서 실행하면 `stdin`을 플러그인에 직접
+노출할 수 있다. 플러그인은 `stdin`이 제공되었는지 확인하기 위해
+`KUBERNETES_EXEC_INFO` 환경 변수에서 받은 입력 `ExecCredential` 오브젝트의
+`spec.interactive` 필드를 사용해야 한다. 플러그인의 `stdin` 요구 사항
+(즉, 플러그인이 성공적으로 실행되기 위해 `stdin`이 선택 사항인지, 반드시 필요한지,
+전혀 사용하지 않는지)은
+[kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)의 `user.exec.interactiveMode` 필드로
+선언한다(유효한 값은 아래 표 참고). `user.exec.interactiveMode` 필드는
+`client.authentication.k8s.io/v1beta1`에서는 선택 사항이며, `client.authentication.k8s.io/v1`에서는 필수이다.
+
+{{< table caption="interactiveMode 값" >}}
+| `interactiveMode` 값 | 의미 |
+| ----------------------- | ------- |
+| `Never` | 이 exec 플러그인은 표준 입력이 전혀 필요하지 않으므로, 사용자 입력을 위한 표준 입력의 사용 가능 여부와 관계없이 실행된다. |
+| `IfAvailable` | 이 exec 플러그인은 표준 입력이 사용 가능하면 사용하려 하지만, 사용할 수 없어도 동작할 수 있다. 따라서 사용자 입력을 위한 stdin의 사용 가능 여부와 관계없이 실행된다. 사용자 입력을 위한 표준 입력을 사용할 수 있으면 이 exec 플러그인에 제공한다. |
+| `Always` | 이 exec 플러그인은 실행에 표준 입력이 필요하므로, 사용자 입력을 위한 표준 입력을 사용할 수 있을 때만 실행된다. 표준 입력을 사용할 수 없으면 exec 플러그인을 실행하지 않고 플러그인 실행기가 오류를 반환한다. |
+{{< /table >}}
+
+베어러 토큰 자격 증명을 사용하려면, 플러그인은
+[`ExecCredential`](/docs/reference/config-api/client-authentication.v1beta1/#client-authentication-k8s-io-v1beta1-ExecCredential)의 status에 토큰을 반환한다.
+
+{{< tabs name="exec_plugin_ExecCredential_example_1" >}}
+{{% tab name="client.authentication.k8s.io/v1" %}}
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1",
+  "kind": "ExecCredential",
+  "status": {
+    "token": "my-bearer-token"
+  }
+}
+```
+{{% /tab %}}
+{{% tab name="client.authentication.k8s.io/v1beta1" %}}
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1beta1",
+  "kind": "ExecCredential",
+  "status": {
+    "token": "my-bearer-token"
+  }
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+또는 TLS 클라이언트 인증을 사용하기 위해 PEM 인코딩된 클라이언트 인증서와 키를 반환할 수 있다.
+플러그인이 후속 호출에서 다른 인증서와 키를 반환하면, `k8s.io/client-go`는
+새 TLS 핸드셰이크를 강제하기 위해 서버와의 기존 연결을 닫는다.
+
+지정하는 경우, `clientKeyData`와 `clientCertificateData`가 모두 존재해야 한다.
+
+`clientCertificateData`에는 서버에 보낼 추가 중간 인증서를 포함할 수 있다.
+
+{{< tabs name="exec_plugin_ExecCredential_example_2" >}}
+{{% tab name="client.authentication.k8s.io/v1" %}}
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1",
+  "kind": "ExecCredential",
+  "status": {
+    "clientCertificateData": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+    "clientKeyData": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+  }
+}
+```
+{{% /tab %}}
+{{% tab name="client.authentication.k8s.io/v1beta1" %}}
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1beta1",
+  "kind": "ExecCredential",
+  "status": {
+    "clientCertificateData": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+    "clientKeyData": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+  }
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+선택적으로 응답에 [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) 타임스탬프 형식의
+자격 증명 만료 시점을 포함할 수 있다.
+
+만료 시점의 유무는 다음과 같은 영향을 준다.
+
+- 만료 시점을 포함하면, 만료 시점에 도달하거나 서버가 HTTP 상태 코드 401로
+  응답하거나 프로세스가 종료될 때까지 베어러 토큰과 TLS 자격 증명을
+  캐시한다.
+- 만료 시점을 생략하면, 서버가 HTTP 상태 코드 401로 응답하거나
+  프로세스가 종료될 때까지 베어러 토큰과 TLS 자격 증명을 캐시한다.
+
+{{< tabs name="exec_plugin_ExecCredential_example_3" >}}
+{{% tab name="client.authentication.k8s.io/v1" %}}
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1",
+  "kind": "ExecCredential",
+  "status": {
+    "token": "my-bearer-token",
+    "expirationTimestamp": "2018-03-05T17:30:20-08:00"
+  }
+}
+```
+{{% /tab %}}
+{{% tab name="client.authentication.k8s.io/v1beta1" %}}
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1beta1",
+  "kind": "ExecCredential",
+  "status": {
+    "token": "my-bearer-token",
+    "expirationTimestamp": "2018-03-05T17:30:20-08:00"
+  }
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+exec 플러그인이 클러스터별 정보를 얻을 수 있도록 하려면,
+[kubeconfig](/docs/concepts/configuration/organize-cluster-access-kubeconfig/)의 `user.exec` 필드에 `provideClusterInfo`를 설정한다.
+그러면 `KUBERNETES_EXEC_INFO` 환경 변수를 통해 플러그인에 클러스터별 정보를 제공한다.
+이 환경 변수의 정보를 사용하여 클러스터별 자격 증명
+획득 로직을 수행할 수 있다.
+다음 `ExecCredential` 매니페스트는 클러스터 정보 예시를 보여준다.
+
+{{< tabs name="exec_plugin_ExecCredential_example_4" >}}
+{{% tab name="client.authentication.k8s.io/v1" %}}
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1",
+  "kind": "ExecCredential",
+  "spec": {
+    "cluster": {
+      "server": "https://172.17.4.100:6443",
+      "certificate-authority-data": "LS0t...",
+      "config": {
+        "arbitrary": "config",
+        "this": "can be provided via the KUBERNETES_EXEC_INFO environment variable upon setting provideClusterInfo",
+        "you": ["can", "put", "anything", "here"]
+      }
+    },
+    "interactive": true
+  }
+}
+```
+{{% /tab %}}
+{{% tab name="client.authentication.k8s.io/v1beta1" %}}
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1beta1",
+  "kind": "ExecCredential",
+  "spec": {
+    "cluster": {
+      "server": "https://172.17.4.100:6443",
+      "certificate-authority-data": "LS0t...",
+      "config": {
+        "arbitrary": "config",
+        "this": "can be provided via the KUBERNETES_EXEC_INFO environment variable upon setting provideClusterInfo",
+        "you": ["can", "put", "anything", "here"]
+      }
+    },
+    "interactive": true
+  }
+}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+## API를 통한 클라이언트 인증 정보 접근 {#self-subject-review}
+
+{{< feature-state for_k8s_version="v1.28" state="stable" >}}
+
+셀프서브젝트리뷰(SelfSubjectReview) API를 사용하면 쿠버네티스 클러스터가
+인증 정보를 매핑하여 클라이언트를 식별하는 방식을 확인할 수 있다.
+이는 사용자(일반적으로 실제 사람을 나타냄)로 인증하든
+서비스어카운트로 인증하든 동작한다.
+
+일반적인 쿠버네티스 클러스터에서는 인증된 모든 사용자가 셀프서브젝트리뷰를 생성할 수 있다.
+이 작업에 대한 접근은 기본 제공 `system:basic-user`
+[클러스터롤(ClusterRole)](/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)이 허용한다.
+
+클라이언트가 자신의 신원을 확인하는 기능은 쿠버네티스 클러스터에서 사용하는 복잡한 인증 흐름의 문제를 해결할 때 매우 유용하다.
+예를 들어 [웹훅 토큰 인증](/docs/reference/access-authn-authz/authentication/#webhook-token-authentication)이나
+[인증 프록시](/docs/reference/access-authn-authz/authentication/#authenticating-proxy)를 사용하는 경우이다.
+
+커맨드라인에서 이 정보를 조회하려면
+[CLI를 통한 인증 정보 접근](#self-subject-review-cli)을 참고한다.
+
+### HTTP를 통한 인증 정보 접근 {#self-subject-review-http-api}
+
+셀프서브젝트리뷰에는 구성할 수 있는 필드가 없다. 요청을 받으면 쿠버네티스
+API 서버는 사용자 속성으로 status를 채워 사용자에게 반환한다.
+이는 이름이 있는 리소스를 클러스터에 영구 저장하지 **않는다**. 셀프서브젝트리뷰를
+다시 가져올 수 없으며, `POST` 요청이 완료되면 버려진다.
+
+요청 예시는 다음과 같다(본문은 셀프서브젝트리뷰이다).
+
+```http
+POST /apis/authentication.k8s.io/v1/selfsubjectreviews
+```
+
+```json
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "SelfSubjectReview"
+}
+```
+
+응답 예시는 다음과 같다.
+
+```json
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "SelfSubjectReview",
+  "status": {
+    "userInfo": {
+      "username": "janedoe@example.com",
+      "groups": [
+        "viewers",
+        "editors",
+        "system:authenticated"
+      ]
+    }
+  }
+}
+```
+
+
+{{< note >}}
+쿠버네티스 API 서버는 [가장](/docs/reference/access-authn-authz/authentication/#user-impersonation)을 포함한
+모든 인증 메커니즘을 적용한 후 `userInfo`를 채운다.
+사용자나 인증 프록시가 가장을 사용하여 셀프서브젝트리뷰를 생성하면,
+가장한 사용자의 상세 정보와 속성이 표시된다.
+{{< /note >}}
+
+이 응답 예시는 사용 가능한 모든 필드를 보여주지는 않는다. 모든
+인증 메커니즘이 사용 가능한 모든 필드를 채우는 것은 아니다.
+사용할 수 있는 필드는 [셀프서브젝트리뷰 API 레퍼런스](/docs/reference/kubernetes-api/authentication-resources/self-subject-review-v1/)를
+참고한다.
+
+다음은 `uid`와 `extra` 필드도 포함하는 다른 예시이다.
+
+<!-- YAML highlighting intentional; JSON is valid YAML -->
+```yaml
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "SelfSubjectReview",
+  "status": {
+    "userInfo": {
+      "username": "janedoe@example.com",
+      "groups": [
+        "viewers",
+        "editors",
+        "system:authenticated"
+      ],
+      "uid": "000042",
+      "extra": {
+        "firstName": [
+          "Jane"
+        ],
+        "familyName": [
+          "Doe"
+        ],
+        "projectAssignments": [
+          "web-frontend",
+          "ai-training-proof-of-concept"
+        ],
+      }
+    }
+  }
+}
+```
+
+이 선택적 필드의 데이터는 인증 통합 기능이나
+해당 기능이 사용하는 사용자 데이터베이스에서 가져온다. 사용자 이름,
+UID, 추가 정보, 이름이 `system:`으로 시작하지 않는 모든
+그룹은 쿠버네티스 외부에서 가져온다.
+
+
+HTTP로 쿠버네티스 API를 조회할 때는 `Accept:` HTTP 헤더를 사용하여 JSON 또는 YAML
+응답을 요청할 수 있다. 예시는 다음과 같다.
+
+{{< tabs name="self_subject_attributes_review_Example_1" >}}
+{{% tab name="JSON" %}}
+```http
+POST /apis/authentication.k8s.io/v1/selfsubjectreviews HTTP/1.1
+Accept: application/json;q=1.0
+Content-Type: application/json
+…other request headers
+
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "SelfSubjectReview"
+}
+
+```
+
+---
+
+```json
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "SelfSubjectReview",
+  "status": {
+    "userInfo": {
+      "username": "jane.doe",
+      "uid": "b79dbf30-0c6a-11ed-861d-0242ac120002",
+      "groups": [
+        "students",
+        "teachers",
+        "system:authenticated"
+      ],
+      "extra": {
+        "skills": [
+          "reading",
+          "learning"
+        ],
+        "subjects": [
+          "math",
+          "sports"
+        ]
+      }
+    }
+  }
+}
+```
+{{% /tab %}}
+
+{{% tab name="YAML" %}}
+```http
+POST /apis/authentication.k8s.io/v1/selfsubjectreviews HTTP/1.1
+Accept: application/yaml;q=1.0
+Content-Type: application/json
+…other request headers
+
+{
+  "apiVersion": "authentication.k8s.io/v1",
+  "kind": "SelfSubjectReview"
+}
+
+```
+
+---
+
+```yaml
+apiVersion: authentication.k8s.io/v1
+kind: SelfSubjectReview
+status:
+  userInfo:
+    username: jane.doe
+    uid: b79dbf30-0c6a-11ed-861d-0242ac120002
+    groups:
+    - students
+    - teachers
+    - system:authenticated
+    extra:
+      skills:
+      - reading
+      - learning
+      subjects:
+      - math
+      - sports
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+### CLI를 통한 인증 정보 접근 {#self-subject-review-cli}
+
+편의를 위해 `kubectl auth whoami` 하위 명령도 제공한다.
+```shell
+kubectl auth whoami
+```
+
+출력은 다음과 유사하다.
+```console
+  ATTRIBUTE         VALUE
+  Username          george.boole
+  Groups            [system:authenticated]
+```
+
+자세한 내용은 [`kubectl auth whoami`](/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_whoami/)를
+참고한다.
+
+
+## {{% heading "whatsnext" %}}
+
+* 사용자 인증서 발급에 대해 알아보려면 [CertificateSigningRequest를 사용하여 쿠버네티스 API 클라이언트 인증서 발급하기](/docs/tasks/tls/certificate-issue-client-csr/)를 읽는다.
+* [클라이언트 인증 레퍼런스(v1)](/docs/reference/config-api/client-authentication.v1/)를 읽는다.
+* [클라이언트 인증 레퍼런스(v1beta1)](/docs/reference/config-api/client-authentication.v1beta1/)를 읽는다.

--- a/content/ko/docs/reference/access-authn-authz/rbac.md
+++ b/content/ko/docs/reference/access-authn-authz/rbac.md
@@ -1,0 +1,1234 @@
+---
+# reviewers:
+# - erictune
+# - deads2k
+# - liggitt
+title: RBAC 인가 사용하기
+content_type: concept
+aliases: [/ko/rbac/]
+weight: 33
+---
+
+<!-- overview -->
+역할 기반 접근 제어(Role-Based Access Control, RBAC)는 조직 내 개별 사용자의 역할을 기준으로
+컴퓨터 또는 네트워크 리소스에 대한 접근을 제어하는 방법이다.
+
+
+<!-- body -->
+RBAC 인가는 `rbac.authorization.k8s.io`
+{{< glossary_tooltip text="API 그룹" term_id="api-group" >}}을 사용하여 인가 여부를
+결정하며, 쿠버네티스 API를 통해 정책을 동적으로 구성할 수 있다.
+
+RBAC을 활성화하려면, `--authorization-config` 플래그에 `RBAC` 인가자가 포함된 파일을 지정하여
+{{< glossary_tooltip text="API 서버" term_id="kube-apiserver" >}}를 시작한다. 예를 들면 다음과 같다.
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthorizationConfiguration
+authorizers:
+  ...
+  - type: RBAC
+  ...
+```
+
+또는 `--authorization-mode` 플래그에 `RBAC`을 포함하는 쉼표로 구분된 목록을 지정하여
+{{< glossary_tooltip text="API 서버" term_id="kube-apiserver" >}}를 시작한다.
+예를 들면 다음과 같다.
+```shell
+kube-apiserver --authorization-mode=...,RBAC --other-options --more-options
+```
+
+## API 오브젝트 {#api-overview}
+
+RBAC API는 네 가지 종류의 쿠버네티스 오브젝트인 _롤(Role)_, _클러스터롤(ClusterRole)_,
+_롤바인딩(RoleBinding)_, _클러스터롤바인딩(ClusterRoleBinding)_ 을 정의한다. 다른 쿠버네티스
+오브젝트와 마찬가지로 `kubectl`과 같은 도구를 사용하여 RBAC
+{{< glossary_tooltip text="오브젝트" term_id="object" >}}를 조회하거나 수정할 수 있다.
+
+{{< caution >}}
+이 오브젝트들은 설계상 접근 제한을 적용한다. 학습하면서
+클러스터를 변경하는 경우,
+[권한 상승 방지 및 부트스트래핑](#privilege-escalation-prevention-and-bootstrapping)을 참고하여
+이러한 제한으로 인해 일부 변경이 차단될 수 있는 이유를 알아본다.
+{{< /caution >}}
+
+### 롤과 클러스터롤 {#role-and-clusterrole}
+
+RBAC _롤_ 또는 _클러스터롤_ 에는 권한 집합을 나타내는 규칙이 포함된다.
+권한은 추가하는 방식으로만 부여된다("거부" 규칙은 없다).
+
+롤은 항상 특정 {{< glossary_tooltip text="네임스페이스" term_id="namespace" >}} 내의 권한을 설정한다.
+롤을 생성할 때는 해당 롤이 속할 네임스페이스를 지정해야 한다.
+
+반면 클러스터롤은 네임스페이스에 속하지 않는 리소스이다. 쿠버네티스 오브젝트는 네임스페이스에 속하거나
+속하지 않는 것 중 하나여야 하며, 두 가지 모두에 해당할 수 없으므로
+이 리소스들은 서로 다른 이름(롤과 클러스터롤)을 사용한다.
+
+클러스터롤은 여러 용도로 사용할 수 있다. 클러스터롤을 사용하여 다음을 수행할 수 있다.
+
+1. 네임스페이스에 속하는 리소스의 권한을 정의하고 개별 네임스페이스 내에서 접근 권한을 부여받는다.
+1. 네임스페이스에 속하는 리소스의 권한을 정의하고 모든 네임스페이스에 걸쳐 접근 권한을 부여받는다.
+1. 클러스터 범위의 리소스에 대한 권한을 정의한다.
+
+네임스페이스 내에서 역할을 정의하려면 롤을 사용하고, 클러스터 전체에 걸쳐
+역할을 정의하려면 클러스터롤을 사용한다.
+
+#### 롤 예시 {#role-example}
+
+다음은 "default" 네임스페이스에서 {{< glossary_tooltip text="파드" term_id="pod" >}}에 대한
+읽기 접근 권한을 부여하는 데 사용할 수 있는 롤의 예시이다.
+
+{{% code_sample file="access/simple-role.yaml" %}}
+
+#### 클러스터롤 예시 {#clusterrole-example}
+
+클러스터롤을 사용하면 롤과 동일한 권한을 부여할 수 있다.
+클러스터롤은 클러스터 범위에 적용되므로 다음에 대한 접근 권한도 부여할 수 있다.
+
+* 클러스터 범위의 리소스({{< glossary_tooltip text="노드" term_id="node" >}} 등)
+* 리소스가 아닌 엔드포인트(`/healthz` 등)
+* 모든 네임스페이스에 걸쳐 네임스페이스에 속하는 리소스(파드 등)
+
+  예를 들어 클러스터롤을 사용하여 특정 사용자가 다음 명령을 실행하도록 허용할 수 있다.
+  `kubectl get pods --all-namespaces`
+
+다음은 특정 네임스페이스 또는 모든 네임스페이스의
+{{< glossary_tooltip text="시크릿(Secret)" term_id="secret" >}}에 대한 읽기 접근 권한을 부여하는 클러스터롤의 예시이다.
+적용 범위는 [바인딩 방식](#rolebinding-and-clusterrolebinding)에 따라 달라진다.
+
+{{% code_sample file="access/simple-clusterrole.yaml" %}}
+
+롤 또는 클러스터롤 오브젝트의 이름은 유효한
+[경로 세그먼트 이름](/docs/concepts/overview/working-with-objects/names#경로-세그먼트-이름)이어야 한다.
+
+### 롤바인딩과 클러스터롤바인딩 {#rolebinding-and-clusterrolebinding}
+
+롤 바인딩은 롤에 정의된 권한을 사용자 또는 사용자 집합에 부여한다.
+롤 바인딩에는 *주체(subject)* 목록(사용자, 그룹 또는 서비스 어카운트)과
+부여할 롤에 대한 참조가 포함된다.
+롤바인딩은 특정 네임스페이스 내에서 권한을 부여하고, 클러스터롤바인딩은
+클러스터 전체에 걸쳐 해당 접근 권한을 부여한다.
+
+롤바인딩은 동일한 네임스페이스의 모든 롤을 참조할 수 있다. 또는 클러스터롤을
+참조하여 해당 클러스터롤을 롤바인딩의 네임스페이스에 바인딩할 수도 있다.
+클러스터롤을 클러스터의 모든 네임스페이스에 바인딩하려면
+클러스터롤바인딩을 사용한다.
+
+롤바인딩 또는 클러스터롤바인딩 오브젝트의 이름은 유효한
+[경로 세그먼트 이름](/docs/concepts/overview/working-with-objects/names#경로-세그먼트-이름)이어야 한다.
+
+#### 롤바인딩 예시 {#rolebinding-example}
+
+다음은 "default" 네임스페이스 내에서 사용자 "jane"에게 "pod-reader" 롤을
+부여하는 롤바인딩의 예시이다.
+이를 통해 "jane"은 "default" 네임스페이스의 파드를 읽을 수 있다.
+
+{{% code_sample file="access/simple-rolebinding-with-role.yaml" %}}
+
+롤바인딩은 클러스터롤을 참조하여 해당 클러스터롤에 정의된 권한을
+롤바인딩의 네임스페이스 내 리소스에 부여할 수도 있다. 이러한 참조를 사용하면
+클러스터 전체에서 공통으로 사용할 롤 집합을 정의한 후, 여러 네임스페이스에서
+재사용할 수 있다.
+
+예를 들어 다음 롤바인딩은 클러스터롤을 참조하지만,
+메타데이터에 지정된 롤바인딩의 네임스페이스가 "development"이므로
+"dave"(주체이며 대소문자를 구분함)는 "development" 네임스페이스의 시크릿만 읽을 수 있다.
+
+{{% code_sample file="access/simple-rolebinding-with-clusterrole.yaml" %}}
+
+#### 클러스터롤바인딩 예시 {#clusterrolebinding-example}
+
+클러스터 전체에 걸쳐 권한을 부여하려면 클러스터롤바인딩을 사용할 수 있다.
+다음 클러스터롤바인딩은 "manager" 그룹에 속한 모든 사용자가 모든 네임스페이스의
+시크릿을 읽을 수 있도록 허용한다.
+
+{{% code_sample file="access/simple-clusterrolebinding.yaml" %}}
+
+바인딩을 생성한 후에는 해당 바인딩이 참조하는 롤이나 클러스터롤을 변경할 수 없다.
+바인딩의 `roleRef`를 변경하려고 하면 유효성 검사 오류가 발생한다. 바인딩의
+`roleRef`를 변경하려면 바인딩 오브젝트를 삭제하고
+새로 생성해야 한다.
+
+이러한 제한이 있는 이유는 두 가지이다.
+
+1. `roleRef`를 변경할 수 없도록 하면, 기존 바인딩 오브젝트에 대한 `update` 권한을 부여받은 사용자가
+   주체에게 부여된 롤을 변경하지 못하면서도
+   주체 목록을 관리할 수 있다.
+1. 다른 롤에 대한 바인딩은 근본적으로 다른 바인딩이다.
+   `roleRef`를 변경할 때 바인딩을 삭제하고 다시 생성하도록 요구하면
+   바인딩에 포함된 모든 주체에게 새 롤을 부여하려는 의도인지
+   확인할 수 있다. 이는 기존 주체 모두에게 새 롤의 권한을
+   부여해도 되는지 확인하지 않은 채 `roleRef`만 변경하도록
+   허용하거나 실수로 변경하는 일을 방지한다.
+
+`kubectl auth reconcile` 커맨드라인 유틸리티는 RBAC 오브젝트가 포함된 매니페스트 파일을 생성하거나 업데이트하고,
+참조하는 롤을 변경하기 위해 필요한 경우 바인딩 오브젝트의 삭제 및 재생성도 처리한다.
+자세한 내용은 [명령 사용법 및 예시](#kubectl-auth-reconcile)를 참고한다.
+
+### 리소스 참조하기 {#referring-to-resources}
+
+쿠버네티스 API에서 대부분의 리소스는 파드의 `pods`와 같이
+오브젝트 이름을 문자열로 표현하여 나타내고 접근한다. RBAC은 해당 API 엔드포인트의
+URL에 나타나는 것과 정확히 동일한 이름을 사용하여 리소스를 참조한다.
+일부 쿠버네티스 API에는 파드의 로그와 같은
+_하위 리소스(subresource)_ 가 있다. 파드의 로그를 요청하는 형식은 다음과 같다.
+
+```http
+GET /api/v1/namespaces/{namespace}/pods/{name}/log
+```
+
+이 경우 `pods`는 파드 리소스에 대한 네임스페이스 범위의 리소스이고, `log`는
+`pods`의 하위 리소스이다. RBAC 롤에서 이를 표현하려면 슬래시(`/`)로
+리소스와 하위 리소스를 구분한다. 주체가 `pods`를 읽고 각 파드의
+`log` 하위 리소스에도 접근할 수 있도록 허용하려면 다음과 같이 작성한다.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-and-pod-logs-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
+```
+
+특정 요청에서는 `resourceNames` 목록을 통해 이름으로 리소스를 참조할 수도 있다.
+이를 지정하면 개별 리소스 인스턴스로 요청을 제한할 수 있다.
+다음은 주체가 `my-configmap`이라는
+{{< glossary_tooltip term_id="ConfigMap" text="컨피그맵(ConfigMap)" >}}에 대해 `get` 또는 `update`만 수행하도록 제한하는 예시이다.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: configmap-updater
+rules:
+- apiGroups: [""]
+  #
+  # at the HTTP level, the name of the resource for accessing ConfigMap
+  # objects is "configmaps"
+  resources: ["configmaps"]
+  resourceNames: ["my-configmap"]
+  verbs: ["update", "get"]
+```
+
+{{< note >}}
+리소스 이름으로 **deletecollection** 또는 최상위 리소스에 대한 **create** 요청을 제한할 수는 없다.
+**create**의 경우, 인가 시점에 새 오브젝트의 이름을 알 수 없을 수 있기 때문에 이러한 제한이 있다. 다만 **create** 제한은 최상위 리소스에만 적용되며 하위 리소스에는 적용되지 않는다. 예를 들어 `pods/exec`에는 `resourceNames` 필드를 사용할 수 있다.
+`resourceName`으로 **list** 또는 **watch**를 제한하는 경우, 클라이언트는 인가를 받기 위해 **list** 또는 **watch** 요청에 지정된 `resourceName`과 일치하는
+`metadata.name` 필드 셀렉터를 포함해야 한다.
+예를 들면 다음과 같다. `kubectl get configmaps --field-selector=metadata.name=my-configmap`
+{{< /note >}}
+
+개별 `resources`, `apiGroups`, `verbs`를 참조하는 대신,
+와일드카드(wildcard) 기호 `*`를 사용하여 해당 오브젝트 모두를 참조할 수 있다.
+`nonResourceURLs`에서는 와일드카드 `*`를 접미사 글로브(glob) 일치에 사용할 수 있다.
+`resourceNames`에서는 빈 집합이 모든 것을 허용한다는 의미이다.
+다음은 `example.com` API 그룹의 현재 및 미래의 모든 리소스에 대해
+현재 및 미래의 모든 작업을 수행할 수 있도록 접근을 허용하는 예시이다.
+이는 기본 제공 `cluster-admin` 롤과 유사하다.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: example.com-superuser # DO NOT USE THIS ROLE, IT IS JUST AN EXAMPLE
+rules:
+- apiGroups: ["example.com"]
+  resources: ["*"]
+  verbs: ["*"]
+```
+
+{{< caution >}}
+리소스와 동사 항목에 와일드카드를 사용하면 민감한 리소스에 대해
+지나치게 광범위한 접근 권한이 부여될 수 있다.
+예를 들어 새 리소스 타입이나 하위 리소스가 추가되거나,
+새 사용자 정의 동사를 검사하게 되면 와일드카드 항목은 자동으로 접근을 허용하므로 의도하지 않은 결과가 발생할 수 있다.
+[최소 권한 원칙](/docs/concepts/security/rbac-good-practices/#최소-권한)에 따라
+구체적인 리소스와 동사를 사용하여 워크로드가 올바르게 동작하는 데
+필요한 권한만 적용해야 한다.
+{{< /caution >}}
+
+### 집계된 클러스터롤 {#aggregated-clusterroles}
+
+여러 클러스터롤을 하나의 클러스터롤로 _집계(aggregate)_ 할 수 있다.
+클러스터 컨트롤 플레인의 일부로 실행되는 컨트롤러는 `aggregationRule`이
+설정된 클러스터롤 오브젝트를 감시한다. `aggregationRule`은 레이블
+{{< glossary_tooltip text="셀렉터" term_id="selector" >}}를 정의하며, 컨트롤러는 이 셀렉터로
+해당 클러스터롤의 `rules` 필드에 합쳐야 하는 다른 클러스터롤
+오브젝트를 찾는다.
+
+{{< caution >}}
+컨트롤 플레인은 집계된 클러스터롤의 `rules` 필드에 수동으로 지정한 값을
+덮어쓴다. 규칙을 변경하거나 추가하려면 `aggregationRule`이 선택하는
+`ClusterRole` 오브젝트에서 변경한다.
+
+집계된 클러스터롤의 매니페스트에서는 `rules` 필드를 생략한다. 빈 목록이라도
+이 필드를 설정하면 [서버 사이드 어플라이](/docs/reference/using-api/server-side-apply/)로
+매니페스트를 적용할 때 해당 필드의 소유권을 갖게 된다. 이러한 소유권은
+적용 주체와 컨트롤 플레인 간에 충돌을 일으킨다. 이후 적용 시 `.rules`의
+필드 관리자 충돌로 실패하거나, GitOps 컨트롤러가 일반적으로 하는 것처럼
+충돌을 강제로 처리하면 집계된 규칙을 반복해서 지우고 컨트롤 플레인이
+다시 채우는 일이 발생한다.
+{{< /caution >}}
+
+다음은 집계된 클러스터롤의 예시이다.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitoring
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.example.com/aggregate-to-monitoring: "true"
+# The control plane automatically fills in the rules
+```
+
+기존 집계된 클러스터롤의 레이블 셀렉터와 일치하는 새 클러스터롤을 생성하면,
+그 변경으로 인해 집계된 클러스터롤에 새 규칙이 추가된다.
+다음은 `rbac.example.com/aggregate-to-monitoring: true` 레이블이 있는 다른
+클러스터롤을 생성하여 "monitoring" 클러스터롤에 규칙을 추가하는 예시이다.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitoring-endpointslices
+  labels:
+    rbac.example.com/aggregate-to-monitoring: "true"
+# When you create the "monitoring-endpointslices" ClusterRole,
+# the rules below will be added to the "monitoring" ClusterRole.
+rules:
+- apiGroups: [""]
+  resources: ["services", "pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
+```
+
+[기본 사용자 대상 롤](#default-roles-and-role-bindings)은 클러스터롤 집계를 사용한다. 이를 통해
+클러스터 관리자는 {{< glossary_tooltip term_id="CustomResourceDefinition" text="커스텀리소스데피니션(CustomResourceDefinition)" >}}이나
+집계된 API 서버가 제공하는 리소스와 같은 사용자 정의 리소스에 대한 규칙을
+포함하여 기본 롤을 확장할 수 있다.
+
+예를 들어 다음 클러스터롤은 "admin"과 "edit" 기본 롤이 CronTab이라는 사용자 정의 리소스를
+관리할 수 있도록 하며, "view" 롤은 CronTab 리소스에 대한 읽기 작업만 수행할 수 있도록 한다.
+API 서버에서 보는 URL에서 CronTab 오브젝트의 이름은 `"crontabs"`라고 가정한다.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregate-cron-tabs-edit
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["stable.example.com"]
+  resources: ["crontabs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-cron-tabs-view
+  labels:
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["stable.example.com"]
+  resources: ["crontabs"]
+  verbs: ["get", "list", "watch"]
+```
+
+#### 롤 예시 {#role-examples}
+
+다음 예시들은 롤 또는 클러스터롤 오브젝트에서 발췌한 것으로,
+`rules` 섹션만 보여준다.
+
+코어 {{< glossary_tooltip text="API 그룹" term_id="api-group" >}}의
+`"pods"` 리소스 읽기를 허용한다.
+
+```yaml
+rules:
+- apiGroups: [""]
+  #
+  # at the HTTP level, the name of the resource for accessing Pod
+  # objects is "pods"
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+```
+
+`"apps"` API 그룹의 디플로이먼트(Deployment)(HTTP 수준에서는 URL의 리소스 부분이
+`"deployments"`인 오브젝트)에 대한 읽기와 쓰기를 허용한다.
+
+```yaml
+rules:
+- apiGroups: ["apps"]
+  #
+  # at the HTTP level, the name of the resource for accessing Deployment
+  # objects is "deployments"
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+코어 API 그룹의 파드 읽기와 `"batch"` API 그룹의 잡(Job)
+리소스 읽기 또는 쓰기를 허용한다.
+
+```yaml
+rules:
+- apiGroups: [""]
+  #
+  # at the HTTP level, the name of the resource for accessing Pod
+  # objects is "pods"
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  #
+  # at the HTTP level, the name of the resource for accessing Job
+  # objects is "jobs"
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+"my-config"라는 컨피그맵 읽기를 허용한다(하나의 네임스페이스에 있는 하나의 컨피그맵으로
+제한하려면 롤바인딩으로 바인딩해야 한다).
+
+```yaml
+rules:
+- apiGroups: [""]
+  #
+  # at the HTTP level, the name of the resource for accessing ConfigMap
+  # objects is "configmaps"
+  resources: ["configmaps"]
+  resourceNames: ["my-config"]
+  verbs: ["get"]
+```
+
+코어 그룹의 `"nodes"` 리소스 읽기를 허용한다(노드는 클러스터 범위이므로
+이 규칙이 효력을 가지려면 클러스터롤바인딩으로 바인딩된
+클러스터롤에 포함되어야 한다).
+
+```yaml
+rules:
+- apiGroups: [""]
+  #
+  # at the HTTP level, the name of the resource for accessing Node
+  # objects is "nodes"
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+```
+
+리소스가 아닌 엔드포인트 `/healthz`와 모든 하위 경로에 대한 GET 및 POST 요청을
+허용한다(효력을 가지려면 클러스터롤바인딩으로 바인딩된
+클러스터롤에 포함되어야 한다).
+
+```yaml
+rules:
+- nonResourceURLs: ["/healthz", "/healthz/*"] # '*' in a nonResourceURL is a suffix glob match
+  verbs: ["get", "post"]
+```
+
+### 주체 참조하기 {#referring-to-subjects}
+
+롤바인딩이나 클러스터롤바인딩은 롤을 주체에 바인딩한다.
+주체는 그룹, 사용자 또는
+{{< glossary_tooltip text="서비스어카운트(ServiceAccount)" term_id="service-account" >}}일 수 있다.
+
+쿠버네티스는 사용자 이름을 문자열로 표현한다.
+"alice"와 같은 일반 이름, "bob@example.com"과 같은 이메일 형식의 이름,
+또는 문자열로 표현된 숫자 사용자 ID를 사용할 수 있다. 클러스터 관리자는
+인증 결과가 원하는 형식의 사용자 이름이 되도록
+[인증 모듈](/docs/reference/access-authn-authz/authentication/)을 구성해야 한다.
+
+{{< caution >}}
+접두사 `system:`은 쿠버네티스 시스템용으로 예약되어 있으므로,
+실수로 `system:`으로 시작하는 이름의 사용자나 그룹을
+만들지 않도록 해야 한다.
+이 특별한 접두사 외에는 RBAC 인가 시스템에서 사용자 이름에
+특정 형식을 요구하지 않는다.
+{{< /caution >}}
+
+쿠버네티스에서는 인증자 모듈이 그룹 정보를 제공한다.
+그룹은 사용자와 마찬가지로 문자열로 표현하며, 접두사 `system:`이 예약되어 있다는 점
+외에는 문자열에 대한 형식 요구 사항이 없다.
+
+[서비스어카운트](/docs/tasks/configure-pod-container/configure-service-account/)의 이름은
+`system:serviceaccount:`로 시작하며, 이름이 `system:serviceaccounts:`로 시작하는 그룹에 속한다.
+
+{{< note >}}
+- `system:serviceaccount:`(단수형)는 서비스 어카운트 사용자 이름의 접두사이다.
+- `system:serviceaccounts:`(복수형)는 서비스 어카운트 그룹의 접두사이다.
+{{< /note >}}
+
+#### 롤바인딩 예시 {#role-binding-examples}
+
+다음은 `RoleBinding`에서 `subjects` 섹션만
+발췌한 예시이다.
+
+`alice@example.com`이라는 사용자의 경우 다음과 같다.
+
+```yaml
+subjects:
+- kind: User
+  name: "alice@example.com"
+  apiGroup: rbac.authorization.k8s.io
+```
+
+`frontend-admins`라는 그룹의 경우 다음과 같다.
+
+```yaml
+subjects:
+- kind: Group
+  name: "frontend-admins"
+  apiGroup: rbac.authorization.k8s.io
+```
+
+"kube-system" 네임스페이스의 기본 서비스 어카운트의 경우 다음과 같다.
+
+```yaml
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system
+```
+
+"qa" 네임스페이스의 모든 서비스 어카운트의 경우 다음과 같다.
+
+```yaml
+subjects:
+- kind: Group
+  name: system:serviceaccounts:qa
+  apiGroup: rbac.authorization.k8s.io
+```
+
+모든 네임스페이스의 모든 서비스 어카운트의 경우 다음과 같다.
+
+```yaml
+subjects:
+- kind: Group
+  name: system:serviceaccounts
+  apiGroup: rbac.authorization.k8s.io
+```
+
+인증된 모든 사용자의 경우 다음과 같다.
+
+```yaml
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+```
+
+인증되지 않은 모든 사용자의 경우 다음과 같다.
+
+```yaml
+subjects:
+- kind: Group
+  name: system:unauthenticated
+  apiGroup: rbac.authorization.k8s.io
+```
+
+모든 사용자의 경우 다음과 같다.
+
+```yaml
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:unauthenticated
+  apiGroup: rbac.authorization.k8s.io
+```
+
+## 기본 롤과 롤 바인딩 {#default-roles-and-role-bindings}
+
+API 서버는 기본 클러스터롤 및 클러스터롤바인딩 오브젝트 집합을 생성한다.
+이 중 다수는 `system:` 접두사를 사용하며, 이는 해당 리소스를 클러스터
+컨트롤 플레인이 직접 관리한다는 의미이다.
+모든 기본 클러스터롤과 클러스터롤바인딩에는 `kubernetes.io/bootstrapping=rbac-defaults` 레이블이 지정된다.
+
+{{< caution >}}
+이름에 `system:` 접두사가 있는 클러스터롤과 클러스터롤바인딩을
+수정할 때는 주의해야 한다.
+이 리소스들을 수정하면 클러스터가 정상적으로 동작하지 않을 수 있다.
+{{< /caution >}}
+
+### 자동 조정 {#auto-reconciliation}
+
+API 서버는 시작할 때마다 기본 클러스터롤에 누락된 권한을 추가하고,
+기본 클러스터롤바인딩에 누락된 주체를 추가한다.
+이를 통해 클러스터는 실수로 변경된 내용을 복구하고, 새 쿠버네티스 릴리스에서 권한과 주체가
+변경됨에 따라 롤과 롤 바인딩을 최신 상태로 유지할 수 있다.
+
+이 조정을 비활성화하려면 기본 클러스터롤 또는 기본 클러스터롤바인딩의
+`rbac.authorization.kubernetes.io/autoupdate` 어노테이션을 `false`로 설정한다.
+기본 권한과 주체가 누락되면 클러스터가 정상적으로 동작하지 않을 수 있음에 유의한다.
+
+RBAC 인가자가 활성화되어 있으면 자동 조정은 기본적으로 활성화된다.
+
+### API 디스커버리 롤 {#discovery-roles}
+
+기본 클러스터롤바인딩은 인증되지 않은 사용자와 인증된 사용자가 공개해도 안전하다고
+판단되는 API 정보(커스텀리소스데피니션 포함)를 읽을 수 있도록 인가한다.
+인증되지 않은 익명 접근을 비활성화하려면 API 서버 구성에
+`--anonymous-auth=false` 플래그를 추가한다.
+
+`kubectl`을 통해 이 롤들의 구성을 확인하려면 다음을 실행한다.
+
+```shell
+kubectl get clusterroles system:discovery -o yaml
+```
+
+{{< note >}}
+해당 클러스터롤을 수정하면 API 서버가 다시 시작될 때
+[자동 조정](#auto-reconciliation)에 의해 변경 사항이 덮어써진다. 이를 방지하려면
+롤을 수동으로 수정하지 않거나 자동 조정을 비활성화한다.
+{{< /note >}}
+
+<table>
+<caption>쿠버네티스 RBAC API 디스커버리 롤</caption>
+<colgroup><col style="width: 25%;" /><col style="width: 25%;" /><col /></colgroup>
+<thead>
+<tr>
+<th>기본 클러스터롤</th>
+<th>기본 클러스터롤바인딩</th>
+<th>설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><b>system:basic-user</b></td>
+<td><b>system:authenticated</b> 그룹</td>
+<td>사용자가 자신에 대한 기본 정보에 읽기 전용으로 접근하도록 허용한다. v1.14 이전에는 이 롤이 기본적으로 <tt>system:unauthenticated</tt>에도 바인딩되었다.</td>
+</tr>
+<tr>
+<td><b>system:discovery</b></td>
+<td><b>system:authenticated</b> 그룹</td>
+<td>API 수준을 탐색하고 협상하는 데 필요한 API 디스커버리 엔드포인트에 대한 읽기 전용 접근을 허용한다. v1.14 이전에는 이 롤이 기본적으로 <tt>system:unauthenticated</tt>에도 바인딩되었다.</td>
+</tr>
+<tr>
+<td><b>system:public-info-viewer</b></td>
+<td><b>system:authenticated</b> 및 <b>system:unauthenticated</b> 그룹</td>
+<td>클러스터의 민감하지 않은 정보에 대한 읽기 전용 접근을 허용한다. 쿠버네티스 v1.14에서 도입되었다.</td>
+</tr>
+</tbody>
+</table>
+
+### 사용자 대상 롤 {#user-facing-roles}
+
+일부 기본 클러스터롤에는 `system:` 접두사가 없다. 이들은 사용자를 대상으로 하는 롤이다.
+여기에는 슈퍼유저 롤(`cluster-admin`), 클러스터롤바인딩을 통해 클러스터 전체에
+부여하도록 설계된 롤, 롤바인딩을 통해 특정 네임스페이스 내에서
+부여하도록 설계된 롤(`admin`, `edit`, `view`)이 포함된다.
+
+사용자 대상 클러스터롤은 [클러스터롤 집계](#aggregated-clusterroles)를 사용하여 관리자가 이 클러스터롤에
+사용자 정의 리소스에 대한 규칙을 포함할 수 있도록 한다. `admin`, `edit`, `view` 롤에 규칙을 추가하려면,
+다음 레이블 중 하나 이상을 포함하는 클러스터롤을 생성한다.
+
+```yaml
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+```
+
+<table>
+<colgroup><col style="width: 25%;" /><col style="width: 25%;" /><col /></colgroup>
+<thead>
+<tr>
+<th>기본 클러스터롤</th>
+<th>기본 클러스터롤바인딩</th>
+<th>설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><b>cluster-admin</b></td>
+<td><b>system:masters</b> 그룹</td>
+<td>모든 리소스에 대해 모든 작업을 수행할 수 있는 슈퍼유저 접근을 허용한다.
+<b>클러스터롤바인딩</b>에서 사용하면 클러스터와 모든 네임스페이스의 모든 리소스에 대한 완전한 제어 권한을 부여한다.
+<b>롤바인딩</b>에서 사용하면 네임스페이스 자체를 포함하여 해당 롤 바인딩의 네임스페이스에 있는 모든 리소스에 대한 완전한 제어 권한을 부여한다.</td>
+</tr>
+<tr>
+<td><b>admin</b></td>
+<td>없음</td>
+<td>관리자 접근을 허용하며, <b>롤바인딩</b>을 사용하여 네임스페이스 내에서 부여하도록 설계되었다.
+
+<b>롤바인딩</b>에서 사용하면 네임스페이스 내에 롤과 롤 바인딩을 생성하는 기능을
+포함하여 네임스페이스의 대부분의 리소스에 대한 읽기와 쓰기 접근을 허용한다.
+이 롤은 리소스 쿼터나 네임스페이스 자체에 대한 쓰기 접근을 허용하지 않는다.
+또한 쿠버네티스 v1.22 이상으로 생성된 클러스터에서는
+엔드포인트슬라이스(EndpointSlice)에 대한 쓰기 접근도 허용하지 않는다. 자세한 내용은
+["엔드포인트슬라이스에 대한 쓰기 접근" 섹션](#write-access-for-endpoints)을 참고한다.</td>
+</tr>
+<tr>
+<td><b>edit</b></td>
+<td>없음</td>
+<td>네임스페이스의 대부분의 오브젝트에 대한 읽기와 쓰기 접근을 허용한다.
+
+이 롤은 롤이나 롤 바인딩의 조회 또는 수정을 허용하지 않는다.
+그러나 시크릿에 접근하고 네임스페이스 내 모든 서비스어카운트로 파드를 실행할 수 있도록
+허용하므로, 네임스페이스 내 모든 서비스어카운트의 API 접근 수준을
+얻는 데 사용될 수 있다. 또한 쿠버네티스 v1.22 이상으로 생성된
+클러스터에서는 엔드포인트슬라이스에 대한 쓰기 접근을 허용하지 않는다.
+자세한 내용은 ["엔드포인트슬라이스에 대한 쓰기 접근" 섹션](#write-access-for-endpoints)을 참고한다.</td>
+</tr>
+<tr>
+<td><b>view</b></td>
+<td>없음</td>
+<td>네임스페이스의 대부분의 오브젝트를 볼 수 있는 읽기 전용 접근을 허용한다.
+롤이나 롤 바인딩의 조회는 허용하지 않는다.
+
+시크릿의 내용을 읽으면 네임스페이스 내 서비스어카운트의
+자격 증명에 접근할 수 있고, 이를 통해 네임스페이스 내
+모든 서비스어카운트로 API에 접근할 수 있으므로
+(권한 상승의 한 형태), 이 롤은 시크릿의 조회를 허용하지 않는다.</td>
+</tr>
+</tbody>
+</table>
+
+### 핵심 컴포넌트 롤 {#core-component-roles}
+
+<table>
+<colgroup><col style="width: 25%;" /><col style="width: 25%;" /><col /></colgroup>
+<thead>
+<tr>
+<th>기본 클러스터롤</th>
+<th>기본 클러스터롤바인딩</th>
+<th>설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><b>system:kube-scheduler</b></td>
+<td><b>system:kube-scheduler</b> 사용자</td>
+<td>{{< glossary_tooltip term_id="kube-scheduler" text="스케줄러" >}} 컴포넌트에 필요한 리소스에 대한 접근을 허용한다.</td>
+</tr>
+<tr>
+<td><b>system:volume-scheduler</b></td>
+<td><b>system:kube-scheduler</b> 사용자</td>
+<td>kube-scheduler 컴포넌트에 필요한 볼륨 리소스에 대한 접근을 허용한다.</td>
+</tr>
+<tr>
+<td><b>system:kube-controller-manager</b></td>
+<td><b>system:kube-controller-manager</b> 사용자</td>
+<td>{{< glossary_tooltip term_id="kube-controller-manager" text="컨트롤러 매니저" >}} 컴포넌트에 필요한 리소스에 대한 접근을 허용한다.
+개별 컨트롤러에 필요한 권한은 <a href="#controller-roles">컨트롤러 롤</a>에 자세히 설명되어 있다.</td>
+</tr>
+<tr>
+<td><b>system:node</b></td>
+<td>없음</td>
+<td><b>모든 시크릿에 대한 읽기 접근과 모든 파드 상태 오브젝트에 대한 쓰기 접근을 포함하여</b> kubelet에 필요한 리소스에 대한 접근을 허용한다.
+
+<tt>system:node</tt> 롤 대신 <a href="/docs/reference/access-authn-authz/node/">노드 인가자</a>와 <a href="/docs/reference/access-authn-authz/admission-controllers/#noderestriction">NodeRestriction 어드미션 플러그인</a>을 사용하여 kubelet에서 실행되도록 스케줄된 파드를 기준으로 kubelet에 API 접근 권한을 부여해야 한다.
+
+<tt>system:node</tt> 롤은 v1.8 이전 버전에서 업그레이드한 쿠버네티스 클러스터와의 호환성을 위해서만 존재한다.
+</td>
+</tr>
+<tr>
+<td><b>system:node-proxier</b></td>
+<td><b>system:kube-proxy</b> 사용자</td>
+<td>{{< glossary_tooltip term_id="kube-proxy" text="kube-proxy" >}} 컴포넌트에 필요한 리소스에 대한 접근을 허용한다.</td>
+</tr>
+</tbody>
+</table>
+
+### 기타 컴포넌트 롤 {#other-component-roles}
+
+<table>
+<colgroup><col style="width: 25%;" /><col style="width: 25%;" /><col /></colgroup>
+<thead>
+<tr>
+<th>기본 클러스터롤</th>
+<th>기본 클러스터롤바인딩</th>
+<th>설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><b>system:auth-delegator</b></td>
+<td>없음</td>
+<td>위임된 인증 및 인가 검사를 허용한다.
+일반적으로 애드온 API 서버가 통합 인증 및 인가를 위해 사용한다.</td>
+</tr>
+<tr>
+<td><b>system:heapster</b></td>
+<td>없음</td>
+<td><a href="https://github.com/kubernetes/heapster">힙스터(Heapster)</a> 컴포넌트용 롤이다(사용 중단(deprecated)).</td>
+</tr>
+<tr>
+<td><b>system:kube-aggregator</b></td>
+<td>없음</td>
+<td><a href="https://github.com/kubernetes/kube-aggregator">kube-aggregator</a> 컴포넌트용 롤이다.</td>
+</tr>
+<tr>
+<td><b>system:kube-dns</b></td>
+<td><b>kube-system</b> 네임스페이스의 <b>kube-dns</b> 서비스 어카운트</td>
+<td>사용 중단된 kube-dns 컴포넌트용 롤이다. (<a href="/docs/concepts/services-networking/dns-pod-service/">CoreDNS</a>는 이 롤을 사용하지 않는다.)</td>
+</tr>
+<tr>
+<td><b>system:kubelet-api-admin</b></td>
+<td>없음</td>
+<td>kubelet API에 대한 전체 접근을 허용한다.</td>
+</tr>
+<tr>
+<td><b>system:node-bootstrapper</b></td>
+<td>없음</td>
+<td><a href="/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/">kubelet TLS 부트스트래핑</a>을 수행하는 데 필요한
+리소스에 대한 접근을 허용한다.</td>
+</tr>
+<tr>
+<td><b>system:node-problem-detector</b></td>
+<td>없음</td>
+<td><a href="https://github.com/kubernetes/node-problem-detector">node-problem-detector</a> 컴포넌트용 롤이다.</td>
+</tr>
+<tr>
+<td><b>system:persistent-volume-provisioner</b></td>
+<td>없음</td>
+<td>대부분의 <a href="/docs/concepts/storage/persistent-volumes/#dynamic">동적 볼륨 프로비저너</a>에 필요한 리소스에 대한 접근을 허용한다.</td>
+</tr>
+<tr>
+<td><b>system:monitoring</b></td>
+<td><b>system:monitoring</b> 그룹</td>
+<td>컨트롤 플레인 모니터링 엔드포인트(즉, {{< glossary_tooltip term_id="kube-apiserver" text="kube-apiserver" >}}의 활성 및 준비성 엔드포인트(<tt>/healthz</tt>, <tt>/livez</tt>, <tt>/readyz</tt>), 개별 헬스 체크 엔드포인트(<tt>/healthz/*</tt>, <tt>/livez/*</tt>, <tt>/readyz/*</tt>), <tt>/metrics</tt>)에 대한 읽기 접근을 허용하고, kube-apiserver가 트레이싱(tracing)을 위해 요청과 함께 제공된 traceparent 헤더를 사용하도록 한다. 개별 헬스 체크 엔드포인트와 메트릭 엔드포인트는 민감한 정보를 노출할 수 있음에 유의한다.</td>
+</tr>
+</tbody>
+</table>
+
+### 기본 제공 컨트롤러의 롤 {#controller-roles}
+
+쿠버네티스 {{< glossary_tooltip term_id="kube-controller-manager" text="컨트롤러 매니저" >}}는
+쿠버네티스 컨트롤 플레인에 내장된
+{{< glossary_tooltip term_id="controller" text="컨트롤러" >}}를 실행한다.
+`--use-service-account-credentials`로 실행하면 kube-controller-manager는 각 컨트롤러를
+별도의 서비스 어카운트를 사용하여 시작한다.
+각 기본 제공 컨트롤러에 대응하는 롤이 있으며, `system:controller:` 접두사를 사용한다.
+컨트롤러 매니저를 `--use-service-account-credentials` 없이 시작하면 자체 자격 증명으로
+모든 제어 루프를 실행하므로, 해당 자격 증명에 관련된 모든 롤을 부여해야 한다.
+이 롤에는 다음이 포함된다.
+
+* `system:controller:attachdetach-controller`
+* `system:controller:certificate-controller`
+* `system:controller:clusterrole-aggregation-controller`
+* `system:controller:cronjob-controller`
+* `system:controller:daemon-set-controller`
+* `system:controller:deployment-controller`
+* `system:controller:disruption-controller`
+* `system:controller:endpoint-controller`
+* `system:controller:expand-controller`
+* `system:controller:generic-garbage-collector`
+* `system:controller:horizontal-pod-autoscaler`
+* `system:controller:job-controller`
+* `system:controller:namespace-controller`
+* `system:controller:node-controller`
+* `system:controller:persistent-volume-binder`
+* `system:controller:pod-garbage-collector`
+* `system:controller:pv-protection-controller`
+* `system:controller:pvc-protection-controller`
+* `system:controller:replicaset-controller`
+* `system:controller:replication-controller`
+* `system:controller:resourcequota-controller`
+* `system:controller:root-ca-cert-publisher`
+* `system:controller:route-controller`
+* `system:controller:service-account-controller`
+* `system:controller:service-controller`
+* `system:controller:statefulset-controller`
+* `system:controller:ttl-controller`
+
+## 권한 상승 방지 및 부트스트래핑 {#privilege-escalation-prevention-and-bootstrapping}
+
+RBAC API는 사용자가 롤이나 롤 바인딩을 수정하여 권한을 상승시키는 것을 방지한다.
+이는 API 수준에서 적용되므로 RBAC 인가자를 사용하지 않는 경우에도 적용된다.
+
+### 롤 생성 또는 업데이트 제한 {#restrictions-on-role-creation-or-update}
+
+다음 중 하나 이상에 해당하는 경우에만 롤을 생성하거나 업데이트할 수 있다.
+
+1. 수정하는 오브젝트와 동일한 범위에서 해당 롤에 포함된 모든 권한을 이미 가지고 있다.
+   (클러스터롤의 경우 클러스터 전체, 롤의 경우 동일한 네임스페이스 또는 클러스터 전체)
+2. `rbac.authorization.k8s.io` API 그룹의 `roles` 또는 `clusterroles` 리소스에 대해
+   `escalate` 동사를 수행할 명시적인 권한을 부여받았다.
+
+예를 들어 `user-1`이 클러스터 전체의 시크릿을 나열할 수 없다면, 해당 권한이 포함된 클러스터롤을
+생성할 수 없다. 사용자가 롤을 생성하거나 업데이트할 수 있도록 허용하려면 다음과 같이 한다.
+
+1. 필요에 따라 롤 또는 클러스터롤 오브젝트를 생성하거나 업데이트할 수 있는 롤을 부여한다.
+2. 생성하거나 업데이트하는 롤에 특정 권한을 포함할 수 있는 권한을 부여한다.
+   * 해당 권한을 부여하여 암묵적으로 허용한다(사용자 자신에게 부여되지 않은 권한을 포함하는 롤이나
+     클러스터롤을 생성하거나 수정하려고 하면 API 요청이 금지된다).
+   * 또는 `rbac.authorization.k8s.io` API 그룹의 `roles` 또는 `clusterroles` 리소스에 대해
+     `escalate` 동사를 수행할 권한을 부여하여 `Role` 또는 `ClusterRole`에
+     모든 권한을 지정할 수 있도록 명시적으로 허용한다.
+
+### 롤 바인딩 생성 또는 업데이트 제한 {#restrictions-on-role-binding-creation-or-update}
+
+참조하는 롤에 포함된 모든 권한을 롤 바인딩과 동일한 범위에서 이미 가지고 있거나,
+참조하는 롤에 대해 `bind` 동사를 수행하도록 인가받은 경우에만 롤 바인딩을 생성하거나 업데이트할 수 있다.
+예를 들어 `user-1`이 클러스터 전체의 시크릿을 나열할 수 없다면, 해당 권한을 부여하는 롤에 대한
+클러스터롤바인딩을 생성할 수 없다. 사용자가 롤 바인딩을 생성하거나 업데이트할 수 있도록 허용하려면 다음과 같이 한다.
+
+1. 필요에 따라 롤바인딩 또는 클러스터롤바인딩 오브젝트를 생성하거나 업데이트할 수 있는 롤을 부여한다.
+2. 특정 롤을 바인딩하는 데 필요한 권한을 부여한다.
+   * 해당 롤에 포함된 권한을 부여하여 암묵적으로 허용한다.
+   * 특정 롤(또는 클러스터롤)에 대해 `bind` 동사를 수행할 권한을 부여하여 명시적으로 허용한다.
+
+예를 들어 다음 클러스터롤과 롤바인딩은 `user-1`이 `user-1-namespace` 네임스페이스에서 다른 사용자에게 `admin`, `edit`, `view` 롤을 부여할 수 있도록 허용한다.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: role-grantor
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings"]
+  verbs: ["create"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  verbs: ["bind"]
+  # omit resourceNames to allow binding any ClusterRole
+  resourceNames: ["admin","edit","view"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: role-grantor-binding
+  namespace: user-1-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: role-grantor
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: user-1
+```
+
+최초의 롤과 롤 바인딩을 부트스트랩할 때는 초기 사용자가 아직 보유하지 않은 권한을 부여해야 한다.
+초기 롤과 롤 바인딩을 부트스트랩하려면 다음과 같이 한다.
+
+* 기본 바인딩에 의해 "cluster-admin" 슈퍼유저 롤에 바인딩된 "system:masters" 그룹의 자격 증명을 사용한다.
+
+## 커맨드라인 유틸리티 {#command-line-utilities}
+
+### `kubectl create role`
+
+하나의 네임스페이스 내에서 권한을 정의하는 롤 오브젝트를 생성한다. 예시는 다음과 같다.
+
+* 사용자가 파드에 대해 `get`, `watch`, `list`를 수행할 수 있는 "pod-reader" 롤을 생성한다.
+
+  ```shell
+  kubectl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods
+  ```
+
+* resourceNames를 지정하여 "pod-reader" 롤을 생성한다.
+
+  ```shell
+  kubectl create role pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
+  ```
+
+* apiGroups를 지정하여 "foo" 롤을 생성한다.
+
+  ```shell
+  kubectl create role foo --verb=get,list,watch --resource=replicasets.apps
+  ```
+
+* 하위 리소스 권한을 포함하는 "foo" 롤을 생성한다.
+
+  ```shell
+  kubectl create role foo --verb=get,list,watch --resource=pods,pods/status
+  ```
+
+* 특정 이름의 리소스를 가져오거나 업데이트할 수 있는 "my-component-lease-holder" 롤을 생성한다.
+
+  ```shell
+  kubectl create role my-component-lease-holder --verb=get,list,watch,update --resource=lease --resource-name=my-component
+  ```
+
+### `kubectl create clusterrole`
+
+클러스터롤을 생성한다. 예시는 다음과 같다.
+
+* 사용자가 파드에 대해 `get`, `watch`, `list`를 수행할 수 있는 "pod-reader" 클러스터롤을 생성한다.
+
+  ```shell
+  kubectl create clusterrole pod-reader --verb=get,list,watch --resource=pods
+  ```
+
+* resourceNames를 지정하여 "pod-reader" 클러스터롤을 생성한다.
+
+  ```shell
+  kubectl create clusterrole pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
+  ```
+
+* apiGroups를 지정하여 "foo" 클러스터롤을 생성한다.
+
+  ```shell
+  kubectl create clusterrole foo --verb=get,list,watch --resource=replicasets.apps
+  ```
+
+* 하위 리소스 권한을 포함하는 "foo" 클러스터롤을 생성한다.
+
+  ```shell
+  kubectl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
+  ```
+
+* nonResourceURL을 지정하여 "foo" 클러스터롤을 생성한다.
+
+  ```shell
+  kubectl create clusterrole "foo" --verb=get --non-resource-url=/logs/*
+  ```
+
+* aggregationRule을 지정하여 "monitoring" 클러스터롤을 생성한다.
+
+  ```shell
+  kubectl create clusterrole monitoring --aggregation-rule="rbac.example.com/aggregate-to-monitoring=true"
+  ```
+
+### `kubectl create rolebinding`
+
+특정 네임스페이스 내에서 롤이나 클러스터롤을 부여한다. 예시는 다음과 같다.
+
+* "acme" 네임스페이스 내에서 "bob" 사용자에게 "admin" 클러스터롤의 권한을 부여한다.
+
+  ```shell
+  kubectl create rolebinding bob-admin-binding --clusterrole=admin --user=bob --namespace=acme
+  ```
+
+* "acme" 네임스페이스 내에서 "acme" 네임스페이스의 "myapp" 서비스 어카운트에 "view" 클러스터롤의 권한을 부여한다.
+
+  ```shell
+  kubectl create rolebinding myapp-view-binding --clusterrole=view --serviceaccount=acme:myapp --namespace=acme
+  ```
+
+* "acme" 네임스페이스 내에서 "myappnamespace" 네임스페이스의 "myapp" 서비스 어카운트에 "view" 클러스터롤의 권한을 부여한다.
+
+  ```shell
+  kubectl create rolebinding myappnamespace-myapp-view-binding --clusterrole=view --serviceaccount=myappnamespace:myapp --namespace=acme
+  ```
+
+### `kubectl create clusterrolebinding`
+
+클러스터 전체(모든 네임스페이스)에 걸쳐 클러스터롤을 부여한다. 예시는 다음과 같다.
+
+* 클러스터 전체에 걸쳐 "root" 사용자에게 "cluster-admin" 클러스터롤의 권한을 부여한다.
+
+  ```shell
+  kubectl create clusterrolebinding root-cluster-admin-binding --clusterrole=cluster-admin --user=root
+  ```
+
+* 클러스터 전체에 걸쳐 "system:kube-proxy" 사용자에게 "system:node-proxier" 클러스터롤의 권한을 부여한다.
+
+  ```shell
+  kubectl create clusterrolebinding kube-proxy-binding --clusterrole=system:node-proxier --user=system:kube-proxy
+  ```
+
+* 클러스터 전체에 걸쳐 "acme" 네임스페이스의 "myapp" 서비스 어카운트에 "view" 클러스터롤의 권한을 부여한다.
+
+  ```shell
+  kubectl create clusterrolebinding myapp-view-binding --clusterrole=view --serviceaccount=acme:myapp
+  ```
+
+### `kubectl auth reconcile` {#kubectl-auth-reconcile}
+
+매니페스트 파일로부터 `rbac.authorization.k8s.io/v1` API 오브젝트를 생성하거나 업데이트한다.
+
+존재하지 않는 오브젝트를 생성하며, 필요한 경우 네임스페이스에 속하는 오브젝트를 위한 네임스페이스도 생성한다.
+
+기존 롤은 입력 오브젝트의 권한을 포함하도록 업데이트하며,
+`--remove-extra-permissions`를 지정하면 추가 권한을 제거한다.
+
+기존 바인딩은 입력 오브젝트의 주체를 포함하도록 업데이트하며,
+`--remove-extra-subjects`를 지정하면 추가 주체를 제거한다.
+
+예시는 다음과 같다.
+
+* RBAC 오브젝트의 매니페스트 파일 적용을 시험하고, 적용 시 변경될 내용을 표시한다.
+
+  ```shell
+  kubectl auth reconcile -f my-rbac-rules.yaml --dry-run=client
+  ```
+
+* 롤의 추가 권한과 바인딩의 추가 주체를 유지하면서 RBAC 오브젝트의 매니페스트 파일을 적용한다.
+
+  ```shell
+  kubectl auth reconcile -f my-rbac-rules.yaml
+  ```
+
+* 롤의 추가 권한과 바인딩의 추가 주체를 제거하면서 RBAC 오브젝트의 매니페스트 파일을 적용한다.
+
+  ```shell
+  kubectl auth reconcile -f my-rbac-rules.yaml --remove-extra-subjects --remove-extra-permissions
+  ```
+
+## 서비스어카운트 권한 {#service-account-permissions}
+
+기본 RBAC 정책은 컨트롤 플레인 컴포넌트, 노드, 컨트롤러에 제한된 범위의 권한을
+부여하지만, `kube-system` 네임스페이스 외부의 서비스 어카운트에는
+([API 디스커버리 롤](#discovery-roles)이 부여하는 권한을 제외하고) *아무런 권한도 부여하지 않는다*.
+
+이를 통해 필요에 따라 특정 서비스어카운트에 특정 롤을 부여할 수 있다.
+세분화된 롤 바인딩은 보안성이 높지만 관리에 더 많은 노력이 필요하다.
+광범위한 권한 부여는 서비스어카운트에 불필요한 API 접근 권한을 부여하고
+권한 상승으로 이어질 가능성도 있지만, 관리하기는 더 쉽다.
+
+보안성이 높은 순서대로 나열하면 다음과 같다.
+
+1. 애플리케이션 전용 서비스 어카운트에 롤 부여(권장 방법)
+
+   애플리케이션은 파드 명세에 `serviceAccountName`을 지정해야 하며,
+   서비스 어카운트도 생성해야 한다(API, 애플리케이션 매니페스트, `kubectl create serviceaccount` 등을 통해 생성).
+
+   예를 들어 "my-sa" 서비스 어카운트에 "my-namespace" 내의 읽기 전용 권한을 부여한다.
+
+   ```shell
+   kubectl create rolebinding my-sa-view \
+     --clusterrole=view \
+     --serviceaccount=my-namespace:my-sa \
+     --namespace=my-namespace
+   ```
+
+2. 네임스페이스의 "default" 서비스 어카운트에 롤 부여
+
+   애플리케이션이 `serviceAccountName`을 지정하지 않으면 "default" 서비스 어카운트를 사용한다.
+
+   {{< note >}}
+   "default" 서비스 어카운트에 부여한 권한은 해당 네임스페이스에서
+   `serviceAccountName`을 지정하지 않은 모든 파드가 사용할 수 있다.
+   {{< /note >}}
+
+   예를 들어 "default" 서비스 어카운트에 "my-namespace" 내의 읽기 전용 권한을 부여한다.
+
+   ```shell
+   kubectl create rolebinding default-view \
+     --clusterrole=view \
+     --serviceaccount=my-namespace:default \
+     --namespace=my-namespace
+   ```
+
+3. 네임스페이스의 모든 서비스 어카운트에 롤 부여
+
+   사용하는 서비스 어카운트에 관계없이 네임스페이스의 모든 애플리케이션에 롤을 부여하려면,
+   해당 네임스페이스의 서비스 어카운트 그룹에 롤을 부여할 수 있다.
+
+   예를 들어 "my-namespace"의 모든 서비스 어카운트에 해당 네임스페이스 내의 읽기 전용 권한을 부여한다.
+
+   ```shell
+   kubectl create rolebinding serviceaccounts-view \
+     --clusterrole=view \
+     --group=system:serviceaccounts:my-namespace \
+     --namespace=my-namespace
+   ```
+
+4. 클러스터 전체의 모든 서비스 어카운트에 제한된 롤 부여(권장하지 않음)
+
+   네임스페이스별로 권한을 관리하지 않으려면, 모든 서비스 어카운트에 클러스터 전체 범위의 롤을 부여할 수 있다.
+
+   예를 들어 클러스터의 모든 서비스 어카운트에 모든 네임스페이스에 걸친 읽기 전용 권한을 부여한다.
+
+   ```shell
+   kubectl create clusterrolebinding serviceaccounts-view \
+     --clusterrole=view \
+    --group=system:serviceaccounts
+   ```
+
+5. 클러스터 전체의 모든 서비스 어카운트에 슈퍼유저 접근 권한 부여(절대 권장하지 않음)
+
+   권한 분리를 전혀 고려하지 않는다면, 모든 서비스 어카운트에 슈퍼유저 접근 권한을 부여할 수 있다.
+
+   {{< warning >}}
+   이렇게 하면 모든 애플리케이션이 클러스터에 대한 전체 접근 권한을 갖게 되며,
+   시크릿에 대한 읽기 접근 권한이 있거나 파드를 생성할 수 있는
+   모든 사용자도 클러스터에 대한 전체 접근 권한을 갖게 된다.
+   {{< /warning >}}
+
+   ```shell
+   kubectl create clusterrolebinding serviceaccounts-cluster-admin \
+     --clusterrole=cluster-admin \
+     --group=system:serviceaccounts
+   ```
+
+## 엔드포인트슬라이스에 대한 쓰기 접근 {#write-access-for-endpoints}
+
+쿠버네티스 v1.22 이전에 생성된 쿠버네티스 클러스터의 집계된 "edit" 및 "admin" 롤에는
+엔드포인트슬라이스(및 현재 사용 중단된 엔드포인트(Endpoints) API)에 대한 쓰기 접근 권한이 포함된다.
+[CVE-2021-25740](https://github.com/kubernetes/kubernetes/issues/103675)에 대한 완화 조치로,
+쿠버네티스 v1.22 이상으로 생성하는 클러스터에서는
+이 접근 권한이 집계된 롤에 포함되지 않는다.
+
+쿠버네티스 v1.22로 업그레이드한 기존 클러스터에는
+이 변경 사항이 적용되지 않는다. [CVE
+공지](https://github.com/kubernetes/kubernetes/issues/103675)에는
+기존 클러스터에서 이 접근 권한을 제한하는 방법이 안내되어 있다.
+
+새 클러스터의 집계된 롤에서도 이 접근 수준을 유지하려면,
+다음 클러스터롤을 생성할 수 있다.
+
+{{% code_sample file="access/endpoints-aggregated.yaml" %}}
+
+## ABAC에서 업그레이드하기 {#upgrading-from-abac}
+
+처음에 이전 쿠버네티스 버전으로 실행되던 클러스터는 모든 서비스 어카운트에
+전체 API 접근 권한을 부여하는 등의
+관대한 ABAC 정책을 사용하는 경우가 많았다.
+
+기본 RBAC 정책은 컨트롤 플레인 컴포넌트, 노드, 컨트롤러에 제한된 범위의 권한을
+부여하지만, `kube-system` 네임스페이스 외부의 서비스 어카운트에는
+([API 디스커버리 롤](#discovery-roles)이 부여하는 권한을 제외하고) *아무런 권한도 부여하지 않는다*.
+
+이 방식은 훨씬 더 안전하지만, API 권한이 자동으로 부여된다고 가정하는 기존 워크로드에는 지장을 줄 수 있다.
+이 전환을 관리하는 두 가지 방법은 다음과 같다.
+
+### 인가자 병행 사용 {#parallel-authorizers}
+
+RBAC 및 ABAC 인가자를 모두 실행하고,
+[기존 ABAC 정책](/docs/reference/access-authn-authz/abac/#policy-file-format)이 포함된 정책 파일을 지정한다.
+
+```shell
+--authorization-mode=...,RBAC,ABAC --authorization-policy-file=mypolicy.json
+```
+
+첫 번째 커맨드라인 옵션을 자세히 설명하면, Node와 같은 앞선 인가자가 요청을
+거부할 경우 RBAC 인가자가 해당 API 요청의 인가를 시도한다. RBAC도
+해당 API 요청을 거부하면 ABAC 인가자가 실행된다. 즉, RBAC 또는 ABAC 정책 중
+*어느 하나라도* 허용하는 요청은 허용된다.
+
+RBAC 컴포넌트의 로그 레벨을 5 이상으로 설정하여
+(`--vmodule=rbac*=5` 또는 `--v=5`) kube-apiserver를 실행하면, API 서버 로그에서
+RBAC 거부 내역을 확인할 수 있다(`RBAC` 접두사로 표시).
+이 정보를 사용하여 어떤 사용자, 그룹 또는 서비스 어카운트에 어떤 롤을 부여해야 하는지 판단할 수 있다.
+
+[서비스 어카운트에 롤을 부여](#service-account-permissions)하고 서버 로그에 RBAC 거부 메시지 없이
+워크로드가 실행되면, ABAC 인가자를 제거할 수 있다.
+
+### 관대한 RBAC 권한 {#permissive-rbac-permissions}
+
+RBAC 롤 바인딩을 사용하여 관대한 ABAC 정책을 재현할 수 있다.
+
+{{< warning >}}
+다음 정책은 **모든** 서비스 어카운트가 클러스터 관리자로 동작할 수 있도록 허용한다.
+컨테이너에서 실행되는 모든 애플리케이션은 서비스 어카운트 자격 증명을 자동으로 받으며,
+시크릿 조회와 권한 수정을 포함하여 API에 대해 모든 작업을 수행할 수 있게 된다.
+이 정책은 권장하지 않는다.
+
+```shell
+kubectl create clusterrolebinding permissive-binding \
+  --clusterrole=cluster-admin \
+  --user=admin \
+  --user=kubelet \
+  --group=system:serviceaccounts
+```
+{{< /warning >}}
+
+RBAC 사용으로 전환한 후에는 클러스터의 접근 제어를 조정하여
+정보 보안 요구 사항에 부합하도록 해야 한다.

--- a/content/ko/docs/tasks/debug/debug-cluster/audit.md
+++ b/content/ko/docs/tasks/debug/debug-cluster/audit.md
@@ -1,88 +1,88 @@
 ---
-#reviewers:
-#- soltysh
-#- sttts
+# reviewers:
+# - soltysh
+# - sttts
 content_type: concept
 title: 감사(auditing)
 ---
 
 <!-- overview -->
 
-쿠버네티스 _감사(auditing)_ 는 클러스터의 작업 순서를 문서화하는 보안 관련 시간별 레코드 세트를 제공한다.
-클러스터는 사용자, 쿠버네티스 API를 사용하는 애플리케이션 및
-컨트롤 플레인 자체에서 생성된 활동을 감사한다.
+쿠버네티스 _감사_ 는 클러스터에서 수행된 작업의 순서를 문서화하는,
+보안 관련 기록을 시간순으로 제공한다. 클러스터는 사용자,
+쿠버네티스 API를 사용하는 애플리케이션, 컨트롤 플레인 자체에서 발생한 활동을 감사한다.
 
 감사를 통해 클러스터 관리자는 다음 질문에 답할 수 있다.
 
- - 무슨 일이 일어났는지?
- - 언제 일어난 일인지?
- - 누가 시작했는지?
- - 어떤 일이 있었는지?
- - 어디서 관찰되었는지?
- - 어디서부터 시작되었는지?
- - 그래서 어디까지 갔는지?
+ - 무슨 일이 일어났는가?
+ - 언제 일어났는가?
+ - 누가 시작했는가?
+ - 어떤 대상에 발생했는가?
+ - 어디서 관찰되었는가?
+ - 어디서 시작되었는가?
+ - 어디로 향했는가?
 
 <!-- body -->
 
-감사 기록은 [kube-apiserver](/docs/reference/command-line-tools-reference/kube-apiserver/) 
-컴포넌트 내에서 수명주기를 시작한다.
-실행의 각 단계에서 각 요청은 감사 이벤트를 생성하고, 
-감사 이벤트는 특정 정책에 따라 사전 처리되고 백엔드에 기록된다.
-정책은 기록된 내용을 결정하고 백엔드는 기록을 유지한다. 
-현재 백엔드 구현에는 로그 파일 및
-웹훅이 포함된다.
+감사 기록은
+[kube-apiserver](/docs/reference/command-line-tools-reference/kube-apiserver/)
+컴포넌트 내부에서 라이프사이클을 시작한다. 각 요청은 실행의 각 단계에서
+감사 이벤트를 생성하며, 이 이벤트는 특정 정책에 따라 전처리한 후
+백엔드에 기록한다. 정책은 기록할 내용을 결정하고,
+백엔드는 기록을 영구 저장한다. 현재 백엔드 구현에는
+로그 파일과 웹훅(webhook)이 포함된다.
 
-각 요청들은 연관된 _단계(stage)_ 와 함께 기록될 수 있다. 정의된 단계는 다음과 같다.
+각 요청은 연관된 _단계(stage)_ 와 함께 기록할 수 있다. 정의된 단계는 다음과 같다.
 
-- `RequestReceived` - 감사 핸들러가 요청을 수신한 직후, 
-  그리고 핸들러 체인으로 위임되기 전에
-  생성되는 이벤트에 대한 단계이다.
-- `ResponseStarted` - 응답 헤더는 전송되었지만, 
-  응답 본문(body)은 전송되기 전인 단계이다.
-  이 단계는 오래 실행되는 요청(예: watch)에 대해서만 생성된다.
-- `ResponseComplete` - 응답 내용이 완료되었으며,
-   더 이상 바이트가 전송되지 않을 때의 단계이다.
-- `Panic` - 패닉이 발생했을 때 생성되는 이벤트이다.
+- `RequestReceived` - 감사 핸들러가 요청을 받은 직후,
+  핸들러 체인의 다음 단계로 위임하기 전에 생성되는 이벤트의
+  단계이다.
+- `ResponseStarted` - 응답 헤더를 보냈지만 응답 본문을
+  보내기 전의 단계이다. 이 단계는 오래 실행되는 요청
+  (예: watch)에 대해서만 생성된다.
+- `ResponseComplete` - 응답 본문 전송이 완료되어 더 이상 바이트를
+  보내지 않는 단계이다.
+- `Panic` - 패닉(panic)이 발생했을 때 생성되는 이벤트이다.
 
 {{< note >}}
-[Audit Event configuration](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Event)
-의 구성은
-[Event](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#event-v1-core)
-API 오브젝트와는 
+[감사 이벤트 구성](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Event)의
+구조는
+[이벤트(Event)](/docs/reference/generated/kubernetes-api/{{< param "version" >}}/#event-v1-core)
+API 오브젝트와
 다르다.
 {{< /note >}}
 
-감사 로깅 기능은 감사에 필요한 일부 컨텍스트가 요청마다 
-저장되기 때문에 API 서버의 메모리 사용량을 증가시킨다. 
-메모리 소비량은 감사 로깅 구성에 따라 다르다.
+감사 로깅 기능은 감사에 필요한 일부 컨텍스트를 요청마다 저장하므로
+API 서버의 메모리 사용량을 증가시킨다.
+메모리 사용량은 감사 로깅 구성에 따라 달라진다.
 
-## 감사 정책
+## 감사 정책 {#audit-policy}
 
-감사 정책은 기록해야 하는 이벤트와 포함해야 하는 
-데이터에 대한 규칙을 정의한다. 감사 정책 오브젝트 구조는
+감사 정책은 어떤 이벤트를 기록하고 어떤 데이터를 포함할지에 대한
+규칙을 정의한다. 감사 정책 오브젝트의 구조는
 [`audit.k8s.io` API 그룹](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Policy)에 정의되어 있다.
-이벤트가 처리되면 규칙 목록과 순서대로 비교된다.
-첫번째 일치 규칙은 이벤트의 _감사 수준(audit level)_ 을 설정한다. 
-정의된 감사 수준은 다음과 같다.
+이벤트를 처리할 때는
+규칙 목록과 순서대로 비교한다. 처음 일치하는 규칙이 이벤트의
+_감사 수준(audit level)_ 을 설정한다. 정의된 감사 수준은 다음과 같다.
 
-- `None` - 이 규칙에 해당되는 이벤트는 로깅하지 않는다.
-- `Metadata` - 요청 메타데이터(요청하는 사용자, 타임스탬프, 리소스, 동사(verb) 등)는 로깅하지만
-  요청/응답 본문은 로깅하지 않는다.
-- `Request` - 이벤트 메타데이터 및 요청 본문을 로깅하지만 응답 본문은 로깅하지 않는다.
-  리소스 외의 요청에는 적용되지 않는다.
-- `RequestResponse` - 이벤트 메타데이터 및 요청/응답 본문을 로깅한다.
-  리소스 외의 요청에는 적용되지 않는다.
+- `None` - 이 규칙과 일치하는 이벤트를 기록하지 않는다.
+- `Metadata` - 이벤트의 메타데이터(요청 사용자, 타임스탬프, 리소스,
+  동사 등)를 기록하지만 요청이나 응답 본문은 기록하지 않는다.
+- `Request` - 요청 메타데이터와 본문을 포함하여 이벤트를 기록하지만 응답 본문은 기록하지 않는다.
+  리소스에 대한 요청이 아닌 경우에는 적용되지 않는다.
+- `RequestResponse` - 요청 메타데이터, 요청 본문, 응답 본문을 포함하여 이벤트를 기록한다.
+  리소스에 대한 요청이 아닌 경우에는 적용되지 않는다.
 
-`--audit-policy-file` 플래그를 사용하여 정책이 포함된 파일을 
-`kube-apiserver`에 전달할 수 있다. 플래그를 생략하면 이벤트가 기록되지 않는다. 
-감사 정책 파일에 `rules` 필드 **반드시** 가 제공되어야 한다.
-규칙이 없는(0개인) 정책은 적절하지 않은(illegal) 것으로 간주된다.
+`--audit-policy-file` 플래그를 사용하여 정책 파일을
+`kube-apiserver`에 전달할 수 있다. 이 플래그를 생략하면 이벤트를 기록하지 않는다.
+감사 정책 파일에 `rules` 필드를 __반드시__ 제공해야 한다.
+규칙이 없는(0개인) 정책은 유효하지 않은 것으로 간주한다.
 
-다음은 감사 정책 파일의 예이다.
+다음은 감사 정책 파일의 예시이다.
 
-{{< codenew file="audit/audit-policy.yaml" >}}
+{{% code_sample file="audit/audit-policy.yaml" %}}
 
-최소 감사 정책 파일을 사용하여 `Metadata` 수준에서 모든 요청을 기록할 수 있다.
+최소한의 감사 정책 파일로 모든 요청을 `Metadata` 수준에서 기록할 수 있다.
 
 ```yaml
 # Log all requests at the Metadata level.
@@ -92,27 +92,27 @@ rules:
 - level: Metadata
 ```
 
-자체 감사 프로필을 만드는 경우 Google Container-Optimized OS에 대한 감사 프로필을 시작점으로 사용할 수 있다.
-감사 정책 파일을 생성하는 [configure-helper.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure-helper.sh) 
-스크립트를 확인하면 된다. 스크립트로 대부분의 감사 정책 파일을 볼 수 있다.
+자체 감사 프로필을 작성하는 경우 Google Container-Optimized OS의 감사 프로필을 출발점으로 사용할 수 있다. 감사 정책 파일을 생성하는
+[configure-helper.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure-helper.sh)
+스크립트를 확인한다. 스크립트를 직접 살펴보면 감사 정책 파일의 대부분을 확인할 수 있다.
 
-정의된 필드에 대한 자세한 내용은 [`Policy` configuration reference](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Policy)를
-참조할 수도 있다.
+정의된 필드에 대한 자세한 내용은 [`Policy` 구성 레퍼런스](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Policy)도
+참고할 수 있다.
 
-## 감사 백엔드
+## 감사 백엔드 {#audit-backends}
 
-감사 백엔드는 감사 이벤트를 외부 저장소에 유지한다. 
-기본적으로 kube-apiserver는 두 가지 백엔드를 제공한다.
+감사 백엔드는 감사 이벤트를 외부 스토리지에 영구 저장한다.
+kube-apiserver는 기본적으로 두 가지 백엔드를 제공한다.
 
-- 이벤트를 파일 시스템에 기록하는 로그 백엔드
-- 이벤트를 외부 HTTP API로 보내는 Webhook 백엔드
+- 이벤트를 파일시스템에 기록하는 로그 백엔드
+- 이벤트를 외부 HTTP API로 보내는 웹훅 백엔드
 
-모든 경우에 감사 이벤트는 쿠버네티스 API의 
-[`audit.k8s.io` API 그룹](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Event)에서 정의한 구조를 따른다.
+모든 경우에 감사 이벤트는 쿠버네티스 API의
+[`audit.k8s.io` API 그룹](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Event)에 정의된 구조를 따른다.
 
 {{< note >}}
-패치의 경우 요청 내용은 적절한 쿠버네티스 API 오브젝트를 포함하는 JSON 오브젝트가 아니라
-패치 작업을 포함하는 JSON 배열이다. 예를 들어 다음 요청 내용은
+패치의 경우 요청 본문은 쿠버네티스 API 오브젝트에 해당하는 JSON 오브젝트가 아니라,
+패치 작업을 포함한 JSON 배열이다. 예를 들어 다음 요청 본문은
 `/apis/batch/v1/namespaces/some-namespace/jobs/some-job-name`에 대한 유효한 패치 요청이다.
 
 ```json
@@ -131,24 +131,26 @@ rules:
 
 {{< /note >}}
 
-### 로그 백엔드
+### 로그 백엔드 {#log-backend}
 
-로그 백엔드는 감사이벤트를 [JSONlines](https://jsonlines.org/) 형식으로 파일에 기록한다.
-다음의 `kube-apiserver` 플래그를 사용하여 로그 감사 백엔드를 구성할 수 있다.
+로그 백엔드는 감사 이벤트를 [JSONlines](https://jsonlines.org/) 형식으로 파일에 기록한다.
+다음 `kube-apiserver` 플래그로 로그 감사 백엔드를 구성할 수 있다.
 
-- `--audit-log-path` 는 로그 백엔드가 감사 이벤트를 쓰는 데 사용하는 로그 파일 경로를 지정한다. 
-  이 플래그를 지정하지 않으면 로그 백엔드가 비활성화된다. `-` 는 표준 출력을 의미한다.
-- `--audit-log-maxage` 는 오래된 감사 로그 파일을 보관할 최대 일수를 정의한다.
-- `--audit-log-maxbackup` 은 보관할 감사 로그 파일의 최대 수를 정의한다.
-- `--audit-log-maxsize` 는 감사 로그 파일이 로테이트 되기 전의 최대 크기(MB)를 정의한다.
+- `--audit-log-path`는 로그 백엔드가 감사 이벤트를 기록할 로그 파일 경로를
+  지정한다. 이 플래그를 지정하지 않으면 로그 백엔드가 비활성화된다. `-`는 표준 출력을 의미한다.
+- `--audit-log-maxage`는 오래된 감사 로그 파일을 보관할 최대 일수를 정의한다.
+- `--audit-log-maxbackup`은 보관할 감사 로그 파일의 최대 개수를 정의한다.
+- `--audit-log-maxsize`는 로그 로테이션 전 감사 로그 파일의 최대 크기를 메가바이트 단위로 정의한다.
 
-클러스터의 컨트롤 플레인이 kube-apiserver를 파드로 실행하는 경우 감사 레코드가 지속되도록 
-정책 파일 및 로그 파일의 위치에 `hostPath` 를 마운트 해야한다. 예를 들면
-```shell
-    --audit-policy-file=/etc/kubernetes/audit-policy.yaml \
-    --audit-log-path=/var/log/kubernetes/audit/audit.log
+클러스터의 컨트롤 플레인에서 kube-apiserver를 파드로 실행한다면, 감사 기록이 영구 저장되도록
+정책 파일과 로그 파일 위치에 `hostPath`를 마운트해야 한다. 예시는 다음과 같다.
+
+```yaml
+  - --audit-policy-file=/etc/kubernetes/audit-policy.yaml
+  - --audit-log-path=/var/log/kubernetes/audit/audit.log
 ```
-그런 다음 볼륨을 마운트 한다.
+
+그런 다음 볼륨을 마운트한다.
 
 ```yaml
 ...
@@ -160,7 +162,7 @@ volumeMounts:
     name: audit-log
     readOnly: false
 ```
-그리고 마지막으로 `hostPath` 를 구성한다.
+마지막으로 `hostPath`를 구성한다.
 
 ```yaml
 ...
@@ -176,81 +178,105 @@ volumes:
     type: DirectoryOrCreate
 ```
 
-### 웹훅 백엔드
+### 웹훅 백엔드 {#webhook-backend}
 
-웹훅 감사 백엔드는 원격 웹 API로 감사 이벤트를 전송하는데, 이는 인증 수단을 포함하여
-쿠버네티스 API의 한 형태로 간주된다. 
-다음 kube-apiserver 플래그를 사용하여 웹훅 감사 백엔드를 구성할 수 있다.
+웹훅 감사 백엔드는 원격 웹 API로 감사 이벤트를 전송한다. 이 API는 인증 수단을
+포함하여 쿠버네티스 API의 형태를 따른다고 가정한다. 다음 kube-apiserver
+플래그로 웹훅 감사 백엔드를 구성할 수 있다.
 
-- `--audit-webhook-config-file` 은 웹훅 구성이 있는 파일의 경로를 지정한다. 
-  웹훅 구성은 효과적으로 전문화된
-  [kubeconfig](/ko/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)이다.
-- `--audit-webhook-initial-backoff` 는 첫 번째 실패한 요청 후 다시 시도하기 전에 대기할 시간을 지정한다.
-  이후 요청은 지수의 백오프로 재시도 된다.
+- `--audit-webhook-config-file`은 웹훅 구성이 포함된 파일의 경로를
+  지정한다. 웹훅 구성은 사실상 특정 용도에 맞춘
+  [kubeconfig](/docs/tasks/access-application-cluster/configure-access-multiple-clusters)이다.
+- `--audit-webhook-initial-backoff`는 첫 요청 실패 후 재시도까지
+  대기할 시간을 지정한다. 이후 요청은 지수 백오프(exponential backoff)로 재시도한다.
 
-웹훅 구성 파일은 kubeconfig 형식을 사용하여 
-서비스의 원격 주소와 서비스에 연결하는 데 사용되는 자격 증명을 지정한다.
+웹훅 구성 파일은 kubeconfig 형식으로 서비스의 원격 주소와
+서비스에 연결할 때 사용할 자격 증명을 지정한다.
 
-## 이벤트 배치 {#배치}
+## 이벤트 배치 처리 {#batching}
 
-로그 및 웹 훅 백엔드는 모두 배치를 지원한다. 웹훅 사용을 예로 들면, 다음은 사용 가능한 플래그 목록이다. 
-로그 백엔드에 대해 동일한 플래그를 가져오려면 플래그 이름에 있는 `webhook` 을 `log` 로 바꾼다.
-기본적으로 배치 기능은 `webhook` 에서 활성화되고 `log` 에서 비활성화된다. 마찬가지로, 기본적으로
-쓰로틀링은 `webhook` 에서는 활성화되고 `log` 에서는 비활성화된다.
+`log`와 `webhook` 백엔드는 모두 배치 처리를 지원한다. 아래는
+각 백엔드에서 사용할 수 있는 플래그 목록이다.
+기본적으로 배치 처리와 스로틀링(throttling)은 `webhook` 백엔드에서 **활성화** 되고, `log` 백엔드에서 **비활성화** 된다.
 
-- `--audit-webhook-mode` 은 버퍼링 전략을 정의한다. 다음 중 하나이다.
-  - `batch` - 이벤트를 버퍼링하고 비동기식으로 배치한다. 이것이 기본값이다.
-  - `blocking` - 각 개별 이벤트를 처리할 때 API 서버 응답을 차단한다.
-  - `blocking-strict` - `blocking`과 동일하지만, RequestReceived 단계에서 감사 로깅 중에 오류가 발생하면 
-    kube-apiserver에 대한 전체 요청이 실패한다.
+{{< tabs name="tab_with_md" >}}
+{{% tab name="webhook" %}}
+- `--audit-webhook-mode`는 버퍼링 전략을 정의한다. 다음 중 하나를 사용한다.
+  - `batch` - 이벤트를 버퍼링하고 비동기적으로 배치 처리한다. `webhook` 백엔드의 기본 모드이다.
+  - `blocking` - 각 개별 이벤트를 처리하는 동안 API 서버 응답을 차단한다.
+  - `blocking-strict` - blocking과 같지만, RequestReceived 단계의 감사 로깅 중
+    실패가 발생하면 kube-apiserver에 대한 전체 요청이 실패한다.
 
-다음 플래그는 `batch` 모드에서만 사용된다.
+다음 플래그는 `batch` 모드에서만 사용한다.
 
-- `--audit-webhook-batch-buffer-size` 는 배치하기 전에 버퍼링할 이벤트 수를 정의한다.
-  들어오는 이벤트의 비율이 버퍼를 초과하면 이벤트가 삭제된다.
-- `--audit-webhook-batch-max-size` 는 한 배치의 최대 이벤트 수를 정의한다.
-- `--audit-webhook-batch-max-wait` 는 대기열에서 이벤트를 무조건 배치하기 전에 
-  대기할 최대 시간을 정의한다.
-- `--audit-webhook-batch-throttle-qps` 는 초당 생성되는 최대 평균 배치 수를
+- `--audit-webhook-batch-buffer-size`는 배치 처리 전에 버퍼링할 이벤트 수를 정의한다.
+  수신 이벤트의 속도가 버퍼 용량을 초과하면 이벤트를 버린다. 기본값은 10000이다.
+- `--audit-webhook-batch-max-size`는 한 배치의 최대 이벤트 수를 정의한다. 기본값은 400이다.
+- `--audit-webhook-batch-max-wait`는 큐의 이벤트를 무조건 배치 처리하기 전까지
+  대기할 수 있는 최대 시간을 정의한다. 기본값은 30초이다.
+- `--audit-webhook-batch-throttle-enable`은 배치 스로틀링의 활성화 여부를 정의한다. 기본적으로 활성화된다.
+- `--audit-webhook-batch-throttle-qps`는 초당 생성하는 배치 수의 최대 평균값을
+  정의한다. 기본값은 10이다.
+- `--audit-webhook-batch-throttle-burst`는 이전에 허용된 QPS를 충분히 사용하지 않은 경우,
+  한 번에 생성할 수 있는 최대 배치 수를 정의한다. 기본값은 15이다.
+{{% /tab %}}
+{{% tab name="log" %}}
+- `--audit-log-mode`는 버퍼링 전략을 정의한다. 다음 중 하나를 사용한다.
+  - `batch` - 이벤트를 버퍼링하고 비동기적으로 배치 처리한다. `log` 백엔드에는 배치 처리를 권장하지 않는다.
+  - `blocking` - 각 개별 이벤트를 처리하는 동안 API 서버 응답을 차단한다. `log` 백엔드의 기본 모드이다.
+  - `blocking-strict` - blocking과 같지만, RequestReceived 단계의 감사 로깅 중
+    실패가 발생하면 kube-apiserver에 대한 전체 요청이 실패한다.
+
+다음 플래그는 `batch` 모드에서만 사용한다(`log` 백엔드의 배치 처리는 기본적으로 **비활성화** 되며, 비활성화된 경우 배치 관련 플래그를 모두 무시한다).
+
+- `--audit-log-batch-buffer-size`는 배치 처리 전에 버퍼링할 이벤트 수를 정의한다.
+  수신 이벤트의 속도가 버퍼 용량을 초과하면 이벤트를 버린다.
+- `--audit-log-batch-max-size`는 한 배치의 최대 이벤트 수를 정의한다.
+- `--audit-log-batch-max-wait`는 큐의 이벤트를 무조건 배치 처리하기 전까지
+  대기할 수 있는 최대 시간을 정의한다.
+- `--audit-log-batch-throttle-enable`은 배치 스로틀링의 활성화 여부를 정의한다.
+- `--audit-log-batch-throttle-qps`는 초당 생성하는 배치 수의 최대 평균값을
   정의한다.
-- `--audit-webhook-batch-throttle-burst` 는 허용된 QPS가 이전에 충분히 활용되지 않은 경우
-  동시에 생성되는 최대 배치 수를 정의한다.
+- `--audit-log-batch-throttle-burst`는 이전에 허용된 QPS를 충분히 사용하지 않은 경우,
+  한 번에 생성할 수 있는 최대 배치 수를 정의한다.
+{{% /tab %}}
+{{< /tabs >}}
 
-## 파라미터 튜닝
+## 파라미터 조정 {#parameter-tuning}
 
-파라미터는 API 서버의 로드를 수용할 수 있도록 설정해야 한다.
+파라미터는 API 서버의 부하를 감당할 수 있도록 설정해야 한다.
 
-예를 들어 kube-apiserver가 초당 100건의 요청을 수신하고 각 요청이 
-`ResponseStarted` 와 `ResponseComplete` 단계에서만 감사되는 경우 초당 생성되는 ≅200건의 감사 이벤트를 고려해야 한다.
-일괄적으로 최대 100개의 이벤트가 있다고 가정할 때 
-초당 최소 2개의 쿼리 조절 수준을 설정해야 한다.
-백엔드가 이벤트를 쓰는 데 최대 5초가 걸릴 수 있다고 가정하면 버퍼크기를 최대 5초의 이벤트를 보유하도록 설정해야 한다.
-즉, 10개의 배치 또는 100개의 이벤트이다.
+예를 들어 kube-apiserver가 초당 100개의 요청을 받고 각 요청을
+`ResponseStarted`와 `ResponseComplete` 단계에서만 감사한다면, 초당 약 200개의 감사
+이벤트가 생성됨을 고려해야 한다. 한 배치에 최대 100개의 이벤트가 있다고 가정하면,
+스로틀링 수준을 최소 초당 2개의 쿼리로 설정해야 한다. 백엔드가 이벤트를 기록하는 데
+최대 5초가 걸린다고 가정하면, 최대 5초 동안의 이벤트를 담도록 버퍼 크기를 설정해야 한다.
+즉, 10개의 배치 또는 1000개의 이벤트이다.
 
-그러나 대부분의 경우 기본 매개 변수만 있으면 충분하며 수동으로 설정할 필요가 없다.
-kube-apiserver에서 노출된 다음과 같은 프로메테우스 메트릭과 로그에서
+그러나 대부분의 경우 기본 파라미터로 충분하므로 수동 설정을 걱정할 필요가 없다.
+kube-apiserver가 노출하는 다음 프로메테우스 메트릭과 로그를 통해
 감사 하위 시스템의 상태를 모니터링할 수 있다.
 
-- `apiserver_audit_event_total` 의 메트릭에는 내보낸 감사 이벤트의 총 수가 포함된다.
-- `apiserver_audit_error_total` 의 메트릭에는 내보내기 중 오류로 인해 삭제된 총 이벤트
-  수가 포함된다.
+- `apiserver_audit_event_total` 메트릭은 내보낸 감사 이벤트의 총개수를 나타낸다.
+- `apiserver_audit_error_total` 메트릭은 내보내기 중 발생한 오류로 버린 이벤트의
+  총개수를 나타낸다.
 
 ### 로그 항목 자르기 {#truncate}
 
-로그 및 웹훅 백엔드는 모두 로깅되는 이벤트의 크기 제한을 지원한다. 
-예를 들어 로그 백엔드에 사용할 수 있는 플래그 목록은 다음과 같다.
+로그와 웹훅 백엔드는 모두 기록하는 이벤트의 크기를 제한할 수 있다.
+예를 들어 로그 백엔드에서 사용할 수 있는 플래그 목록은 다음과 같다.
 
-- `audit-log-truncate-enabled` 는 이벤트 및 자르기 배치가 활성화 되었는지 여부를 나타낸다.
-- `audit-log-truncate-max-batch-size` 는 기본 백엔드로 전송되는 배치의 바이트 단위의 최대 크기이다.
-- `audit-log-truncate-max-event-size` 는 기본 백엔드로 전송된 감사 이벤트의 바이트 단위의 최대 크기이다.
+- `audit-log-truncate-enabled`: 이벤트와 배치 자르기의 활성화 여부.
+- `audit-log-truncate-max-batch-size`: 하위 백엔드에 보내는 배치의 최대 크기(바이트).
+- `audit-log-truncate-max-event-size`: 하위 백엔드에 보내는 감사 이벤트의 최대 크기(바이트).
 
-기본적으로 `webhook` 과 `log` 모두에서 자르기 기능이 비활성화되어 있으므로 이 기능을 활성화 하기 위해
-클러스터 관리자는 `audit-log-truncate-enabled` 또는 `audit-webhook-truncate-enabled` 를 설정해야 한다.
+자르기 기능은 `webhook`과 `log` 모두에서 기본적으로 비활성화되어 있다. 이 기능을 활성화하려면 클러스터 관리자가
+`audit-log-truncate-enabled` 또는 `audit-webhook-truncate-enabled`를 설정해야 한다.
 
 ## {{% heading "whatsnext" %}}
 
-* [Mutating webhook auditing annotations](/docs/reference/access-authn-authz/extensible-admission-controllers/#mutating-webhook-auditing-annotations) 에 대해 알아보기.
-* [`Event`](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Event) 에 대해 알아보고
-  감사 구성 참조를 읽고 [`Policy`](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Policy)
-  리소스 유형 확인하기.
+* [변형 웹훅 감사 어노테이션](/docs/reference/access-authn-authz/extensible-admission-controllers/#mutating-webhook-auditing-annotations)에 대해 알아본다.
+* 감사 구성 레퍼런스를 읽고
+  [`Event`](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Event)와 [`Policy`](/docs/reference/config-api/apiserver-audit.v1/#audit-k8s-io-v1-Policy)
+  리소스 타입에 대해 자세히 알아본다.
 


### PR DESCRIPTION
### Description

Translate the authentication, RBAC, and admission control references into Korean, and update the security overview, auditing, Pod Security Standards, and Service Accounts pages to match the English source at `5fcb15cb74ddf18ebaa5aea5a4d91e25093980bc`.

- Follow the official Kubernetes Korean glossary and localization guidelines.
- Preserve the source structure, shortcodes, code examples, and line alignment.
- Update internal anchors to match translated headings, correct the admission diagram link, and use a Korean RBAC alias to avoid a cross-language redirect conflict.

AI assistance was used during translation. The content was checked against the English source and Korean localization guidelines, and verified with a local Hugo 0.144.2 build of the English and Korean sites. `git diff --check` passed; all 136 code blocks match the source apart from trailing whitespace, and 401 internal links were checked, including anchors and configured redirects.

### Issue

No related issue.