### PR TITLE
Change `yum` to `dnf` and update RHEL10 install command

### DIFF
--- a/content/en/docs/concepts/workloads/pods/user-namespaces.md
+++ b/content/en/docs/concepts/workloads/pods/user-namespaces.md
@@ -120,7 +120,7 @@ isolate the users in the container from the users in the node.
 
 This means containers can run as root and be mapped to a non-root user on the
 host. Inside the container the process will think it is running as root (and
-therefore tools like `apt`, `yum`, etc. work fine), while in reality the process
+therefore tools like `apt`, `dnf`, etc. work fine), while in reality the process
 doesn't have privileges on the host. You can verify this, for example, if you
 check which user the container process is running by executing `ps aux` from
 the host. The user `ps` shows is not the same as the user you see if you

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -286,9 +286,9 @@ exist by default, and it should be created before the curl command.
 
 2. Add the Kubernetes `yum` repository. The `exclude` parameter in the
    repository definition ensures that the packages related to Kubernetes are
-   not upgraded upon running `yum update` as there's a special procedure that
+   not upgraded upon running a normal `dnf update` as there's a special procedure that
    must be followed for upgrading Kubernetes. Please note that this repository
-   have packages only for Kubernetes {{< skew currentVersion >}}; for other
+   has packages only for Kubernetes {{< skew currentVersion >}}; for other
    Kubernetes minor versions, you need to change the Kubernetes minor version
    in the URL to match your desired minor version (you should also check that
    you are reading the documentation for the version of Kubernetes that you
@@ -309,13 +309,13 @@ exist by default, and it should be created before the curl command.
 
 3. Install kubelet, kubeadm and kubectl:
 
-   For systems with DNF:
+   For systems with DNF4 (Fedora < 41, RHEL/CentOS < 10)
    ```shell
-   sudo yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
+   sudo dnf install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
    ```
    For systems with DNF5:
    ```shell
-   sudo yum install -y kubelet kubeadm kubectl --setopt=disable_excludes=kubernetes
+   sudo dnf install -y kubelet kubeadm kubectl --setopt=disable_excludes=kubernetes
    ```
 
 4. (Optional) Enable the kubelet service before running kubeadm:

--- a/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/install-kubeadm.md
@@ -313,9 +313,14 @@ exist by default, and it should be created before the curl command.
    ```shell
    sudo dnf install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
    ```
-   For systems with DNF5:
+   For Fedora systems with DNF5:
    ```shell
    sudo dnf install -y kubelet kubeadm kubectl --setopt=disable_excludes=kubernetes
+   ```
+
+   For RHEL/CentOS 10 and later, to avoid pulling in `iptables` as a dependency:
+   ```shell
+   sudo dnf install -y kubelet kubeadm kubectl --setopt=disable_excludes=kubernetes --setopt=install_weak_deps=False
    ```
 
 4. (Optional) Enable the kubelet service before running kubeadm:

--- a/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
+++ b/content/en/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm.md
@@ -77,7 +77,7 @@ Then you may be missing `ebtables`, `ethtool` or a similar executable on your no
 You can install them with the following commands:
 
 - For Ubuntu/Debian users, run `apt install ebtables ethtool`.
-- For CentOS/Fedora users, run `yum install ebtables ethtool`.
+- For CentOS/Fedora users, run `dnf install ebtables ethtool`.
 
 ## kubeadm blocks waiting for control plane during installation
 
@@ -324,14 +324,14 @@ To work around the issue, choose one of these options:
 - Roll back to an earlier version of Docker, such as 1.13.1-75
 
   ```
-  yum downgrade docker-1.13.1-75.git8633870.el7.centos.x86_64 docker-client-1.13.1-75.git8633870.el7.centos.x86_64 docker-common-1.13.1-75.git8633870.el7.centos.x86_64
+  dnf downgrade docker-1.13.1-75.git8633870.el7.centos.x86_64 docker-client-1.13.1-75.git8633870.el7.centos.x86_64 docker-common-1.13.1-75.git8633870.el7.centos.x86_64
   ```
 
 - Install one of the more recent recommended versions, such as 18.06:
 
   ```bash
-  sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-  yum install docker-ce-18.06.1.ce-3.el7.x86_64
+  sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  dnf install docker-ce-18.06.1.ce-3.el7.x86_64
   ```
 
 ## Not possible to pass a comma separated list of values to arguments inside a `--component-extra-args` flag

--- a/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade.md
@@ -104,17 +104,17 @@ sudo apt-cache madison kubeadm
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
 
-For systems with DNF:
+For systems with DNF4 (Fedora < 41, RHEL/CentOS < 10):
 ```shell
 # Find the latest {{< skew currentVersion >}} version in the list.
 # It should look like {{< skew currentVersion >}}.x-*, where x is the latest patch.
-sudo yum list --showduplicates kubeadm --disableexcludes=kubernetes
+sudo dnf list --showduplicates kubeadm --disableexcludes=kubernetes
 ```
 For systems with DNF5:
 ```shell
 # Find the latest {{< skew currentVersion >}} version in the list.
 # It should look like {{< skew currentVersion >}}.x-*, where x is the latest patch.
-sudo yum list --showduplicates kubeadm --setopt=disable_excludes=kubernetes
+sudo dnf list --showduplicates kubeadm --setopt=disable_excludes=kubernetes
 ```
 
 {{% /tab %}}
@@ -146,15 +146,15 @@ Pick a control plane node that you wish to upgrade first. It must have the `/etc
    {{% /tab %}}
    {{% tab name="CentOS, RHEL or Fedora" %}}
 
-   For systems with DNF:
+   For systems with DNF4 (Fedora < 41, RHEL/CentOS < 10):
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+   sudo dnf install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
    ```
    For systems with DNF5:
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
+   sudo dnf install -y kubeadm-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
    ```
 
    {{% /tab %}}
@@ -263,15 +263,15 @@ To learn more, refer to the [Kubernetes cgroup v1 deprecation documentation](/do
    {{% /tab %}}
    {{% tab name="CentOS, RHEL or Fedora" %}}
 
-   For systems with DNF:   
+   For systems with DNF4 (Fedora < 41, RHEL/CentOS < 10):
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+   sudo dnf install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
    ```
    For systems with DNF5:   
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
+   sudo dnf install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
    ```
 
    {{% /tab %}}

--- a/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
+++ b/content/en/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes.md
@@ -42,15 +42,15 @@ sudo apt-mark hold kubeadm
 ```
 {{% /tab %}}
 {{% tab name="CentOS, RHEL or Fedora" %}}
-For systems with DNF:
+For systems with DNF4 (Fedora < 41, RHEL/Centos < 10):
 ```shell
 # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+sudo dnf install -y kubeadm-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
 ```
 For systems with DNF5:
 ```shell
 # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-sudo yum install -y kubeadm-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
+sudo dnf install -y kubeadm-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -87,15 +87,15 @@ kubectl drain <node-to-drain> --ignore-daemonsets
    ```
    {{% /tab %}}
    {{% tab name="CentOS, RHEL or Fedora" %}}
-   For systems with DNF:
+   For systems with DNF4 (Fedora < 41, RHEL/CentOS < 10):
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
+   sudo dnf install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --disableexcludes=kubernetes
    ```
    For systems with DNF5:
    ```shell
    # replace x in {{< skew currentVersion >}}.x-* with the latest patch version
-   sudo yum install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
+   sudo dnf install -y kubelet-'{{< skew currentVersion >}}.x-*' kubectl-'{{< skew currentVersion >}}.x-*' --setopt=disable_excludes=kubernetes
    ```
    {{% /tab %}}
    {{< /tabs >}}

--- a/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
+++ b/content/en/docs/tasks/administer-cluster/migrating-from-dockershim/change-runtime-containerd.md
@@ -129,7 +129,7 @@ If the node appears healthy, remove Docker.
 {{% tab name="CentOS" %}}
 
 ```shell
-sudo yum remove docker-ce docker-ce-cli
+sudo dnf remove docker-ce docker-ce-cli
 ```
 {{% /tab %}}
 {{% tab name="Debian" %}}

--- a/content/en/docs/tasks/extend-kubectl/kubectl-plugins.md
+++ b/content/en/docs/tasks/extend-kubectl/kubectl-plugins.md
@@ -370,7 +370,7 @@ discover your plugin and install it.
 
 ### Native / platform specific package management {#distributing-native}
 
-Alternatively, you can use traditional package managers such as, `apt` or `yum`
+Alternatively, you can use traditional package managers such as, `apt` or `dnf`
 on Linux, Chocolatey on Windows, and Homebrew on macOS. Any package
 manager will be suitable if it can place new executables placed somewhere
 in the user's `PATH`.

--- a/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
+++ b/content/en/docs/tasks/tools/included/optional-kubectl-configs-bash-linux.md
@@ -22,7 +22,7 @@ which means that you have to install this software first
 
 bash-completion is provided by many package managers
 (see [here](https://github.com/scop/bash-completion#installation)).
-You can install it with `apt-get install bash-completion` or `yum install bash-completion`, etc.
+You can install it with `apt-get install bash-completion` or `dnf install bash-completion`, etc.
 
 The above commands create `/usr/share/bash-completion/bash_completion`,
 which is the main script of bash-completion. Depending on your package manager,

--- a/content/en/docs/tasks/tools/install-kubectl-linux.md
+++ b/content/en/docs/tasks/tools/install-kubectl-linux.md
@@ -187,13 +187,13 @@ To upgrade kubectl to another minor release, you'll need to bump the version in 
    ```
 
 {{< note >}}
-To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/yum.repos.d/kubernetes.repo` before running `yum update`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
+To upgrade kubectl to another minor release, you'll need to bump the version in `/etc/yum.repos.d/kubernetes.repo` before running `dnf update`. This procedure is described in more detail in [Changing The Kubernetes Package Repository](/docs/tasks/administer-cluster/kubeadm/change-package-repository/).
 {{< /note >}}
 
-2. Install kubectl using `yum`:
+2. Install kubectl using `dnf`:
 
    ```bash
-   sudo yum install -y kubectl
+   sudo dnf install -y kubectl
    ```
 
 {{% /tab %}}


### PR DESCRIPTION
As discussed in https://github.com/kubernetes/enhancements/issues/5343#issuecomment-5546700706, we want to avoid trying to pull in `iptables` as a dependency of the kubernetes packages on RHEL10, because it's not needed, and will pull in lots of additional unwanted deps.

https://github.com/kubernetes/release/pull/4518 updates our RPMs to make the kubelet iptables dependency `Recommended` rather than `Requires`. This PR updates the kubeadm docs to suggest using `--setopt=install_weak_deps=False` to skip the `Recommended` dependency.

Since `install_weak_deps` didn't exist as an option in "real" `yum`, it felt wrong to add this without changing the example to use `dnf` rather than `yum`, but then it seems like there's really no reason to be saying `yum` everywhere any more anyway; in the past it made sense because RHEL7 didn't have `dnf`, but we don't support RHEL7 any more. So this also updates all the `yum` references to `dnf` instead.
