### PR TITLE
Clarify activeDeadlineSeconds behavior

### DIFF
--- a/content/en/docs/concepts/workloads/pods/init-containers.md
+++ b/content/en/docs/concepts/workloads/pods/init-containers.md
@@ -312,7 +312,7 @@ Use `activeDeadlineSeconds` on the Pod to prevent init containers from failing f
 The active deadline includes init containers.
 However it is recommended to use `activeDeadlineSeconds` only if teams deploy their application
 as a Job, because `activeDeadlineSeconds` has an effect even after initContainer finished.
-The Pod which is already running correctly would be killed by `activeDeadlineSeconds` if you set.
+The Pod which is already running correctly would be killed after the period specified by `activeDeadlineSeconds`.
 
 The name of each app and init container in a Pod must be unique; a
 validation error is thrown for any container sharing a name with another.


### PR DESCRIPTION
### Description

Last sentence didn't make sense, I believe the trailing "if you set" was a mistake. Also added `after the period specified` instead of just `by`.

### Issue

None