### PR TITLE
Remove IdentityPodOS feature gate note from windows guide

### DIFF
--- a/content/en/docs/concepts/windows/user-guide.md
+++ b/content/en/docs/concepts/windows/user-guide.md
@@ -167,12 +167,6 @@ that the containers in that Pod are designed for. For Pods that run Linux contai
 `.spec.os.name` to `linux`. For Pods that run Windows containers, set `.spec.os.name`
 to `windows`.
 
-{{< note >}}
-If you are running a version of Kubernetes older than 1.24, you may need to enable
-the `IdentifyPodOS` [feature gate](/docs/reference/command-line-tools-reference/feature-gates/)
-to be able to set a value for `.spec.os.name`.
-{{< /note >}}
-
 The scheduler does not use the value of `.spec.os.name` when assigning Pods to nodes. You should
 use normal Kubernetes mechanisms for
 [assigning pods to nodes](/docs/concepts/scheduling-eviction/assign-pod-node/)


### PR DESCRIPTION
### Description

Removes the `IdentifyPodOS` feature gate note from the Windows user guide.
The note only applies to Kubernetes versions older than v1.24, which are no longer supported.

### Issue

Follow-up to: [#57151](https://github.com/kubernetes/website/pull/57151#discussion_r3951182938)
