### PR TITLE
Fix 'allows to' grammar in DaemonSet matchExpressions docs

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/daemonset.md
+++ b/content/en/docs/concepts/workloads/controllers/daemonset.md
@@ -92,7 +92,7 @@ The `.spec.selector` is an object consisting of two fields:
 
 * `matchLabels` - works the same as the `.spec.selector` of a
   [ReplicationController](/docs/concepts/workloads/controllers/replicationcontroller/).
-* `matchExpressions` - allows to build more sophisticated selectors by specifying key,
+* `matchExpressions` - allows building more sophisticated selectors by specifying key,
   list of values and an operator that relates the key and values.
 
 When the two are specified the result is ANDed.


### PR DESCRIPTION
### Description

Fix grammar in the DaemonSet selector docs: "allows to build" → "allows building".

### Issue

N/A — unsolicited tiny grammar fix.

### Notes

I have not made any changes related to translation.