### PR TITLE
Fix code blocks rendering RTL on RTL documentation pages

### DIFF
--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -181,11 +181,11 @@ div.api-reference-header-note.empty {
   border-width: 0 4px 0 0;
 }
 
-// Keep code blocks and inline code left-to-right (LTR) even on
-// right-to-left (RTL) documentation pages. Code syntax, indentation,
-// and punctuation are not localized and rely on LTR rendering.
-pre,
-code {
+// Keep code blocks and inline code left-to-right (LTR) on RTL pages
+// only. Code syntax, indentation, and punctuation are not localized
+// and rely on LTR rendering.
+pre:dir(rtl),
+code:dir(rtl) {
   direction: ltr;
   unicode-bidi: isolate;
 }

--- a/assets/scss/_documentation.scss
+++ b/assets/scss/_documentation.scss
@@ -181,6 +181,15 @@ div.api-reference-header-note.empty {
   border-width: 0 4px 0 0;
 }
 
+// Keep code blocks and inline code left-to-right (LTR) even on
+// right-to-left (RTL) documentation pages. Code syntax, indentation,
+// and punctuation are not localized and rely on LTR rendering.
+pre,
+code {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
 .glossary-tooltip {
   display: inline-block;
   border-bottom: 1px dotted var(--bs-body-color);


### PR DESCRIPTION
## What this PR does

Fixes #57476: code blocks and inline code are rendered right-to-left (RTL) on RTL documentation pages, which breaks code indentation, syntax, and punctuation.

Code is not localized, so code blocks and inline code should always render left-to-right (LTR) regardless of the surrounding page direction.

## Change

Adds a rule to `_documentation.scss` that sets `direction: ltr` and `unicode-bidi: isolate` on `pre` and `code` elements.

- Documentation text on RTL pages stays RTL.
- Code blocks and inline code render LTR.

This follows the same RTL-specific styling approach already used for callouts (`.alert:dir(rtl)`).
