### PR TITLE
Fix GRPCRoute example service field to match explanation

### DIFF
--- a/content/en/docs/concepts/services-networking/gateway.md
+++ b/content/en/docs/concepts/services-networking/gateway.md
@@ -212,7 +212,7 @@ spec:
   rules:
   - matches:
     - method:
-        service: com.example
+        service: com.example.User
         method: Login
     backendRefs:
     - name: foo-svc


### PR DESCRIPTION
The GRPCRoute example in the Gateway API concepts page sets the method service field to `com.example`, but the explanation text immediately below refers to `com.example.User.Login`. This updates the YAML to include the `User` service name so the example is consistent with the explanation.

Fixes #57488
