### PR TITLE
[ja] Translate glossary term Pod Disruption Budget

### DIFF
--- a/content/ja/docs/reference/glossary/pod-disruption-budget.md
+++ b/content/ja/docs/reference/glossary/pod-disruption-budget.md
@@ -1,0 +1,21 @@
+---
+id: pod-disruption-budget
+title: Pod Disruption Budget
+full_link: /docs/concepts/workloads/pods/disruptions/
+short_description: >
+  レプリカを持つアプリケーションのうち、自発的なDisruptionによって同時にダウンするPodの数を制限するオブジェクト。
+
+aka:
+ - PDB
+related:
+ - pod
+ - container
+tags:
+ - operation
+---
+
+[Pod Disruption Budget](/docs/concepts/workloads/pods/disruptions/)は、アプリケーションの所有者がレプリカを持つアプリケーション向けに作成するオブジェクトで、特定のラベルが付いた{{< glossary_tooltip text="Pod" term_id="pod" >}}のうち一定の数または割合が、どの時点でも自発的に退避されないことを保証します。
+
+<!--more-->
+
+非自発的なDisruptionはPDBによって防ぐことはできません。ただし、予算にはカウントされます。


### PR DESCRIPTION
## Summary
- Add Japanese translation for `content/en/docs/reference/glossary/pod-disruption-budget.md`
- Fixes missing JA glossary entry used by glossary_tooltip on Japanese pages

### Description
Add Japanese localization for the Pod Disruption Budget glossary term so tooltips on Japanese pages no longer fall back to English.

### Issue
Fixes #56853

## Test plan
- [x] Confirm the term appears on the Japanese glossary page
- [x] Confirm JA pages using this tooltip no longer fall back to English